### PR TITLE
feat: compression handlers (phase 3)

### DIFF
--- a/src/handlers/filesystem.ts
+++ b/src/handlers/filesystem.ts
@@ -1,0 +1,22 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const HEAD_LINES = 50;
+
+export const filesystemHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  const lines = raw.split("\n");
+  const totalLines = lines.length;
+  const head = lines.slice(0, HEAD_LINES).join("\n");
+  const truncated = totalLines > HEAD_LINES;
+
+  const header = `[${totalLines} line${totalLines === 1 ? "" : "s"}${truncated ? `, showing first ${HEAD_LINES}` : ""}]`;
+  const summary = `${header}\n${head}${truncated ? "\n…" : ""}`;
+
+  return { summary, originalSize };
+};

--- a/src/handlers/generic.ts
+++ b/src/handlers/generic.ts
@@ -1,0 +1,18 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const MAX_CHARS = 500;
+
+export const genericHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  const excerpt = raw.slice(0, MAX_CHARS).trimEnd();
+  const truncated = raw.length > MAX_CHARS;
+  const summary = truncated ? `${excerpt}\n…` : excerpt;
+
+  return { summary, originalSize };
+};

--- a/src/handlers/github.ts
+++ b/src/handlers/github.ts
@@ -1,0 +1,79 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const BODY_EXCERPT_CHARS = 200;
+
+type JsonObject = Record<string, unknown>;
+
+function summariseItem(item: JsonObject): string {
+  const parts: string[] = [];
+
+  if (typeof item["number"] === "number") parts.push(`#${item["number"]}`);
+  if (typeof item["title"] === "string") parts.push(`"${item["title"]}"`);
+  if (typeof item["state"] === "string") parts.push(`[${item["state"]}]`);
+  if (typeof item["name"] === "string" && !item["title"]) parts.push(item["name"]);
+
+  const url = item["html_url"] ?? item["url"];
+  if (typeof url === "string") parts.push(url);
+
+  const labels = item["labels"];
+  if (Array.isArray(labels) && labels.length > 0) {
+    const names = labels
+      .map((l) =>
+        typeof l === "object" && l !== null && typeof (l as JsonObject)["name"] === "string"
+          ? (l as JsonObject)["name"]
+          : String(l)
+      )
+      .join(", ");
+    parts.push(`labels: ${names}`);
+  }
+
+  if (typeof item["body"] === "string" && item["body"].length > 0) {
+    const excerpt = item["body"].slice(0, BODY_EXCERPT_CHARS).trimEnd();
+    const truncated = item["body"].length > BODY_EXCERPT_CHARS ? "…" : "";
+    parts.push(`body: ${excerpt}${truncated}`);
+  }
+
+  return parts.join(" · ");
+}
+
+export const githubHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    // Not JSON — fall back to plain excerpt
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  // Array of items (e.g. list_issues, list_pull_requests)
+  if (Array.isArray(parsed)) {
+    const items = parsed as unknown[];
+    const lines = items
+      .slice(0, 10)
+      .map((item) =>
+        typeof item === "object" && item !== null
+          ? summariseItem(item as JsonObject)
+          : String(item)
+      );
+    const more = items.length > 10 ? `\n…and ${items.length - 10} more` : "";
+    return { summary: lines.join("\n") + more, originalSize };
+  }
+
+  // Single item
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summariseItem(parsed as JsonObject), originalSize };
+  }
+
+  return { summary: String(parsed), originalSize };
+};

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,0 +1,47 @@
+import type { Handler } from "./types";
+import { playwrightHandler } from "./playwright";
+import { githubHandler } from "./github";
+import { filesystemHandler } from "./filesystem";
+import { jsonHandler } from "./json";
+import { genericHandler } from "./generic";
+import { extractText } from "./types";
+
+export type { CompressionResult, Handler } from "./types";
+export { extractText } from "./types";
+
+/**
+ * Returns the appropriate compression handler for a given MCP tool name.
+ *
+ * Dispatch order:
+ *   1. Playwright browser_snapshot → playwright handler
+ *   2. GitHub tools               → github handler
+ *   3. Filesystem tools           → filesystem handler
+ *   4. Unmatched with JSON output → json handler
+ *   5. Everything else            → generic handler
+ */
+export function getHandler(toolName: string, output: unknown): Handler {
+  if (toolName.includes("playwright") && toolName.includes("snapshot")) {
+    return playwrightHandler;
+  }
+
+  if (toolName.startsWith("mcp__github__")) {
+    return githubHandler;
+  }
+
+  if (
+    toolName.startsWith("mcp__filesystem__") ||
+    toolName.includes("read_file") ||
+    toolName.includes("get_file")
+  ) {
+    return filesystemHandler;
+  }
+
+  // Content-based fallback: try JSON handler if output looks like JSON
+  const text = extractText(output);
+  const trimmed = text.trimStart();
+  if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
+    return jsonHandler;
+  }
+
+  return genericHandler;
+}

