### PR TITLE
feat: hook pipeline (phase 5)

### DIFF
--- a/src/cli.ts
+++ b/src/cli.ts
@@ -1,24 +1,40 @@
 /**
  * CLI entrypoint for hook subcommands.
- * Fully implemented in Phase 5.
  *
  * Subcommands:
- *   session-start   — record today as an active session day
- *   post-tool-use   — compress and store MCP tool output
+ *   session-start   — record today as an active session day, prune expired entries
+ *   post-tool-use   — compress and store MCP tool output, return summary to Claude
  */
+
+import { handleSessionStart } from "./hooks/session-start";
+import { handlePostToolUse } from "./hooks/post-tool-use";
 
 const subcommand = process.argv[2];
 
-switch (subcommand) {
-  case "session-start":
-    // Phase 5: src/hooks/session-start.ts
+async function main(): Promise<void> {
+  const raw = await Bun.stdin.text();
+
+  try {
+    switch (subcommand) {
+      case "session-start":
+        handleSessionStart(raw);
+        process.stdout.write(JSON.stringify({ suppressOutput: true }) + "\n");
+        break;
+      case "post-tool-use": {
+        const result = handlePostToolUse(raw);
+        process.stdout.write(JSON.stringify(result) + "\n");
+        break;
+      }
+      default:
+        process.stderr.write(`[recall] unknown subcommand: ${subcommand}\n`);
+        process.exit(1);
+    }
+  } catch (err) {
+    // Fail open — a recall error must never break Claude's workflow
+    process.stderr.write(`[recall] error in ${subcommand}: ${err}\n`);
+    process.stdout.write("{}\n");
     process.exit(0);
-    break;
-  case "post-tool-use":
-    // Phase 5: src/hooks/post-tool-use.ts
-    process.exit(0);
-    break;
-  default:
-    process.stderr.write(`[recall] unknown subcommand: ${subcommand}\n`);
-    process.exit(1);
+  }
 }
+
+main();

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -107,7 +107,10 @@ const SCHEMA = `
 let instance: Database | null = null;
 
 export function defaultDbPath(projectKey: string): string {
-  return join(homedir(), ".local", "share", "mcp-recall", `${projectKey}.db`);
+  return (
+    process.env.RECALL_DB_PATH ??
+    join(homedir(), ".local", "share", "mcp-recall", `${projectKey}.db`)
+  );
 }
 
 export function getDb(path: string): Database {

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,0 +1,74 @@
+import { loadConfig } from "../config";
+import { getProjectKey } from "../project-key";
+import { isDenied } from "../denylist";
+import { containsSecret, findSecrets } from "../secrets";
+import { getHandler, extractText } from "../handlers/index";
+import { getDb, defaultDbPath, storeOutput } from "../db/index";
+
+interface PostToolUseInput {
+  session_id: string;
+  cwd: string;
+  tool_name: string;
+  tool_response: unknown;
+  [key: string]: unknown;
+}
+
+export interface HookOutput {
+  updatedMCPToolOutput?: string;
+  suppressOutput?: boolean;
+}
+
+function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}
+
+export function handlePostToolUse(raw: string): HookOutput {
+  const input = JSON.parse(raw) as PostToolUseInput;
+  const { tool_name, tool_response, cwd, session_id } = input;
+  const config = loadConfig();
+
+  // 1. Denylist check
+  if (isDenied(tool_name, config)) {
+    return {};
+  }
+
+  // 2. Extract text and check for secrets
+  const fullContent = extractText(tool_response);
+  if (containsSecret(fullContent)) {
+    const names = findSecrets(fullContent);
+    process.stderr.write(`[recall] skipped ${tool_name}: detected ${names.join(", ")}\n`);
+    return {};
+  }
+
+  // 3. Compress
+  const handler = getHandler(tool_name, tool_response);
+  const { summary, originalSize } = handler(tool_name, tool_response);
+  const summarySize = Buffer.byteLength(summary, "utf8");
+
+  // 4. Only store when compression is meaningful
+  if (summarySize >= originalSize) {
+    return {};
+  }
+
+  // 5. Store
+  const projectKey = getProjectKey(cwd);
+  const db = getDb(defaultDbPath(projectKey));
+  const stored = storeOutput(db, {
+    project_key: projectKey,
+    session_id,
+    tool_name,
+    summary,
+    full_content: fullContent,
+    original_size: originalSize,
+  });
+
+  // 6. Return compressed output to Claude
+  const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
+  const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)]`;
+  return {
+    updatedMCPToolOutput: `${header}\n${summary}`,
+    suppressOutput: true,
+  };
+}

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,0 +1,20 @@
+import { loadConfig } from "../config";
+import { getProjectKey } from "../project-key";
+import { getDb, defaultDbPath, recordSession, pruneExpired } from "../db/index";
+
+interface SessionStartInput {
+  session_id: string;
+  cwd: string;
+  [key: string]: unknown;
+}
+
+export function handleSessionStart(raw: string): void {
+  const input = JSON.parse(raw) as SessionStartInput;
+  const config = loadConfig();
+  const projectKey = getProjectKey(input.cwd);
+  const db = getDb(defaultDbPath(projectKey));
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+  recordSession(db, today);
+  pruneExpired(db, projectKey, config.store.expire_after_session_days);
+}

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,0 +1,193 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { handleSessionStart } from "../src/hooks/session-start";
+import { handlePostToolUse } from "../src/hooks/post-tool-use";
+import { getDb, closeDb, listOutputs, getSessionDays, retrieveOutput } from "../src/db/index";
+import { resetConfig } from "../src/config";
+
+const TEST_CWD = process.cwd();
+const SESSION_ID = "test-session-abc123";
+
+function makeSessionStartInput(overrides: Record<string, unknown> = {}): string {
+  return JSON.stringify({
+    session_id: SESSION_ID,
+    cwd: TEST_CWD,
+    hook_event_name: "SessionStart",
+    transcript_path: "/tmp/test",
+    permission_mode: "default",
+    ...overrides,
+  });
+}
+
+function makePostToolUseInput(
+  toolName: string,
+  toolResponse: unknown,
+  overrides: Record<string, unknown> = {}
+): string {
+  return JSON.stringify({
+    session_id: SESSION_ID,
+    cwd: TEST_CWD,
+    hook_event_name: "PostToolUse",
+    tool_name: toolName,
+    tool_input: {},
+    tool_response: toolResponse,
+    tool_use_id: "toolu_test123",
+    transcript_path: "/tmp/test",
+    permission_mode: "default",
+    ...overrides,
+  });
+}
+
+// Large enough to compress meaningfully
+const LARGE_GITHUB_RESPONSE = JSON.stringify(
+  Array.from({ length: 5 }, (_, i) => ({
+    number: i + 1,
+    title: `Issue number ${i + 1} with a descriptive title`,
+    state: "open",
+    html_url: `https://github.com/org/repo/issues/${i + 1}`,
+    labels: [{ name: "bug" }],
+    body: "x".repeat(300),
+  }))
+);
+
+describe("handleSessionStart", () => {
+  beforeEach(() => {
+    process.env.RECALL_DB_PATH = ":memory:";
+  });
+
+  afterEach(() => {
+    closeDb();
+    resetConfig();
+    delete process.env.RECALL_DB_PATH;
+  });
+
+  it("records today's date in the sessions table", () => {
+    handleSessionStart(makeSessionStartInput());
+    const db = getDb(":memory:");
+    const days = getSessionDays(db);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(days).toContain(today);
+  });
+
+  it("is idempotent — running twice records only one session entry", () => {
+    handleSessionStart(makeSessionStartInput());
+    handleSessionStart(makeSessionStartInput());
+    const db = getDb(":memory:");
+    const days = getSessionDays(db);
+    const today = new Date().toISOString().slice(0, 10);
+    expect(days.filter((d) => d === today).length).toBe(1);
+  });
+
+  it("does not throw on valid input", () => {
+    expect(() => handleSessionStart(makeSessionStartInput())).not.toThrow();
+  });
+});
+
+describe("handlePostToolUse", () => {
+  beforeEach(() => {
+    process.env.RECALL_DB_PATH = ":memory:";
+  });
+
+  afterEach(() => {
+    closeDb();
+    resetConfig();
+    delete process.env.RECALL_DB_PATH;
+  });
+
+  it("returns empty object for denied tools (recall tools)", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__recall__search", { content: [{ type: "text", text: "x" }] })
+    );
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object for denied tools (1password)", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__1password__item_lookup", { content: [{ type: "text", text: "secret=abc" }] })
+    );
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object and logs when content contains a secret", () => {
+    const pem = "-----BEGIN RSA PRIVATE KEY-----\nMIIE...";
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__get_file_contents", {
+        content: [{ type: "text", text: pem }],
+      })
+    );
+    expect(result).toEqual({});
+  });
+
+  it("returns empty object when output is too small to compress", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: "tiny" }],
+      })
+    );
+    expect(result).toEqual({});
+  });
+
+  it("compresses large output and returns updatedMCPToolOutput", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    expect(result.updatedMCPToolOutput).toBeDefined();
+    expect(result.suppressOutput).toBe(true);
+  });
+
+  it("updatedMCPToolOutput contains recall ID header", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    expect(result.updatedMCPToolOutput).toMatch(/^\[recall:recall_[0-9a-f]{8}/);
+  });
+
+  it("updatedMCPToolOutput contains size and reduction info", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    expect(result.updatedMCPToolOutput).toContain("% reduction");
+    expect(result.updatedMCPToolOutput).toMatch(/→\d+(\.\d+)?(B|KB|MB)/);
+  });
+
+  it("stores the output in the DB", () => {
+    handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    const db = getDb(":memory:");
+    const items = db.prepare("SELECT COUNT(*) as n FROM stored_outputs").get() as { n: number };
+    expect(items.n).toBeGreaterThan(0);
+  });
+
+  it("stored output preserves session_id from hook input", () => {
+    handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    const db = getDb(":memory:");
+    const allItems = db.prepare("SELECT * FROM stored_outputs").all() as Array<{ session_id: string }>;
+    expect(allItems[0]!.session_id).toBe(SESSION_ID);
+  });
+
+  it("stored full_content is the extracted text, not raw MCP wrapper", () => {
+    handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    const db = getDb(":memory:");
+    const items = db.prepare("SELECT * FROM stored_outputs").all() as Array<{ id: string }>;
+    const item = retrieveOutput(db, items[0]!.id)!;
+    // full_content should be the raw JSON text, not the MCP { content: [...] } wrapper
+    expect(item.full_content).toContain('"number"');
+    expect(item.full_content).not.toContain('"content":[{');
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `src/hooks/session-start.ts` — records today's date in the sessions table and prunes expired entries on every session start
- Adds `src/hooks/post-tool-use.ts` — full intercept pipeline: denylist → secret scan → compress → store → return `updatedMCPToolOutput` to Claude with recall ID header and size reduction stats
- Updates `src/cli.ts` — wires subcommands to hook modules with top-level fail-open error handler
- Adds `RECALL_DB_PATH` env override to `src/db/index.ts` for test isolation (mirrors `RECALL_CONFIG_PATH`)

## Test plan
- [x] `bun test` — 124/124 passing
- [x] Denied tools (recall, 1password) pass through unchanged
- [x] Secrets in content skip storage and log to stderr
- [x] Small outputs below compression threshold pass through
- [x] Large GitHub response is compressed, stored, and returned with recall header
- [x] `session_id` from hook input is preserved in stored row
- [x] `full_content` stores extracted text, not the raw MCP content wrapper