### PR TITLE
feat(tools): pin, note, export + retrieve/list/forget updates

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -4,6 +4,9 @@
  * Tools exposed:
  *   recall__retrieve     — fetch stored content, FTS-scoped
  *   recall__search       — FTS across all stored outputs
+ *   recall__pin          — pin/unpin an item from expiry and eviction
+ *   recall__note         — store arbitrary text as a recall note
+ *   recall__export       — JSON dump of all stored items
  *   recall__forget       — delete stored items
  *   recall__list_stored  — paginated item browser
  *   recall__stats        — aggregate session efficiency report
@@ -16,6 +19,9 @@ import { getDb, defaultDbPath } from "./db/index";
 import {
   toolRetrieve,
   toolSearch,
+  toolPin,
+  toolNote,
+  toolExport,
   toolForget,
   toolListStored,
   toolStats,
@@ -31,14 +37,14 @@ const server = new McpServer({
 
 server.tool(
   "recall__retrieve",
-  "Fetch stored content from a previous tool call. Pass a query to return only relevant sections via FTS. Use when you need more detail from a compressed result.",
+  "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.",
   {
     id: z.string().describe("8-char or full item ID"),
-    query: z.string().optional().describe("FTS query to narrow the result"),
+    query: z.string().optional().describe("FTS query to return a focused excerpt"),
     max_bytes: z
       .number()
       .optional()
-      .describe("Override default 8KB cap on returned bytes"),
+      .describe("Override default 8KB cap on returned bytes (used when FTS returns no match)"),
   },
   async (args) => ({
     content: [{ type: "text", text: toolRetrieve(db, args) }],
@@ -59,8 +65,41 @@ server.tool(
 );
 
 server.tool(
+  "recall__pin",
+  "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin.",
+  {
+    id: z.string().describe("Item ID to pin or unpin"),
+    pinned: z.boolean().optional().describe("true to pin (default), false to unpin"),
+  },
+  async (args) => ({
+    content: [{ type: "text", text: toolPin(db, projectKey, args) }],
+  })
+);
+
+server.tool(
+  "recall__note",
+  "Store arbitrary text as a recall note — conclusions, findings, context that should survive context resets. Use for project memory.",
+  {
+    text: z.string().describe("Note content to store"),
+    title: z.string().optional().describe("Short title for the note (shown in list/search)"),
+  },
+  async (args) => ({
+    content: [{ type: "text", text: toolNote(db, projectKey, args) }],
+  })
+);
+
+server.tool(
+  "recall__export",
+  "Export all stored items for this project as JSON. Use before a full clear to preserve data.",
+  {},
+  async () => ({
+    content: [{ type: "text", text: toolExport(db, projectKey) }],
+  })
+);
+
+server.tool(
   "recall__forget",
-  "Delete stored items by ID, tool pattern, session, age, or clear all. Always confirm before clearing all.",
+  "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true.",
   {
     id: z.string().optional().describe("Delete a single item by ID"),
     tool: z.string().optional().describe("Delete all items matching tool name substring"),
@@ -71,6 +110,7 @@ server.tool(
       .describe("Delete items older than N calendar days"),
     all: z.boolean().optional().describe("Clear entire store (requires confirmed: true)"),
     confirmed: z.boolean().optional().describe("Required to execute all: true"),
+    force: z.boolean().optional().describe("Override pin protection and delete pinned items too"),
   },
   async (args) => ({
     content: [{ type: "text", text: toolForget(db, projectKey, args) }],
@@ -79,7 +119,7 @@ server.tool(
 
 server.tool(
   "recall__list_stored",
-  "Browse stored items by recency or size. Use to find a specific item to retrieve or forget.",
+  "Browse stored items by recency, access frequency, or size. Use to find a specific item to retrieve or forget.",
   {
     limit: z.number().optional().describe("Items per page (default 10)"),
     offset: z.number().optional().describe("Pagination offset"),
@@ -87,7 +127,7 @@ server.tool(
     sort: z
       .enum(["recent", "accessed", "size"])
       .optional()
-      .describe("Sort order (default: recent)"),
+      .describe("Sort order: recent (default), accessed (most-used first), size (largest first)"),
   },
   async (args) => ({
     content: [{ type: "text", text: toolListStored(db, projectKey, args) }],

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -7,11 +7,16 @@
 import type { Database } from "bun:sqlite";
 import {
   retrieveOutput,
+  retrieveSnippet,
+  recordAccess,
+  pinOutput,
   searchOutputs,
   listOutputs,
   forgetOutputs,
   getStats,
   getSessionDays,
+  storeOutput,
+  type StoredOutput,
   type ForgetOptions,
 } from "./db/index";
 import { loadConfig } from "./config";
@@ -33,6 +38,10 @@ function formatDate(unixSecs: number): string {
 function reductionPct(original: number, summary: number): string {
   if (original === 0) return "0%";
   return `${((1 - summary / original) * 100).toFixed(0)}%`;
+}
+
+function itemHeader(item: StoredOutput): string {
+  return `[recall:${item.id} · ${item.tool_name} · ${formatDate(item.created_at)} · ${formatBytes(item.original_size)}→${formatBytes(item.summary_size)}]`;
 }
 
 // ---------------------------------------------------------------------------
@@ -57,16 +66,21 @@ export function toolRetrieve(
     return `[recall: no item found with id "${args.id}"]`;
   }
 
-  const header = `[recall:${item.id} · ${item.tool_name} · ${formatDate(item.created_at)} · ${formatBytes(item.original_size)}→${formatBytes(item.summary_size)}]`;
+  recordAccess(db, args.id);
+  const header = itemHeader(item);
 
-  // With a query, return full content (capped) so Claude can find more detail
   if (args.query) {
+    // Try FTS snippet first for a focused, relevant excerpt
+    const snippet = retrieveSnippet(db, args.id, args.query);
+    if (snippet) {
+      return `${header}\n${snippet}`;
+    }
+    // No FTS match: fall back to full content capped at max_bytes
     const content = item.full_content.slice(0, cap);
     const truncated = item.full_content.length > cap ? `\n…(truncated at ${formatBytes(cap)})` : "";
     return `${header}\n${content}${truncated}`;
   }
 
-  // Without a query, return the summary
   return `${header}\n${item.summary}`;
 }
 
@@ -115,6 +129,79 @@ export function toolSearch(
 }
 
 // ---------------------------------------------------------------------------
+// recall__pin
+// ---------------------------------------------------------------------------
+
+export interface PinArgs {
+  id: string;
+  pinned?: boolean; // defaults to true
+}
+
+export function toolPin(
+  db: Database,
+  projectKey: string,
+  args: PinArgs
+): string {
+  const pinned = args.pinned ?? true;
+  const success = pinOutput(db, args.id, projectKey, pinned);
+  if (!success) {
+    return `[recall: no item found with id "${args.id}"]`;
+  }
+  return `[recall: ${pinned ? "pinned" : "unpinned"} ${args.id}]`;
+}
+
+// ---------------------------------------------------------------------------
+// recall__note
+// ---------------------------------------------------------------------------
+
+export interface NoteArgs {
+  text: string;
+  title?: string;
+}
+
+export function toolNote(
+  db: Database,
+  projectKey: string,
+  args: NoteArgs
+): string {
+  const title = args.title ?? "(note)";
+  const excerpt = args.text.slice(0, 200);
+  const ellipsis = args.text.length > 200 ? "…" : "";
+  const summary = `${title}: ${excerpt}${ellipsis}`;
+  const originalSize = Buffer.byteLength(args.text, "utf8");
+  const sessionId = new Date().toISOString().slice(0, 10);
+
+  const stored = storeOutput(db, {
+    project_key: projectKey,
+    session_id: sessionId,
+    tool_name: "recall__note",
+    summary,
+    full_content: args.text,
+    original_size: originalSize,
+  });
+
+  return `[recall: note stored as ${stored.id}]`;
+}
+
+// ---------------------------------------------------------------------------
+// recall__export
+// ---------------------------------------------------------------------------
+
+export function toolExport(db: Database, projectKey: string): string {
+  const items = db
+    .prepare(
+      `SELECT * FROM stored_outputs WHERE project_key = ? ORDER BY created_at ASC`
+    )
+    .all(projectKey) as StoredOutput[];
+
+  if (items.length === 0) {
+    return `[recall: no items to export]`;
+  }
+
+  return JSON.stringify(items, null, 2);
+}
+
+// ---------------------------------------------------------------------------
 // recall__forget
 // ---------------------------------------------------------------------------
 
@@ -125,6 +212,7 @@ export interface ForgetArgs {
   older_than_days?: number;
   all?: boolean;
   confirmed?: boolean;
+  force?: boolean;
 }
 
 export function toolForget(
@@ -142,6 +230,7 @@ export function toolForget(
     session_id: args.session_id,
     older_than_days: args.older_than_days,
     all: args.all,
+    force: args.force,
   };
 
   const deleted = forgetOutputs(db, projectKey, options);
@@ -173,7 +262,12 @@ export function toolListStored(
   const offset = args.offset ?? 0;
 
   const order =
-    args.sort === "size" ? "original_size DESC" : "created_at DESC";
+    args.sort === "size"
+      ? "original_size DESC"
+      : args.sort === "accessed"
+      ? "access_count DESC, last_accessed DESC NULLS LAST, created_at DESC"
+      : "created_at DESC";
+
   const sql = `
     SELECT * FROM stored_outputs
     WHERE project_key = ?
@@ -194,7 +288,8 @@ export function toolListStored(
 
   const rows = items.map((item) => {
     const reduction = reductionPct(item.original_size, item.summary_size);
-    return `${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}→${formatBytes(item.summary_size).padEnd(8)}  ${reduction}`;
+    const pin = item.pinned ? " 📌" : "";
+    return `${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}→${formatBytes(item.summary_size).padEnd(8)}  ${reduction}${pin}`;
   });
 
   const header = `${"ID".padEnd(16)}  ${"Tool".padEnd(40)}  ${"Date".padEnd(10)}  ${"Size".padStart(7)} ${"→".padEnd(9)}  Red.`;

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,17 +4,6 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-### v2 — Phase 2c: MCP Tools
-- [ ] `recall__pin(id, pinned?)` — pin/unpin an item, protect from expiry and eviction
-- [ ] `recall__note(text, title?)` — store arbitrary text as `tool_name = "recall__note"`
-- [ ] `recall__export` — JSON dump of all stored items for current project
-- [ ] Update `recall__retrieve` — use `retrieveSnippet()` when query provided; call `recordAccess`
-- [ ] Update `recall__list_stored` — add `sort: "accessed"` using access_count + last_accessed
-- [ ] Update `recall__forget` — skip pinned items; add `force` param to override
-- [ ] Tests for all new/updated tools
-
-## Backlog
-
 ### v2 — Phase 2d: Additional Handlers
 - [ ] `handlers/csv.ts` — header row + first 5 rows + row count
 - [ ] `handlers/linear.ts` — issue number, title, state, priority, description excerpt

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,8 +1,11 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { getDb, closeDb, storeOutput, recordSession, type StoreInput } from "../src/db/index";
+import { getDb, closeDb, storeOutput, pinOutput, recordSession, type StoreInput } from "../src/db/index";
 import {
   toolRetrieve,
   toolSearch,
+  toolPin,
+  toolNote,
+  toolExport,
   toolForget,
   toolListStored,
   toolStats,
@@ -229,6 +232,192 @@ describe("MCP tool handlers", () => {
       storeOutput(db, makeInput({ original_size: 40000, summary: "x".repeat(200) }));
       const result = toolStats(db, PROJECT_KEY);
       expect(result).toContain("Tokens saved");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolRetrieve — updated behavior
+  // -------------------------------------------------------------------------
+
+  describe("toolRetrieve (v2)", () => {
+    it("increments access_count on retrieve", () => {
+      const stored = storeOutput(db, makeInput());
+      expect(stored.access_count).toBe(0);
+      toolRetrieve(db, { id: stored.id });
+      const row = db.prepare("SELECT access_count FROM stored_outputs WHERE id = ?").get(stored.id) as { access_count: number };
+      expect(row.access_count).toBe(1);
+    });
+
+    it("returns FTS snippet when query matches full_content", () => {
+      const stored = storeOutput(db, makeInput({
+        full_content: "The deployment pipeline uses kubernetes and helm charts",
+      }));
+      const result = toolRetrieve(db, { id: stored.id, query: "kubernetes" });
+      expect(result).toContain("kubernetes");
+    });
+
+    it("falls back to full_content slice when query has no FTS match", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "hello world content" }));
+      const result = toolRetrieve(db, { id: stored.id, query: "zzznomatch" });
+      expect(result).toContain("hello world content");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolPin
+  // -------------------------------------------------------------------------
+
+  describe("toolPin", () => {
+    it("pins an item and returns confirmation", () => {
+      const stored = storeOutput(db, makeInput());
+      const result = toolPin(db, PROJECT_KEY, { id: stored.id });
+      expect(result).toContain("pinned");
+      expect(result).toContain(stored.id);
+    });
+
+    it("unpins when pinned: false", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      const result = toolPin(db, PROJECT_KEY, { id: stored.id, pinned: false });
+      expect(result).toContain("unpinned");
+    });
+
+    it("returns not-found for unknown id", () => {
+      const result = toolPin(db, PROJECT_KEY, { id: "recall_00000000" });
+      expect(result).toContain("no item found");
+    });
+
+    it("defaults pinned to true when omitted", () => {
+      const stored = storeOutput(db, makeInput());
+      toolPin(db, PROJECT_KEY, { id: stored.id });
+      const row = db.prepare("SELECT pinned FROM stored_outputs WHERE id = ?").get(stored.id) as { pinned: number };
+      expect(row.pinned).toBe(1);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolNote
+  // -------------------------------------------------------------------------
+
+  describe("toolNote", () => {
+    it("stores a note with tool_name recall__note", () => {
+      toolNote(db, PROJECT_KEY, { text: "Important finding about the auth flow" });
+      const rows = db.prepare("SELECT tool_name FROM stored_outputs WHERE project_key = ?").all(PROJECT_KEY) as Array<{ tool_name: string }>;
+      expect(rows.some((r) => r.tool_name === "recall__note")).toBe(true);
+    });
+
+    it("returns stored id in response", () => {
+      const result = toolNote(db, PROJECT_KEY, { text: "some note text" });
+      expect(result).toMatch(/recall_[0-9a-f]{8}/);
+    });
+
+    it("includes title in summary when provided", () => {
+      toolNote(db, PROJECT_KEY, { text: "content here", title: "My Finding" });
+      const row = db.prepare("SELECT summary FROM stored_outputs WHERE tool_name = 'recall__note'").get() as { summary: string };
+      expect(row.summary).toContain("My Finding");
+    });
+
+    it("uses (note) as default title when none given", () => {
+      toolNote(db, PROJECT_KEY, { text: "untitled note" });
+      const row = db.prepare("SELECT summary FROM stored_outputs WHERE tool_name = 'recall__note'").get() as { summary: string };
+      expect(row.summary).toContain("(note)");
+    });
+
+    it("stores full text as full_content", () => {
+      const text = "The full text of this important note";
+      toolNote(db, PROJECT_KEY, { text });
+      const row = db.prepare("SELECT full_content FROM stored_outputs WHERE tool_name = 'recall__note'").get() as { full_content: string };
+      expect(row.full_content).toBe(text);
+    });
+
+    it("truncates summary at 200 chars with ellipsis", () => {
+      const text = "x".repeat(300);
+      toolNote(db, PROJECT_KEY, { text });
+      const row = db.prepare("SELECT summary FROM stored_outputs WHERE tool_name = 'recall__note'").get() as { summary: string };
+      expect(row.summary).toContain("…");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolExport
+  // -------------------------------------------------------------------------
+
+  describe("toolExport", () => {
+    it("returns no-items message when store is empty", () => {
+      const result = toolExport(db, PROJECT_KEY);
+      expect(result).toContain("no items to export");
+    });
+
+    it("returns JSON array of stored items", () => {
+      storeOutput(db, makeInput());
+      const result = toolExport(db, PROJECT_KEY);
+      const parsed = JSON.parse(result) as unknown[];
+      expect(Array.isArray(parsed)).toBe(true);
+      expect(parsed.length).toBe(1);
+    });
+
+    it("exported items include id, tool_name, summary, and full_content", () => {
+      storeOutput(db, makeInput({ summary: "exported summary" }));
+      const result = toolExport(db, PROJECT_KEY);
+      const parsed = JSON.parse(result) as Array<Record<string, unknown>>;
+      const item = parsed[0]!;
+      expect(item).toHaveProperty("id");
+      expect(item).toHaveProperty("tool_name");
+      expect(item).toHaveProperty("summary", "exported summary");
+      expect(item).toHaveProperty("full_content");
+    });
+
+    it("orders items oldest-first", () => {
+      const now = Math.floor(Date.now() / 1000);
+      db.prepare(`INSERT INTO stored_outputs (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at) VALUES ('recall_exp00001',?,?,?,?,?,100,3,?)`).run(PROJECT_KEY, "s", "mcp__tool", "older", "c", now - 10);
+      db.prepare(`INSERT INTO stored_outputs (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at) VALUES ('recall_exp00002',?,?,?,?,?,100,3,?)`).run(PROJECT_KEY, "s", "mcp__tool", "newer", "c", now);
+      const parsed = JSON.parse(toolExport(db, PROJECT_KEY)) as Array<{ summary: string }>;
+      expect(parsed[0]!.summary).toBe("older");
+      expect(parsed[1]!.summary).toBe("newer");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolForget (v2) — pin awareness
+  // -------------------------------------------------------------------------
+
+  describe("toolForget (v2)", () => {
+    it("skips pinned items by default", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      storeOutput(db, makeInput());
+      const result = toolForget(db, PROJECT_KEY, { all: true, confirmed: true });
+      expect(result).toContain("deleted 1 item");
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(stored.id)).not.toBeNull();
+    });
+
+    it("deletes pinned items when force: true", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      toolForget(db, PROJECT_KEY, { all: true, confirmed: true, force: true });
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(stored.id)).toBeNull();
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolListStored (v2) — sort: accessed
+  // -------------------------------------------------------------------------
+
+  describe("toolListStored (v2)", () => {
+    it("sorts by access_count descending when sort=accessed", () => {
+      const a = storeOutput(db, makeInput({ summary: "item a" }));
+      const b = storeOutput(db, makeInput({ summary: "item b" }));
+      // Give item b more accesses
+      db.prepare("UPDATE stored_outputs SET access_count = 5 WHERE id = ?").run(b.id);
+      const result = toolListStored(db, PROJECT_KEY, { sort: "accessed" });
+      expect(result.indexOf(b.id)).toBeLessThan(result.indexOf(a.id));
+    });
+
+    it("shows pin indicator for pinned items", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      const result = toolListStored(db, PROJECT_KEY, {});
+      expect(result).toContain("📌");
     });
   });
 });


### PR DESCRIPTION
## Summary

- **`recall__pin`**: pin/unpin items to protect from expiry and LFU eviction
- **`recall__note`**: store arbitrary text (with optional title) as project memory — survives context resets
- **`recall__export`**: JSON dump of all stored items, oldest-first — use before `forget(all: true)`
- **`recall__retrieve`**: now calls `recordAccess` on every fetch; uses FTS `retrieveSnippet` when query provided, falls back to full_content slice on no match
- **`recall__list_stored`**: new `sort: "accessed"` (access_count DESC); pinned items show 📌
- **`recall__forget`**: new `force` param to override pin protection

## Test plan

- [x] `toolPin`: pin/unpin, returns not-found for unknown id, defaults to `pinned: true`
- [x] `toolNote`: stores as `recall__note`, returns id, includes title in summary, truncates at 200 chars
- [x] `toolExport`: empty state, JSON array output, correct fields, oldest-first order
- [x] `toolRetrieve` (v2): access_count incremented, FTS snippet returned on match, full_content fallback on no match
- [x] `toolForget` (v2): skips pinned by default, `force: true` deletes pinned
- [x] `toolListStored` (v2): `sort=accessed` orders by access_count, pin indicator shown
- [x] 193 tests total, 0 failures