--- a/src/handlers/json.ts
+++ b/src/handlers/json.ts
@@ -1,0 +1,49 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const MAX_DEPTH = 3;
+const MAX_ARRAY_ITEMS = 3;
+
+function truncate(value: unknown, depth: number): unknown {
+  if (depth > MAX_DEPTH) return "…";
+
+  if (Array.isArray(value)) {
+    const items = value.slice(0, MAX_ARRAY_ITEMS).map((v) => truncate(v, depth + 1));
+    const more = value.length - MAX_ARRAY_ITEMS;
+    if (more > 0) items.push(`…${more} more` as unknown);
+    return items;
+  }
+
+  if (value !== null && typeof value === "object") {
+    const result: Record<string, unknown> = {};
+    for (const [k, v] of Object.entries(value as Record<string, unknown>)) {
+      result[k] = truncate(v, depth + 1);
+    }
+    return result;
+  }
+
+  return value;
+}
+
+export const jsonHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  const truncated = truncate(parsed, 0);
+  const summary = JSON.stringify(truncated, null, 2);
+  return { summary, originalSize };
+};

--- a/src/handlers/playwright.ts
+++ b/src/handlers/playwright.ts
@@ -1,0 +1,84 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const INTERACTIVE_ROLES = new Set([
+  "button",
+  "link",
+  "textbox",
+  "input",
+  "checkbox",
+  "radio",
+  "select",
+  "combobox",
+  "menuitem",
+  "tab",
+  "searchbox",
+  "spinbutton",
+  "slider",
+  "switch",
+]);
+
+const TEXT_ROLES = new Set([
+  "heading",
+  "paragraph",
+  "statictext",
+  "text",
+  "label",
+  "status",
+  "alert",
+  "cell",
+  "columnheader",
+  "rowheader",
+]);
+
+const MAX_INTERACTIVE = 20;
+const MAX_TEXT_CHARS = 400;
+
+export const playwrightHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  const interactive: string[] = [];
+  const textChunks: string[] = [];
+
+  for (const line of raw.split("\n")) {
+    const trimmed = line.trim();
+    if (!trimmed) continue;
+
+    // Accessibility tree lines look like:  - role "label" [attr=val]
+    const match = trimmed.match(/^-\s+(\w+)\s+"([^"]*)"(.*)$/i);
+    if (!match) continue;
+
+    const [, role, label] = match;
+    const roleLower = role.toLowerCase();
+
+    if (INTERACTIVE_ROLES.has(roleLower) && interactive.length < MAX_INTERACTIVE) {
+      interactive.push(`[${roleLower} "${label}"]`);
+    } else if (TEXT_ROLES.has(roleLower) && label.trim().length > 0) {
+      textChunks.push(label.trim());
+    }
+  }
+
+  const textContent = textChunks
+    .join(" ")
+    .slice(0, MAX_TEXT_CHARS)
+    .trimEnd();
+
+  const parts: string[] = [];
+  if (interactive.length > 0) {
+    parts.push(`Interactive: ${interactive.join(", ")}`);
+  }
+  if (textContent.length > 0) {
+    parts.push(`Visible text: ${textContent}`);
+  }
+
+  const summary =
+    parts.length > 0
+      ? parts.join("\n")
+      : "[snapshot: no interactive elements or visible text extracted]";
+
+  return { summary, originalSize };
+};

