### PR TITLE
feat(hooks): dedup check and eviction in post-tool-use

### DIFF
--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -1,14 +1,16 @@
+import { createHash } from "crypto";
 import { loadConfig } from "../config";
 import { getProjectKey } from "../project-key";
 import { isDenied } from "../denylist";
 import { containsSecret, findSecrets } from "../secrets";
 import { getHandler, extractText } from "../handlers/index";
-import { getDb, defaultDbPath, storeOutput } from "../db/index";
+import { getDb, defaultDbPath, storeOutput, checkDedup, evictIfNeeded } from "../db/index";
 
 interface PostToolUseInput {
   session_id: string;
   cwd: string;
   tool_name: string;
+  tool_input?: unknown;
   tool_response: unknown;
   [key: string]: unknown;
 }
@@ -26,7 +28,7 @@ function formatBytes(bytes: number): string {
 
 export function handlePostToolUse(raw: string): HookOutput {
   const input = JSON.parse(raw) as PostToolUseInput;
-  const { tool_name, tool_response, cwd, session_id } = input;
+  const { tool_name, tool_input, tool_response, cwd, session_id } = input;
   const config = loadConfig();
 
   // 1. Denylist check
@@ -42,19 +44,41 @@ export function handlePostToolUse(raw: string): HookOutput {
     return {};
   }
 
-  // 3. Compress
+  // 3. Setup DB (needed for dedup check before compression)
+  const projectKey = getProjectKey(cwd);
+  const db = getDb(defaultDbPath(projectKey));
+
+  // 4. Dedup check — skip when tool_input is absent
+  const input_hash =
+    tool_input !== undefined
+      ? createHash("sha256")
+          .update(tool_name + JSON.stringify(tool_input))
+          .digest("hex")
+      : null;
+
+  if (input_hash) {
+    const cached = checkDedup(db, projectKey, input_hash);
+    if (cached) {
+      const cachedDate = new Date(cached.created_at * 1000).toISOString().slice(0, 10);
+      const header = `[recall:${cached.id} · cached · ${cachedDate}]`;
+      return {
+        updatedMCPToolOutput: `${header}\n${cached.summary}`,
+        suppressOutput: true,
+      };
+    }
+  }
+
+  // 5. Compress
   const handler = getHandler(tool_name, tool_response);
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
 
-  // 4. Only store when compression is meaningful
+  // 6. Only store when compression is meaningful
   if (summarySize >= originalSize) {
     return {};
   }
 
-  // 5. Store
-  const projectKey = getProjectKey(cwd);
-  const db = getDb(defaultDbPath(projectKey));
+  // 7. Store
   const stored = storeOutput(db, {
     project_key: projectKey,
     session_id,
@@ -62,9 +86,13 @@ export function handlePostToolUse(raw: string): HookOutput {
     summary,
     full_content: fullContent,
     original_size: originalSize,
+    input_hash: input_hash ?? undefined,
   });
 
-  // 6. Return compressed output to Claude
+  // 8. Evict if store exceeds size limit
+  evictIfNeeded(db, projectKey, config.store.max_size_mb);
+
+  // 9. Return compressed output to Claude
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
   const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)]`;
   return {

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,14 +4,6 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-### v2 — Phase 2b: Hook Updates
-- [ ] `post-tool-use`: compute `input_hash` from `tool_name + tool_input`, check dedup before compressing
-- [ ] `post-tool-use`: return cached summary with `[recall:id · cached · <date>]` header on hit
-- [ ] `post-tool-use`: call `evictIfNeeded` after storing
-- [ ] Tests
-
-## Backlog
-
 ### v2 — Phase 2c: MCP Tools
 - [ ] `recall__pin(id, pinned?)` — pin/unpin an item, protect from expiry and eviction
 - [ ] `recall__note(text, title?)` — store arbitrary text as `tool_name = "recall__note"`
@@ -20,6 +12,8 @@ Active work and upcoming tasks.
 - [ ] Update `recall__list_stored` — add `sort: "accessed"` using access_count + last_accessed
 - [ ] Update `recall__forget` — skip pinned items; add `force` param to override
 - [ ] Tests for all new/updated tools
+
+## Backlog
 
 ### v2 — Phase 2d: Additional Handlers
 - [ ] `handlers/csv.ts` — header row + first 5 rows + row count

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -1,8 +1,12 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtempSync, writeFileSync, rmSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
 import { handleSessionStart } from "../src/hooks/session-start";
 import { handlePostToolUse } from "../src/hooks/post-tool-use";
 import { getDb, closeDb, listOutputs, getSessionDays, retrieveOutput } from "../src/db/index";
 import { resetConfig } from "../src/config";
+import { getProjectKey } from "../src/project-key";
 
 const TEST_CWD = process.cwd();
 const SESSION_ID = "test-session-abc123";
@@ -189,5 +193,84 @@ describe("handlePostToolUse", () => {
     // full_content should be the raw JSON text, not the MCP { content: [...] } wrapper
     expect(item.full_content).toContain('"number"');
     expect(item.full_content).not.toContain('"content":[{');
+  });
+
+  // -------------------------------------------------------------------------
+  // Dedup
+  // -------------------------------------------------------------------------
+
+  it("returns cached response on second call with same tool_input", () => {
+    const input = makePostToolUseInput("mcp__github__list_issues", {
+      content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+    }, { tool_input: { owner: "org", repo: "repo" } });
+
+    handlePostToolUse(input); // first call — stores item
+    const second = handlePostToolUse(input); // second call — cache hit
+
+    expect(second.updatedMCPToolOutput).toMatch(/· cached · \d{4}-\d{2}-\d{2}/);
+    expect(second.suppressOutput).toBe(true);
+  });
+
+  it("cached header contains the original recall id", () => {
+    const input = makePostToolUseInput("mcp__github__list_issues", {
+      content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+    }, { tool_input: { owner: "org", repo: "repo" } });
+
+    const first = handlePostToolUse(input);
+    const idMatch = first.updatedMCPToolOutput!.match(/\[recall:(recall_[0-9a-f]{8})/);
+    const originalId = idMatch![1];
+
+    const second = handlePostToolUse(input);
+    expect(second.updatedMCPToolOutput).toContain(originalId);
+  });
+
+  it("does not store a second item on cache hit", () => {
+    const input = makePostToolUseInput("mcp__github__list_issues", {
+      content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+    }, { tool_input: { owner: "org", repo: "repo" } });
+
+    handlePostToolUse(input);
+    handlePostToolUse(input);
+
+    const db = getDb(":memory:");
+    const count = (db.prepare("SELECT COUNT(*) as n FROM stored_outputs").get() as { n: number }).n;
+    expect(count).toBe(1);
+  });
+
+  // -------------------------------------------------------------------------
+  // Eviction
+  // -------------------------------------------------------------------------
+
+  it("evicts non-pinned items after storing when store exceeds max_size_mb", () => {
+    const tempDir = mkdtempSync(join(tmpdir(), "recall-hooks-test-"));
+    const configPath = join(tempDir, "config.toml");
+    // ~3KB limit: allows the new item (~2.25KB) but not the pre-inserted + new item together
+    writeFileSync(configPath, "[store]\nmax_size_mb = 0.003\n");
+    process.env.RECALL_CONFIG_PATH = configPath;
+    resetConfig();
+
+    try {
+      const db = getDb(":memory:");
+      const projectKey = getProjectKey(TEST_CWD);
+      const oldTs = Math.floor(Date.now() / 1000) - 60;
+      db.prepare(`
+        INSERT INTO stored_outputs
+          (id, project_key, session_id, tool_name, summary, full_content, original_size, summary_size, created_at)
+        VALUES ('recall_evict0001', ?, 'session', 'mcp__old__tool', 'old', 'old content', 2000, 3, ?)
+      `).run(projectKey, oldTs);
+
+      handlePostToolUse(
+        makePostToolUseInput("mcp__github__list_issues", {
+          content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+        })
+      );
+
+      // Pre-inserted item (older, lower access_count) should have been evicted
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = 'recall_evict0001'").get()).toBeNull();
+    } finally {
+      delete process.env.RECALL_CONFIG_PATH;
+      resetConfig();
+      rmSync(tempDir, { recursive: true });
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Compute `sha256(tool_name + JSON.stringify(tool_input))` as `input_hash` for each hook invocation
- Check dedup before compression: repeated identical tool calls return `[recall:id · cached · YYYY-MM-DD]` with the original summary — no re-compression, no second DB write
- Call `evictIfNeeded` after storing to enforce the `max_size_mb` cap

## Test plan

- [x] Returns `· cached ·` header on second call with same `tool_input`
- [x] Cached header contains the original recall ID
- [x] Cache hit does not write a second item to the DB
- [x] Non-pinned items are evicted when store exceeds `max_size_mb` after storing
- [x] 172 tests total, 0 failures