### PR TITLE
feat(db): pinning, access tracking, dedup, eviction, FTS snippets

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -18,6 +18,10 @@ export interface StoredOutput {
   original_size: number;
   summary_size: number;
   created_at: number;
+  pinned: number;        // 0 | 1
+  access_count: number;
+  last_accessed: number | null;
+  input_hash: string | null;
 }
 
 export interface StoreInput {
@@ -27,6 +31,7 @@ export interface StoreInput {
   summary: string;
   full_content: string;
   original_size: number;
+  input_hash?: string;
 }
 
 export interface SearchOptions {
@@ -49,6 +54,7 @@ export interface ForgetOptions {
   session_id?: string;
   older_than_days?: number;
   all?: boolean;
+  force?: boolean; // override pinned protection
 }
 
 export interface Stats {
@@ -59,7 +65,7 @@ export interface Stats {
 }
 
 // ---------------------------------------------------------------------------
-// Schema
+// Schema + migrations
 // ---------------------------------------------------------------------------
 
 const SCHEMA = `
@@ -72,12 +78,17 @@ const SCHEMA = `
     full_content TEXT NOT NULL,
     original_size INTEGER NOT NULL,
     summary_size INTEGER NOT NULL,
-    created_at INTEGER NOT NULL
+    created_at INTEGER NOT NULL,
+    pinned INTEGER NOT NULL DEFAULT 0,
+    access_count INTEGER NOT NULL DEFAULT 0,
+    last_accessed INTEGER,
+    input_hash TEXT
   );
 
   CREATE INDEX IF NOT EXISTS idx_so_project_key ON stored_outputs(project_key);
   CREATE INDEX IF NOT EXISTS idx_so_created_at  ON stored_outputs(created_at);
   CREATE INDEX IF NOT EXISTS idx_so_tool_name   ON stored_outputs(tool_name);
+  CREATE INDEX IF NOT EXISTS idx_so_input_hash  ON stored_outputs(project_key, input_hash);
 
   CREATE VIRTUAL TABLE IF NOT EXISTS outputs_fts USING fts5(
     id UNINDEXED,
@@ -99,6 +110,24 @@ const SCHEMA = `
     date TEXT PRIMARY KEY
   );
 `;
+
+// Columns added after initial schema — applied once, idempotent via try/catch
+const MIGRATIONS = [
+  "ALTER TABLE stored_outputs ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
+  "ALTER TABLE stored_outputs ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0",
+  "ALTER TABLE stored_outputs ADD COLUMN last_accessed INTEGER",
+  "ALTER TABLE stored_outputs ADD COLUMN input_hash TEXT",
+];
+
+function applyMigrations(db: Database): void {
+  for (const sql of MIGRATIONS) {
+    try {
+      db.run(sql);
+    } catch {
+      // Column already exists — safe to ignore
+    }
+  }
+}
 
 // ---------------------------------------------------------------------------
 // Connection
@@ -122,6 +151,7 @@ export function getDb(path: string): Database {
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
   instance.run(SCHEMA);
+  applyMigrations(instance);
   return instance;
 }
 
@@ -142,23 +172,118 @@ export function storeOutput(db: Database, input: StoreInput): StoredOutput {
   const id = generateId();
   const summary_size = Buffer.byteLength(input.summary, "utf8");
   const created_at = Math.floor(Date.now() / 1000);
+  const input_hash = input.input_hash ?? null;
 
   db.prepare(`
     INSERT INTO stored_outputs
-      (id, project_key, session_id, tool_name, summary, full_content, original_size, summary_size, created_at)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)
+      (id, project_key, session_id, tool_name, summary, full_content,
+       original_size, summary_size, created_at, input_hash)
+    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
   `).run(
     id, input.project_key, input.session_id, input.tool_name,
-    input.summary, input.full_content, input.original_size, summary_size, created_at
+    input.summary, input.full_content, input.original_size,
+    summary_size, created_at, input_hash
   );
 
-  return { id, ...input, summary_size, created_at };
+  return {
+    id, ...input, summary_size, created_at,
+    pinned: 0, access_count: 0, last_accessed: null,
+    input_hash: input_hash,
+  };
 }
 
 export function retrieveOutput(db: Database, id: string): StoredOutput | null {
   return db.prepare(
     `SELECT * FROM stored_outputs WHERE id = ?`
   ).get(id) as StoredOutput | null;
+}
+
+export function recordAccess(db: Database, id: string): void {
+  const now = Math.floor(Date.now() / 1000);
+  db.prepare(`
+    UPDATE stored_outputs
+    SET access_count = access_count + 1, last_accessed = ?
+    WHERE id = ?
+  `).run(now, id);
+}
+
+export function pinOutput(
+  db: Database,
+  id: string,
+  project_key: string,
+  pinned: boolean
+): boolean {
+  const result = db.prepare(`
+    UPDATE stored_outputs SET pinned = ? WHERE id = ? AND project_key = ?
+  `).run(pinned ? 1 : 0, id, project_key);
+  return result.changes > 0;
+}
+
+export function checkDedup(
+  db: Database,
+  project_key: string,
+  input_hash: string
+): StoredOutput | null {
+  return db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND input_hash = ?
+    ORDER BY created_at DESC
+    LIMIT 1
+  `).get(project_key, input_hash) as StoredOutput | null;
+}
+
+export function evictIfNeeded(
+  db: Database,
+  project_key: string,
+  max_size_mb: number
+): number {
+  const max_bytes = max_size_mb * 1024 * 1024;
+  let evicted = 0;
+
+  while (true) {
+    const total = (db.prepare(`
+      SELECT COALESCE(SUM(original_size), 0) as n
+      FROM stored_outputs WHERE project_key = ?
+    `).get(project_key) as { n: number }).n;
+
+    if (total <= max_bytes) break;
+
+    // Evict the least-frequently-accessed non-pinned item
+    const candidate = db.prepare(`
+      SELECT id FROM stored_outputs
+      WHERE project_key = ? AND pinned = 0
+      ORDER BY access_count ASC, last_accessed ASC NULLS FIRST, created_at ASC
+      LIMIT 1
+    `).get(project_key) as { id: string } | null;
+
+    if (!candidate) break; // all remaining items are pinned
+
+    db.prepare(`DELETE FROM stored_outputs WHERE id = ?`).run(candidate.id);
+    evicted++;
+  }
+
+  return evicted;
+}
+
+export function retrieveSnippet(
+  db: Database,
+  id: string,
+  query: string
+): string | null {
+  const row = db.prepare(
+    `SELECT rowid FROM stored_outputs WHERE id = ?`
+  ).get(id) as { rowid: number } | null;
+
+  if (!row) return null;
+
+  const result = db.prepare(`
+    SELECT snippet(outputs_fts, 3, '', '', ' [...] ', 64) as excerpt
+    FROM outputs_fts
+    WHERE outputs_fts MATCH ?
+    AND rowid = ?
+  `).get(query, row.rowid) as { excerpt: string } | null;
+
+  return result?.excerpt ?? null;
 }
 
 export function searchOutputs(
@@ -215,21 +340,24 @@ export function forgetOutputs(
   project_key: string,
   options: ForgetOptions
 ): number {
+  const pinGuard = options.force ? "" : "AND pinned = 0";
+
   if (options.all) {
-    return countAndDelete(db, "project_key = ?", [project_key]);
+    return countAndDelete(db, `project_key = ? ${pinGuard}`, [project_key]);
   }
   if (options.id) {
+    // Single-item delete: ignore pin guard (explicit ID targets are intentional)
     return countAndDelete(db, "id = ? AND project_key = ?", [options.id, project_key]);
   }
   if (options.tool) {
-    return countAndDelete(db, "tool_name = ? AND project_key = ?", [options.tool, project_key]);
+    return countAndDelete(db, `tool_name = ? AND project_key = ? ${pinGuard}`, [options.tool, project_key]);
   }
   if (options.session_id) {
-    return countAndDelete(db, "session_id = ? AND project_key = ?", [options.session_id, project_key]);
+    return countAndDelete(db, `session_id = ? AND project_key = ? ${pinGuard}`, [options.session_id, project_key]);
   }
   if (options.older_than_days !== undefined) {
     const cutoff = Math.floor(Date.now() / 1000) - options.older_than_days * 86400;
-    return countAndDelete(db, "created_at < ? AND project_key = ?", [cutoff, project_key]);
+    return countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
   }
   return 0;
 }
@@ -262,7 +390,7 @@ export function pruneExpired(
   calendar_days: number
 ): number {
   const cutoff = Math.floor(Date.now() / 1000) - calendar_days * 86400;
-  return countAndDelete(db, "created_at < ? AND project_key = ?", [cutoff, project_key]);
+  return countAndDelete(db, "created_at < ? AND project_key = ? AND pinned = 0", [cutoff, project_key]);
 }
 
 export function recordSession(db: Database, date: string): void {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,11 +4,29 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-_nothing in progress_
+### v2 — Phase 2b: Hook Updates
+- [ ] `post-tool-use`: compute `input_hash` from `tool_name + tool_input`, check dedup before compressing
+- [ ] `post-tool-use`: return cached summary with `[recall:id · cached · <date>]` header on hit
+- [ ] `post-tool-use`: call `evictIfNeeded` after storing
+- [ ] Tests
 
 ## Backlog
 
-_all phases complete — see archive.md_
+### v2 — Phase 2c: MCP Tools
+- [ ] `recall__pin(id, pinned?)` — pin/unpin an item, protect from expiry and eviction
+- [ ] `recall__note(text, title?)` — store arbitrary text as `tool_name = "recall__note"`
+- [ ] `recall__export` — JSON dump of all stored items for current project
+- [ ] Update `recall__retrieve` — use `retrieveSnippet()` when query provided; call `recordAccess`
+- [ ] Update `recall__list_stored` — add `sort: "accessed"` using access_count + last_accessed
+- [ ] Update `recall__forget` — skip pinned items; add `force` param to override
+- [ ] Tests for all new/updated tools
+
+### v2 — Phase 2d: Additional Handlers
+- [ ] `handlers/csv.ts` — header row + first 5 rows + row count
+- [ ] `handlers/linear.ts` — issue number, title, state, priority, description excerpt
+- [ ] `handlers/slack.ts` — channel, user, timestamp, message text excerpt
+- [ ] Update dispatcher in `handlers/index.ts`
+- [ ] Tests for each handler
 
 ## Blocked
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -4,6 +4,11 @@ import {
   closeDb,
   storeOutput,
   retrieveOutput,
+  recordAccess,
+  pinOutput,
+  checkDedup,
+  evictIfNeeded,
+  retrieveSnippet,
   searchOutputs,
   listOutputs,
   forgetOutputs,
@@ -320,6 +325,185 @@ describe("db", () => {
       const days = getSessionDays(db);
       expect(days[0]).toBe("2026-03-01");
       expect(days[1]).toBe("2026-02-28");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // recordAccess
+  // -------------------------------------------------------------------------
+
+  describe("recordAccess", () => {
+    it("increments access_count", () => {
+      const stored = storeOutput(db, makeInput());
+      expect(stored.access_count).toBe(0);
+      recordAccess(db, stored.id);
+      const updated = retrieveOutput(db, stored.id)!;
+      expect(updated.access_count).toBe(1);
+    });
+
+    it("accumulates on repeated access", () => {
+      const stored = storeOutput(db, makeInput());
+      recordAccess(db, stored.id);
+      recordAccess(db, stored.id);
+      recordAccess(db, stored.id);
+      expect(retrieveOutput(db, stored.id)!.access_count).toBe(3);
+    });
+
+    it("sets last_accessed to a recent timestamp", () => {
+      const before = Math.floor(Date.now() / 1000);
+      const stored = storeOutput(db, makeInput());
+      recordAccess(db, stored.id);
+      const after = Math.floor(Date.now() / 1000);
+      const updated = retrieveOutput(db, stored.id)!;
+      expect(updated.last_accessed).toBeGreaterThanOrEqual(before);
+      expect(updated.last_accessed!).toBeLessThanOrEqual(after);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // pinOutput
+  // -------------------------------------------------------------------------
+
+  describe("pinOutput", () => {
+    it("pins an item", () => {
+      const stored = storeOutput(db, makeInput());
+      expect(stored.pinned).toBe(0);
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      expect(retrieveOutput(db, stored.id)!.pinned).toBe(1);
+    });
+
+    it("unpins a pinned item", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      pinOutput(db, stored.id, PROJECT_KEY, false);
+      expect(retrieveOutput(db, stored.id)!.pinned).toBe(0);
+    });
+
+    it("returns true when item exists", () => {
+      const stored = storeOutput(db, makeInput());
+      expect(pinOutput(db, stored.id, PROJECT_KEY, true)).toBe(true);
+    });
+
+    it("returns false for unknown id", () => {
+      expect(pinOutput(db, "recall_00000000", PROJECT_KEY, true)).toBe(false);
+    });
+
+    it("pruneExpired skips pinned items", () => {
+      const old_ts = Math.floor(Date.now() / 1000) - 10 * 86400;
+      db.prepare(`
+        INSERT INTO stored_outputs
+          (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at,pinned)
+        VALUES ('recall_pin00001',?,?,?,?,?,100,3,?,1)
+      `).run(PROJECT_KEY, "2026-02-19", "mcp__tool", "pinned old", "content", old_ts);
+      expect(pruneExpired(db, PROJECT_KEY, 7)).toBe(0);
+    });
+
+    it("forgetOutputs(all) skips pinned items by default", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      storeOutput(db, makeInput());
+      const deleted = forgetOutputs(db, PROJECT_KEY, { all: true });
+      expect(deleted).toBe(1); // only the unpinned one
+      expect(retrieveOutput(db, stored.id)).not.toBeNull();
+    });
+
+    it("forgetOutputs(all, force) deletes pinned items too", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      forgetOutputs(db, PROJECT_KEY, { all: true, force: true });
+      expect(retrieveOutput(db, stored.id)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // checkDedup
+  // -------------------------------------------------------------------------
+
+  describe("checkDedup", () => {
+    it("returns null when no matching hash exists", () => {
+      expect(checkDedup(db, PROJECT_KEY, "abc123")).toBeNull();
+    });
+
+    it("returns the stored item when hash matches", () => {
+      storeOutput(db, makeInput({ input_hash: "hash1234" }));
+      const hit = checkDedup(db, PROJECT_KEY, "hash1234");
+      expect(hit).not.toBeNull();
+      expect(hit!.input_hash).toBe("hash1234");
+    });
+
+    it("returns the most recent match when multiple exist", () => {
+      const now = Math.floor(Date.now() / 1000);
+      db.prepare(`
+        INSERT INTO stored_outputs (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at,input_hash)
+        VALUES ('recall_dedup0001',?,?,?,?,?,100,3,?,?)
+      `).run(PROJECT_KEY, "2026-03-01", "mcp__tool", "old", "content", now - 10, "hash1234");
+      db.prepare(`
+        INSERT INTO stored_outputs (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at,input_hash)
+        VALUES ('recall_dedup0002',?,?,?,?,?,100,3,?,?)
+      `).run(PROJECT_KEY, "2026-03-01", "mcp__tool", "new", "content", now, "hash1234");
+      const hit = checkDedup(db, PROJECT_KEY, "hash1234");
+      expect(hit!.summary).toBe("new");
+    });
+
+    it("does not match hash from a different project", () => {
+      storeOutput(db, makeInput({ project_key: "otherproject567", input_hash: "hash1234" }));
+      expect(checkDedup(db, PROJECT_KEY, "hash1234")).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // evictIfNeeded
+  // -------------------------------------------------------------------------
+
+  describe("evictIfNeeded", () => {
+    it("returns 0 when store is under the size limit", () => {
+      storeOutput(db, makeInput({ original_size: 100 }));
+      expect(evictIfNeeded(db, PROJECT_KEY, 500)).toBe(0);
+    });
+
+    it("evicts least-accessed item when over limit", () => {
+      // Two items totalling 600B, limit is effectively 0 (0.0005 MB ≈ 512B)
+      const a = storeOutput(db, makeInput({ original_size: 300, summary: "item a" }));
+      const b = storeOutput(db, makeInput({ original_size: 300, summary: "item b" }));
+      // Give item b more accesses so it survives
+      recordAccess(db, b.id);
+      recordAccess(db, b.id);
+      const evicted = evictIfNeeded(db, PROJECT_KEY, 0.0005);
+      expect(evicted).toBeGreaterThan(0);
+      // item b (more accessed) should survive longer
+      expect(retrieveOutput(db, b.id)).not.toBeNull();
+    });
+
+    it("does not evict pinned items", () => {
+      const stored = storeOutput(db, makeInput({ original_size: 1000000 }));
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      // Even with a 0 limit, pinned item is not evicted
+      evictIfNeeded(db, PROJECT_KEY, 0);
+      expect(retrieveOutput(db, stored.id)).not.toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // retrieveSnippet
+  // -------------------------------------------------------------------------
+
+  describe("retrieveSnippet", () => {
+    it("returns null for unknown id", () => {
+      expect(retrieveSnippet(db, "recall_00000000", "query")).toBeNull();
+    });
+
+    it("returns a text excerpt when query matches full_content", () => {
+      const stored = storeOutput(db, makeInput({
+        full_content: "The quick brown fox jumps over the lazy authentication dog",
+      }));
+      const snippet = retrieveSnippet(db, stored.id, "authentication");
+      expect(snippet).not.toBeNull();
+      expect(snippet).toContain("authentication");
+    });
+
+    it("returns null when query does not match", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "hello world" }));
+      expect(retrieveSnippet(db, stored.id, "zzznomatch")).toBeNull();
     });
   });
 });


### PR DESCRIPTION
## Summary

- Add `pinned`, `access_count`, `last_accessed`, `input_hash` columns via idempotent `ALTER TABLE` migrations
- New operations: `recordAccess`, `pinOutput`, `checkDedup`, `evictIfNeeded`, `retrieveSnippet`
- `pruneExpired` and `forgetOutputs` now skip pinned items (`force: true` to override)
- `storeOutput` accepts optional `input_hash` for dedup support

## Test plan

- [x] 52 db tests (20 new), 168 total, 0 failures
- [x] `recordAccess`: increments count, accumulates on repeat, sets `last_accessed`
- [x] `pinOutput`: pin/unpin, returns true/false, pruneExpired skips pinned, forgetOutputs skips pinned, force override works
- [x] `checkDedup`: null on miss, returns item on hash match, most-recent on multi-match, project-isolated
- [x] `evictIfNeeded`: no eviction under limit, evicts least-accessed first, never evicts pinned
- [x] `retrieveSnippet`: null on unknown id, returns excerpt on match, null on no match