--- a/src/handlers/types.ts
+++ b/src/handlers/types.ts
@@ -1,0 +1,34 @@
+export interface CompressionResult {
+  summary: string;
+  originalSize: number;
+}
+
+export type Handler = (toolName: string, output: unknown) => CompressionResult;
+
+/**
+ * Extracts plain text from an MCP tool result.
+ * MCP results arrive as { content: [{ type: "text", text: "..." }, ...] }.
+ * Falls back to JSON serialization for unrecognized shapes.
+ */
+export function extractText(output: unknown): string {
+  if (typeof output === "string") return output;
+
+  if (output !== null && typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (Array.isArray(obj["content"])) {
+      const text = (obj["content"] as unknown[])
+        .filter(
+          (c): c is { type: string; text: string } =>
+            typeof c === "object" &&
+            c !== null &&
+            (c as Record<string, unknown>)["type"] === "text" &&
+            typeof (c as Record<string, unknown>)["text"] === "string"
+        )
+        .map((c) => c.text)
+        .join("\n");
+      if (text.length > 0) return text;
+    }
+  }
+
+  return JSON.stringify(output);
+}

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1,0 +1,274 @@
+import { describe, it, expect } from "bun:test";
+import { playwrightHandler } from "../src/handlers/playwright";
+import { githubHandler } from "../src/handlers/github";
+import { filesystemHandler } from "../src/handlers/filesystem";
+import { jsonHandler } from "../src/handlers/json";
+import { genericHandler } from "../src/handlers/generic";
+import { getHandler, extractText } from "../src/handlers/index";
+
+// ---------------------------------------------------------------------------
+// extractText
+// ---------------------------------------------------------------------------
+
+describe("extractText", () => {
+  it("returns string as-is", () => {
+    expect(extractText("hello")).toBe("hello");
+  });
+
+  it("extracts text from MCP content array", () => {
+    const output = { content: [{ type: "text", text: "foo" }, { type: "text", text: "bar" }] };
+    expect(extractText(output)).toBe("foo\nbar");
+  });
+
+  it("ignores non-text content items", () => {
+    const output = { content: [{ type: "image", data: "abc" }, { type: "text", text: "hi" }] };
+    expect(extractText(output)).toBe("hi");
+  });
+
+  it("falls back to JSON.stringify for unknown shapes", () => {
+    const output = { foo: 42 };
+    expect(extractText(output)).toBe(JSON.stringify(output));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// playwrightHandler
+// ---------------------------------------------------------------------------
+
+describe("playwrightHandler", () => {
+  const snapshot = [
+    '- document "Page"',
+    '  - heading "Welcome"',
+    '  - button "Submit"',
+    '  - textbox "Email"',
+    '  - link "Home"',
+    '  - statictext "Some visible text here"',
+  ].join("\n");
+
+  it("extracts interactive elements", () => {
+    const { summary } = playwrightHandler("mcp__playwright__browser_snapshot", snapshot);
+    expect(summary).toContain('[button "Submit"]');
+    expect(summary).toContain('[textbox "Email"]');
+    expect(summary).toContain('[link "Home"]');
+  });
+
+  it("extracts visible text from headings and statictext", () => {
+    const { summary } = playwrightHandler("mcp__playwright__browser_snapshot", snapshot);
+    expect(summary).toContain("Welcome");
+    expect(summary).toContain("Some visible text here");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = playwrightHandler("mcp__playwright__browser_snapshot", snapshot);
+    expect(originalSize).toBe(Buffer.byteLength(snapshot, "utf8"));
+  });
+
+  it("handles MCP content wrapper", () => {
+    const output = { content: [{ type: "text", text: snapshot }] };
+    const { summary } = playwrightHandler("mcp__playwright__browser_snapshot", output);
+    expect(summary).toContain('[button "Submit"]');
+  });
+
+  it("returns fallback message for empty snapshot", () => {
+    const { summary } = playwrightHandler("mcp__playwright__browser_snapshot", "");
+    expect(summary).toContain("no interactive elements");
+  });
+
+  it("caps interactive elements at 20", () => {
+    const lines = Array.from({ length: 25 }, (_, i) => `- button "Btn${i}"`).join("\n");
+    const { summary } = playwrightHandler("mcp__playwright__browser_snapshot", lines);
+    const matches = summary.match(/\[button/g) ?? [];
+    expect(matches.length).toBeLessThanOrEqual(20);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// githubHandler
+// ---------------------------------------------------------------------------
+
+describe("githubHandler", () => {
+  it("summarises a single issue object", () => {
+    const issue = {
+      number: 42,
+      title: "Fix the thing",
+      state: "open",
+      html_url: "https://github.com/org/repo/issues/42",
+      labels: [{ name: "bug" }, { name: "P1: High" }],
+      body: "This is broken.",
+    };
+    const { summary } = githubHandler("mcp__github__issue_read", JSON.stringify(issue));
+    expect(summary).toContain("#42");
+    expect(summary).toContain('"Fix the thing"');
+    expect(summary).toContain("[open]");
+    expect(summary).toContain("bug");
+    expect(summary).toContain("This is broken.");
+  });
+
+  it("summarises an array of items", () => {
+    const issues = [
+      { number: 1, title: "First", state: "open" },
+      { number: 2, title: "Second", state: "closed" },
+    ];
+    const { summary } = githubHandler("mcp__github__list_issues", JSON.stringify(issues));
+    expect(summary).toContain("#1");
+    expect(summary).toContain("#2");
+  });
+
+  it("truncates arrays longer than 10 items", () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({ number: i + 1, title: `Item ${i + 1}`, state: "open" }));
+    const { summary } = githubHandler("mcp__github__list_issues", JSON.stringify(items));
+    expect(summary).toContain("5 more");
+  });
+
+  it("truncates long body excerpts", () => {
+    const issue = { number: 1, title: "T", state: "open", body: "x".repeat(300) };
+    const { summary } = githubHandler("mcp__github__issue_read", JSON.stringify(issue));
+    expect(summary).toContain("…");
+  });
+
+  it("falls back gracefully for non-JSON text", () => {
+    const { summary } = githubHandler("mcp__github__get_file_contents", "plain text response");
+    expect(summary).toContain("plain text response");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const raw = JSON.stringify({ number: 1, title: "T", state: "open" });
+    const { originalSize } = githubHandler("mcp__github__issue_read", raw);
+    expect(originalSize).toBe(Buffer.byteLength(raw, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// filesystemHandler
+// ---------------------------------------------------------------------------
+
+describe("filesystemHandler", () => {
+  it("includes line count header", () => {
+    const content = "line1\nline2\nline3";
+    const { summary } = filesystemHandler("mcp__filesystem__read_file", content);
+    expect(summary).toContain("3 lines");
+  });
+
+  it("shows all lines when under the limit", () => {
+    const content = Array.from({ length: 10 }, (_, i) => `line ${i + 1}`).join("\n");
+    const { summary } = filesystemHandler("mcp__filesystem__read_file", content);
+    expect(summary).toContain("line 1");
+    expect(summary).toContain("line 10");
+    expect(summary).not.toContain("…");
+  });
+
+  it("truncates and marks when over 50 lines", () => {
+    const content = Array.from({ length: 80 }, (_, i) => `line ${i + 1}`).join("\n");
+    const { summary } = filesystemHandler("mcp__filesystem__read_file", content);
+    expect(summary).toContain("showing first 50");
+    expect(summary).toContain("…");
+    expect(summary).not.toContain("line 51");
+  });
+
+  it("handles single-line content", () => {
+    const { summary } = filesystemHandler("mcp__filesystem__read_file", "one line");
+    expect(summary).toContain("1 line");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const content = "hello\nworld";
+    const { originalSize } = filesystemHandler("mcp__filesystem__read_file", content);
+    expect(originalSize).toBe(Buffer.byteLength(content, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// jsonHandler
+// ---------------------------------------------------------------------------
+
+describe("jsonHandler", () => {
+  it("pretty-prints JSON at depth limit", () => {
+    // MAX_DEPTH=3: values at depth 4 are replaced, so a.b.c is visible but a.b.c.d is "…"
+    const obj = { a: { b: { c: { d: "deep" } } } };
+    const { summary } = jsonHandler("mcp__some__tool", JSON.stringify(obj));
+    const parsed = JSON.parse(summary);
+    expect(parsed.a.b.c.d).toBe("…");
+  });
+
+  it("truncates arrays to 3 items with count", () => {
+    const obj = { items: [1, 2, 3, 4, 5] };
+    const { summary } = jsonHandler("mcp__some__tool", JSON.stringify(obj));
+    const parsed = JSON.parse(summary);
+    expect(parsed.items).toHaveLength(4); // 3 items + "…2 more"
+    expect(parsed.items[3]).toContain("2 more");
+  });
+
+  it("preserves short arrays unchanged", () => {
+    const obj = { items: [1, 2] };
+    const { summary } = jsonHandler("mcp__some__tool", JSON.stringify(obj));
+    const parsed = JSON.parse(summary);
+    expect(parsed.items).toEqual([1, 2]);
+  });
+
+  it("falls back to plain excerpt for non-JSON", () => {
+    const { summary } = jsonHandler("mcp__some__tool", "not json at all");
+    expect(summary).toContain("not json at all");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const raw = JSON.stringify({ x: 1 });
+    const { originalSize } = jsonHandler("mcp__some__tool", raw);
+    expect(originalSize).toBe(Buffer.byteLength(raw, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// genericHandler
+// ---------------------------------------------------------------------------
+
+describe("genericHandler", () => {
+  it("returns content under 500 chars unchanged", () => {
+    const content = "short content";
+    const { summary } = genericHandler("mcp__some__tool", content);
+    expect(summary).toBe(content);
+  });
+
+  it("truncates at 500 chars and appends ellipsis", () => {
+    const content = "x".repeat(600);
+    const { summary } = genericHandler("mcp__some__tool", content);
+    expect(summary.length).toBeLessThanOrEqual(502); // 500 chars + "\n…"
+    expect(summary).toContain("…");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const content = "hello";
+    const { originalSize } = genericHandler("mcp__some__tool", content);
+    expect(originalSize).toBe(Buffer.byteLength(content, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getHandler dispatcher
+// ---------------------------------------------------------------------------
+
+describe("getHandler", () => {
+  it("routes playwright snapshot to playwright handler", () => {
+    const h = getHandler("mcp__plugin_playwright_playwright__browser_snapshot", "");
+    expect(h).toBe(playwrightHandler);
+  });
+
+  it("routes github tools to github handler", () => {
+    const h = getHandler("mcp__github__list_issues", "");
+    expect(h).toBe(githubHandler);
+  });
+
+  it("routes filesystem tools to filesystem handler", () => {
+    const h = getHandler("mcp__filesystem__read_file", "");
+    expect(h).toBe(filesystemHandler);
+  });
+
+  it("routes JSON output to json handler when tool name is unrecognised", () => {
+    const h = getHandler("mcp__unknown__tool", '{"key": "value"}');
+    expect(h).toBe(jsonHandler);
+  });
+
+  it("routes plain text to generic handler when tool name is unrecognised", () => {
+    const h = getHandler("mcp__unknown__tool", "plain text output");
+    expect(h).toBe(genericHandler);
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/handlers/` with 5 compression handlers and a dispatcher
- Playwright: extracts interactive elements (buttons, inputs, links) and visible text from accessibility trees
- GitHub: summarises issues/PRs (number, title, state, labels, body excerpt); handles arrays up to 10 items
- Filesystem: line count header + first 50 lines
- JSON: 3-level depth limit, arrays capped at 3 items with overflow count
- Generic: first 500 chars fallback for anything else
- Dispatcher (`getHandler`) routes by tool name, falls back to content-based detection for unknown tools

## Test plan
- [x] `bun test` — 79/79 passing
- [x] Each handler tested for compression, truncation, originalSize, and MCP content wrapper
- [x] Dispatcher routing tested for all 5 paths including content-based JSON detection