### PR TITLE
chore: initialize tasks/ directory

### DIFF
--- a/tasks/archive.md
+++ b/tasks/archive.md
@@ -1,0 +1,16 @@
+# archive
+
+Completed work.
+
+## 2026-03-01
+
+### Phase 1 — Scaffold, Config, Project Key
+- `src/config.ts` — TOML config loader with Zod validation, caching, `resetConfig()`
+- `src/project-key.ts` — git root detection + 16-char SHA256 path hash
+- `tests/config.test.ts` — 7 tests, full coverage
+- `tests/project-key.test.ts` — 6 tests, full coverage
+- Branch: `feat/phase-1-scaffold` (commit 935a5d0), pending merge to main
+
+### Project Initialization
+- `CLAUDE.md` — project-level conventions, architecture, phase roadmap
+- `tasks/` — initialized todo, lessons, tests, archive

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -1,0 +1,19 @@
+# lessons
+
+Learnings captured after corrections. Updated after any mistake or course correction.
+
+## Format
+
+**Pattern**: what situation triggers this
+**Mistake**: what went wrong
+**Rule**: the corrected behavior
+**Date**: YYYY-MM-DD
+
+---
+
+## Git
+
+**Pattern**: Pushing commits to GitHub repos with email privacy enabled
+**Mistake**: Committed with local Gmail address; GitHub rejected push with GH007
+**Rule**: Both author AND committer email must use the GitHub noreply address (`<id>+<username>@users.noreply.github.com`). Amending author alone is not enough — set `GIT_COMMITTER_EMAIL` too, or configure `user.email` globally.
+**Date**: 2026-03-01

--- a/tasks/tests.md
+++ b/tasks/tests.md
@@ -1,0 +1,42 @@
+# tests
+
+Living test registry. Update when adding or removing coverage.
+
+## Run Commands
+
+```bash
+bun test              # all tests
+bun test --watch      # watch mode
+bun run typecheck     # tsc --noEmit (no emit, type check only)
+```
+
+## Coverage
+
+### `tests/config.test.ts` — 7 tests
+| Test | Description |
+|------|-------------|
+| loads defaults when no config file exists | returns full default config |
+| merges user TOML over defaults | user values override, rest stays default |
+| validates compression_ratio_threshold range | rejects values outside 0–1 |
+| validates max_stored_bytes positive | rejects non-positive values |
+| caches config after first load | second call returns same object |
+| resetConfig() clears cache | next load re-reads from disk |
+| respects RECALL_CONFIG_PATH env override | reads from custom path |
+
+### `tests/project-key.test.ts` — 6 tests
+| Test | Description |
+|------|-------------|
+| returns git root when inside a git repo | resolves to repo root path |
+| falls back to cwd outside a git repo | graceful non-git fallback |
+| returns 16-char hex hash | stable SHA256 truncation |
+| same path always produces same key | deterministic |
+| different paths produce different keys | no collision |
+| handles nested subdirectory | resolves to repo root, not subdir |
+
+## Phases Without Tests Yet
+
+- Phase 2: denylist, secrets
+- Phase 3: compression handlers
+- Phase 4: DB layer
+- Phase 5: hooks
+- Phase 6: MCP server tools

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -1,0 +1,48 @@
+# todo
+
+Active work and upcoming tasks.
+
+## In Progress
+
+_nothing in progress_
+
+## Backlog
+
+### Phase 2 — Denylist + Secret Detection
+- [ ] Implement `src/denylist.ts` — built-in patterns + config-extensible denylist
+- [ ] Implement `src/secrets.ts` — PEM, GitHub PAT, OpenAI key, etc. detection
+- [ ] Unit tests for both modules
+- [ ] Integrate into hook pipeline
+
+### Phase 3 — Compression Handlers
+- [ ] `handlers/playwright.ts` — interactive elements + visible text
+- [ ] `handlers/github.ts` — number, title, state, body excerpt, labels
+- [ ] `handlers/filesystem.ts` — line count + first 50 lines
+- [ ] `handlers/json.ts` — 3-level depth limit, 3-item array samples
+- [ ] `handlers/generic.ts` — first 500 chars fallback
+- [ ] Unit tests for each handler
+
+### Phase 4 — SQLite + FTS DB Layer
+- [ ] Schema design: stored outputs, sessions, stats
+- [ ] FTS5 index for full-text search
+- [ ] CRUD + query operations
+- [ ] Session-scoped expiry logic
+- [ ] Integration tests
+
+### Phase 5 — Hook Implementations
+- [ ] `hooks/session-start.ts` — record active session day
+- [ ] `hooks/post-tool-use.ts` — full intercept pipeline (denylist → secrets → compress → store)
+- [ ] Wire `bin/recall` CLI to hook modules
+- [ ] Integration tests
+
+### Phase 6 — MCP Server Tools
+- [ ] `recall__retrieve` — fetch by ID with optional FTS scoping
+- [ ] `recall__search` — FTS across all stored outputs
+- [ ] `recall__forget` — delete by ID / tool / session / age / all
+- [ ] `recall__list_stored` — paginated browse
+- [ ] `recall__stats` — session efficiency report
+- [ ] Integration tests
+
+## Blocked
+
+_nothing blocked_


### PR DESCRIPTION
## Summary
- Adds `tasks/todo.md` with backlog organized by phase (2–6)
- Adds `tasks/tests.md` with registry of all 13 existing tests
- Adds `tasks/lessons.md` with first entry (git email privacy)
- Adds `tasks/archive.md` logging Phase 1 and project init as complete

## Test plan
- [ ] Verify all four files render correctly on GitHub