### PR TITLE
feat(handlers): CSV, Linear, and Slack compression handlers

### DIFF
--- a/src/handlers/csv.ts
+++ b/src/handlers/csv.ts
@@ -1,0 +1,79 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const MAX_PREVIEW_ROWS = 5;
+
+/**
+ * Splits a single CSV row, handling double-quoted fields with embedded commas.
+ */
+function splitCsvRow(row: string): string[] {
+  const fields: string[] = [];
+  let current = "";
+  let inQuotes = false;
+
+  for (const char of row) {
+    if (char === '"') {
+      inQuotes = !inQuotes;
+    } else if (char === "," && !inQuotes) {
+      fields.push(current.trim());
+      current = "";
+    } else {
+      current += char;
+    }
+  }
+  fields.push(current.trim());
+  return fields;
+}
+
+export const csvHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  const lines = raw.split("\n").filter((l) => l.trim().length > 0);
+
+  if (lines.length === 0) {
+    return { summary: "(empty CSV)", originalSize };
+  }
+
+  const headerCols = splitCsvRow(lines[0]!);
+  const dataRows = lines.slice(1);
+  const totalRows = dataRows.length;
+
+  const previewLines = dataRows.slice(0, MAX_PREVIEW_ROWS).map((line, i) => {
+    const vals = splitCsvRow(line);
+    // Show as key: value pairs for readability (up to 5 cols)
+    const pairs = headerCols
+      .slice(0, 5)
+      .map((col, ci) => `${col}=${vals[ci] ?? ""}`)
+      .join(", ");
+    const overflow = headerCols.length > 5 ? ` [+${headerCols.length - 5} cols]` : "";
+    return `  row ${i + 1}: ${pairs}${overflow}`;
+  });
+
+  const more =
+    totalRows > MAX_PREVIEW_ROWS
+      ? `\n[…${totalRows - MAX_PREVIEW_ROWS} more rows]`
+      : "";
+
+  const summary = [
+    `[${totalRows} rows × ${headerCols.length} cols]`,
+    `headers: ${headerCols.slice(0, 10).join(", ")}${headerCols.length > 10 ? ` [+${headerCols.length - 10} more]` : ""}`,
+    ...previewLines,
+  ].join("\n") + more;
+
+  return { summary, originalSize };
+};
+
+/**
+ * Returns true if the text looks like a CSV file:
+ * at least 3 non-empty lines, first line has 2+ commas.
+ */
+export function looksLikeCsv(text: string): boolean {
+  const lines = text.split("\n").filter((l) => l.trim().length > 0);
+  if (lines.length < 3) return false;
+  const firstLineCommas = (lines[0]!.match(/,/g) ?? []).length;
+  return firstLineCommas >= 2;
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,6 +2,9 @@ import type { Handler } from "./types";
 import { playwrightHandler } from "./playwright";
 import { githubHandler } from "./github";
 import { filesystemHandler } from "./filesystem";
+import { linearHandler } from "./linear";
+import { slackHandler } from "./slack";
+import { csvHandler, looksLikeCsv } from "./csv";
 import { jsonHandler } from "./json";
 import { genericHandler } from "./generic";
 import { extractText } from "./types";
@@ -16,8 +19,12 @@ export { extractText } from "./types";
  *   1. Playwright browser_snapshot → playwright handler
  *   2. GitHub tools               → github handler
  *   3. Filesystem tools           → filesystem handler
- *   4. Unmatched with JSON output → json handler
- *   5. Everything else            → generic handler
+ *   4. Linear tools               → linear handler
+ *   5. Slack tools                → slack handler
+ *   6. CSV tools (name-based)     → csv handler
+ *   7. Unmatched with JSON output → json handler
+ *   8. CSV content-based fallback → csv handler
+ *   9. Everything else            → generic handler
  */
 export function getHandler(toolName: string, output: unknown): Handler {
   if (toolName.includes("playwright") && toolName.includes("snapshot")) {
@@ -36,11 +43,28 @@ export function getHandler(toolName: string, output: unknown): Handler {
     return filesystemHandler;
   }
 
-  // Content-based fallback: try JSON handler if output looks like JSON
+  if (toolName.includes("linear")) {
+    return linearHandler;
+  }
+
+  if (toolName.includes("slack")) {
+    return slackHandler;
+  }
+
+  if (toolName.includes("csv")) {
+    return csvHandler;
+  }
+
+  // Content-based fallbacks
   const text = extractText(output);
   const trimmed = text.trimStart();
+
   if (trimmed.startsWith("{") || trimmed.startsWith("[")) {
     return jsonHandler;
+  }
+
+  if (looksLikeCsv(text)) {
+    return csvHandler;
   }
 
   return genericHandler;

--- a/src/handlers/linear.ts
+++ b/src/handlers/linear.ts
@@ -1,0 +1,144 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+type JsonObject = Record<string, unknown>;
+
+const PRIORITY_LABEL: Record<number, string> = {
+  0: "No Priority",
+  1: "Urgent",
+  2: "High",
+  3: "Medium",
+  4: "Low",
+};
+
+const DESC_CHARS = 200;
+const MAX_LIST_ITEMS = 10;
+
+function priorityLabel(priority: unknown): string | null {
+  if (typeof priority === "number" && priority in PRIORITY_LABEL) {
+    return PRIORITY_LABEL[priority]!;
+  }
+  if (typeof priority === "string" && priority.length > 0) return priority;
+  return null;
+}
+
+function stateLabel(state: unknown): string | null {
+  if (typeof state === "object" && state !== null) {
+    const name = (state as JsonObject)["name"];
+    if (typeof name === "string") return name;
+  }
+  if (typeof state === "string") return state;
+  return null;
+}
+
+function summariseIssue(issue: JsonObject, includeDesc = true): string {
+  const parts: string[] = [];
+
+  const id = issue["identifier"] ?? issue["id"];
+  if (id != null) parts.push(String(id));
+  if (typeof issue["title"] === "string") parts.push(`"${issue["title"]}"`);
+
+  const state = stateLabel(issue["state"] ?? issue["stateName"]);
+  if (state) parts.push(`[${state}]`);
+
+  const priority = priorityLabel(issue["priority"]);
+  if (priority) parts.push(`Priority: ${priority}`);
+
+  const url = issue["url"] ?? issue["branchName"];
+  if (typeof url === "string" && url.startsWith("http")) parts.push(url);
+
+  const lines = [parts.join(" · ")];
+
+  if (includeDesc) {
+    const desc = issue["description"];
+    if (typeof desc === "string" && desc.length > 0) {
+      const excerpt = desc.slice(0, DESC_CHARS).trimEnd();
+      const truncated = desc.length > DESC_CHARS ? "…" : "";
+      lines.push(`Description: ${excerpt}${truncated}`);
+    }
+  }
+
+  return lines.join("\n");
+}
+
+/**
+ * Unwraps common Linear MCP response shapes into a flat array of issues.
+ * Returns null if the shape is unrecognized.
+ */
+function extractIssues(parsed: unknown): JsonObject[] | null {
+  if (Array.isArray(parsed)) {
+    return parsed.filter((i): i is JsonObject => typeof i === "object" && i !== null);
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as JsonObject;
+
+  // GraphQL: { data: { issue: {...} } }
+  const data = obj["data"];
+  if (typeof data === "object" && data !== null) {
+    const d = data as JsonObject;
+    if (typeof d["issue"] === "object" && d["issue"] !== null) {
+      return [d["issue"] as JsonObject];
+    }
+    // GraphQL list: { data: { issues: { nodes: [...] } } }
+    const issues = d["issues"];
+    if (typeof issues === "object" && issues !== null) {
+      const nodes = (issues as JsonObject)["nodes"];
+      if (Array.isArray(nodes)) {
+        return nodes.filter((i): i is JsonObject => typeof i === "object" && i !== null);
+      }
+    }
+  }
+
+  // Relay-style: { nodes: [...] }
+  if (Array.isArray(obj["nodes"])) {
+    return (obj["nodes"] as unknown[]).filter(
+      (i): i is JsonObject => typeof i === "object" && i !== null
+    );
+  }
+
+  // Single issue object (has identifier or title)
+  if (obj["identifier"] != null || typeof obj["title"] === "string") {
+    return [obj];
+  }
+
+  return null;
+}
+
+export const linearHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { summary: raw.slice(0, 500), originalSize };
+  }
+
+  const issues = extractIssues(parsed);
+  if (!issues || issues.length === 0) {
+    // Unrecognized shape — fall back to a short JSON excerpt
+    return { summary: raw.slice(0, 500), originalSize };
+  }
+
+  if (issues.length === 1) {
+    return { summary: summariseIssue(issues[0]!, true), originalSize };
+  }
+
+  const lines = issues
+    .slice(0, MAX_LIST_ITEMS)
+    .map((issue, i) => `${i + 1}. ${summariseIssue(issue, false)}`);
+  const more =
+    issues.length > MAX_LIST_ITEMS
+      ? `\n…and ${issues.length - MAX_LIST_ITEMS} more`
+      : "";
+
+  return {
+    summary: `${issues.length} Linear issues:\n${lines.join("\n")}${more}`,
+    originalSize,
+  };
+};

--- a/src/handlers/slack.ts
+++ b/src/handlers/slack.ts
@@ -1,0 +1,118 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+type JsonObject = Record<string, unknown>;
+
+const MSG_CHARS = 200;
+const MAX_MESSAGES = 10;
+
+function formatSlackTs(ts: unknown): string {
+  if (typeof ts !== "string" && typeof ts !== "number") return "";
+  const secs = typeof ts === "string" ? parseFloat(ts) : ts;
+  if (isNaN(secs)) return "";
+  return new Date(secs * 1000).toISOString().slice(0, 16).replace("T", " ");
+}
+
+function resolveUser(msg: JsonObject): string {
+  // Prefer display name over raw ID
+  const profile = msg["user_profile"] ?? msg["profile"];
+  if (typeof profile === "object" && profile !== null) {
+    const p = profile as JsonObject;
+    const name = p["display_name"] ?? p["real_name"] ?? p["name"];
+    if (typeof name === "string" && name.length > 0) return name;
+  }
+  return (
+    (typeof msg["username"] === "string" ? msg["username"] : null) ??
+    (typeof msg["user"] === "string" ? msg["user"] : null) ??
+    "unknown"
+  );
+}
+
+function summariseMessage(msg: JsonObject): string {
+  const ts = formatSlackTs(msg["ts"]);
+  const user = resolveUser(msg);
+  const text = typeof msg["text"] === "string" ? msg["text"] : "";
+  const excerpt = text.slice(0, MSG_CHARS).replace(/\n/g, " ").trimEnd();
+  const truncated = text.length > MSG_CHARS ? "…" : "";
+  const prefix = ts ? `[${ts}] ` : "";
+  return `${prefix}${user}: ${excerpt}${truncated}`;
+}
+
+function resolveChannel(obj: JsonObject): string | null {
+  // { channel: "C12345" } or { channel: { name: "general" } }
+  const ch = obj["channel"];
+  if (typeof ch === "string") return ch;
+  if (typeof ch === "object" && ch !== null) {
+    const name = (ch as JsonObject)["name"] ?? (ch as JsonObject)["id"];
+    if (typeof name === "string") return `#${name}`;
+  }
+  // { channelId: "..." }
+  if (typeof obj["channelId"] === "string") return obj["channelId"];
+  return null;
+}
+
+/**
+ * Extracts messages array from common Slack MCP response shapes.
+ */
+function extractMessages(parsed: unknown): { messages: JsonObject[]; channel: string | null } | null {
+  if (Array.isArray(parsed)) {
+    const msgs = parsed.filter((m): m is JsonObject => typeof m === "object" && m !== null);
+    if (msgs.length > 0 && (msgs[0]!["ts"] != null || msgs[0]!["text"] != null)) {
+      return { messages: msgs, channel: null };
+    }
+    return null;
+  }
+
+  if (typeof parsed !== "object" || parsed === null) return null;
+  const obj = parsed as JsonObject;
+
+  // Single message
+  if (obj["ts"] != null && obj["text"] != null) {
+    return { messages: [obj], channel: resolveChannel(obj) };
+  }
+
+  // Wrapper: { messages: [...] } or { ok: true, messages: [...] }
+  if (Array.isArray(obj["messages"])) {
+    const msgs = (obj["messages"] as unknown[]).filter(
+      (m): m is JsonObject => typeof m === "object" && m !== null
+    );
+    return { messages: msgs, channel: resolveChannel(obj) };
+  }
+
+  return null;
+}
+
+export const slackHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { summary: raw.slice(0, 500), originalSize };
+  }
+
+  const result = extractMessages(parsed);
+  if (!result || result.messages.length === 0) {
+    return { summary: raw.slice(0, 500), originalSize };
+  }
+
+  const { messages, channel } = result;
+  const channelPrefix = channel ? `${channel} — ` : "";
+  const count = messages.length;
+
+  const lines = messages
+    .slice(0, MAX_MESSAGES)
+    .map((msg, i) => `${i + 1}. ${summariseMessage(msg)}`);
+  const more =
+    count > MAX_MESSAGES ? `\n…and ${count - MAX_MESSAGES} more messages` : "";
+
+  return {
+    summary: `${channelPrefix}${count} message${count === 1 ? "" : "s"}:\n${lines.join("\n")}${more}`,
+    originalSize,
+  };
+};

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,12 +4,7 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-### v2 — Phase 2d: Additional Handlers
-- [ ] `handlers/csv.ts` — header row + first 5 rows + row count
-- [ ] `handlers/linear.ts` — issue number, title, state, priority, description excerpt
-- [ ] `handlers/slack.ts` — channel, user, timestamp, message text excerpt
-- [ ] Update dispatcher in `handlers/index.ts`
-- [ ] Tests for each handler
+_nothing in progress — v2 complete_
 
 ## Blocked
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -2,6 +2,9 @@ import { describe, it, expect } from "bun:test";
 import { playwrightHandler } from "../src/handlers/playwright";
 import { githubHandler } from "../src/handlers/github";
 import { filesystemHandler } from "../src/handlers/filesystem";
+import { csvHandler, looksLikeCsv } from "../src/handlers/csv";
+import { linearHandler } from "../src/handlers/linear";
+import { slackHandler } from "../src/handlers/slack";
 import { jsonHandler } from "../src/handlers/json";
 import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
@@ -270,5 +273,296 @@ describe("getHandler", () => {
   it("routes plain text to generic handler when tool name is unrecognised", () => {
     const h = getHandler("mcp__unknown__tool", "plain text output");
     expect(h).toBe(genericHandler);
+  });
+
+  it("routes linear tools to linear handler", () => {
+    const h = getHandler("mcp__linear__get_issue", "");
+    expect(h).toBe(linearHandler);
+  });
+
+  it("routes slack tools to slack handler", () => {
+    const h = getHandler("mcp__slack__get_messages", "");
+    expect(h).toBe(slackHandler);
+  });
+
+  it("routes csv tools to csv handler by name", () => {
+    const h = getHandler("mcp__export__get_csv", "");
+    expect(h).toBe(csvHandler);
+  });
+
+  it("routes CSV-shaped plain text to csv handler", () => {
+    const csv = "col1,col2,col3\nv1,v2,v3\nv4,v5,v6\nv7,v8,v9";
+    const h = getHandler("mcp__unknown__tool", csv);
+    expect(h).toBe(csvHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// csvHandler
+// ---------------------------------------------------------------------------
+
+describe("csvHandler", () => {
+  const CSV = [
+    "name,age,city,country",
+    "Alice,30,London,UK",
+    "Bob,25,Paris,France",
+    "Carol,35,Berlin,Germany",
+  ].join("\n");
+
+  it("includes row and column count in summary", () => {
+    const { summary } = csvHandler("mcp__csv__export", CSV);
+    expect(summary).toContain("3 rows");
+    expect(summary).toContain("4 cols");
+  });
+
+  it("includes header column names", () => {
+    const { summary } = csvHandler("mcp__csv__export", CSV);
+    expect(summary).toContain("name");
+    expect(summary).toContain("age");
+    expect(summary).toContain("city");
+  });
+
+  it("includes preview rows with key=value pairs", () => {
+    const { summary } = csvHandler("mcp__csv__export", CSV);
+    expect(summary).toContain("Alice");
+    expect(summary).toContain("row 1");
+  });
+
+  it("shows only first 5 data rows with overflow count", () => {
+    const rows = Array.from({ length: 10 }, (_, i) => `v${i},x,y`);
+    const input = ["a,b,c", ...rows].join("\n");
+    const { summary } = csvHandler("mcp__csv__export", input);
+    expect(summary).toContain("5 more rows");
+  });
+
+  it("handles quoted fields with embedded commas", () => {
+    const input = `name,address\nAlice,"123 Main St, Apt 4"\nBob,456 Oak Ave`;
+    const { summary } = csvHandler("mcp__csv__export", input);
+    expect(summary).toContain("Alice");
+    expect(summary).toContain("2 rows");
+  });
+
+  it("handles empty CSV input", () => {
+    const { summary } = csvHandler("mcp__csv__export", "");
+    expect(summary).toContain("empty");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = csvHandler("mcp__csv__export", CSV);
+    expect(originalSize).toBe(Buffer.byteLength(CSV, "utf8"));
+  });
+
+  it("handles MCP content wrapper", () => {
+    const { summary } = csvHandler("mcp__csv__export", {
+      content: [{ type: "text", text: CSV }],
+    });
+    expect(summary).toContain("3 rows");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// looksLikeCsv
+// ---------------------------------------------------------------------------
+
+describe("looksLikeCsv", () => {
+  it("returns true for CSV-shaped text with 3+ lines and 2+ commas in first line", () => {
+    expect(looksLikeCsv("a,b,c\n1,2,3\n4,5,6")).toBe(true);
+  });
+
+  it("returns false for plain text", () => {
+    expect(looksLikeCsv("hello world\nno commas here\nstill no commas")).toBe(false);
+  });
+
+  it("returns false for fewer than 3 lines", () => {
+    expect(looksLikeCsv("a,b,c\n1,2,3")).toBe(false);
+  });
+
+  it("returns false for JSON (handled earlier in dispatcher)", () => {
+    expect(looksLikeCsv('{"key": "value"}\n{"a": "b"}\n{"c": "d"}')).toBe(false);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// linearHandler
+// ---------------------------------------------------------------------------
+
+describe("linearHandler", () => {
+  const SINGLE_ISSUE = JSON.stringify({
+    identifier: "ENG-123",
+    title: "Fix authentication bug",
+    state: { name: "In Progress" },
+    priority: 2,
+    description: "The login form throws a 500 on invalid credentials.",
+    url: "https://linear.app/org/issue/ENG-123",
+  });
+
+  it("includes identifier and title for a single issue", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("ENG-123");
+    expect(summary).toContain("Fix authentication bug");
+  });
+
+  it("includes state label", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("[In Progress]");
+  });
+
+  it("maps numeric priority to human label", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("Priority: High");
+  });
+
+  it("includes description excerpt", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("500 on invalid credentials");
+  });
+
+  it("includes URL", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("https://linear.app");
+  });
+
+  it("summarises an array of issues with count header", () => {
+    const arr = JSON.stringify([
+      { identifier: "ENG-1", title: "Issue one", state: { name: "Todo" }, priority: 3 },
+      { identifier: "ENG-2", title: "Issue two", state: { name: "Done" }, priority: 4 },
+    ]);
+    const { summary } = linearHandler("mcp__linear__list_issues", arr);
+    expect(summary).toContain("2 Linear issues");
+    expect(summary).toContain("ENG-1");
+    expect(summary).toContain("ENG-2");
+  });
+
+  it("caps list at 10 items with overflow count", () => {
+    const arr = JSON.stringify(
+      Array.from({ length: 15 }, (_, i) => ({
+        identifier: `ENG-${i + 1}`,
+        title: `Issue ${i + 1}`,
+        state: { name: "Todo" },
+        priority: 0,
+      }))
+    );
+    const { summary } = linearHandler("mcp__linear__list_issues", arr);
+    expect(summary).toContain("5 more");
+  });
+
+  it("handles GraphQL wrapper { data: { issue: {...} } }", () => {
+    const gql = JSON.stringify({
+      data: { issue: { identifier: "ENG-99", title: "GraphQL issue", state: { name: "Backlog" }, priority: 4 } },
+    });
+    const { summary } = linearHandler("mcp__linear__get_issue", gql);
+    expect(summary).toContain("ENG-99");
+  });
+
+  it("handles Relay-style { nodes: [...] } wrapper", () => {
+    const relay = JSON.stringify({
+      nodes: [
+        { identifier: "ENG-10", title: "Node issue", state: { name: "Todo" }, priority: 3 },
+      ],
+    });
+    const { summary } = linearHandler("mcp__linear__list_issues", relay);
+    expect(summary).toContain("ENG-10");
+  });
+
+  it("falls back gracefully for non-JSON input", () => {
+    const { summary } = linearHandler("mcp__linear__get_issue", "not json");
+    expect(summary).toContain("not json");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = linearHandler("mcp__linear__get_issue", SINGLE_ISSUE);
+    expect(originalSize).toBe(Buffer.byteLength(SINGLE_ISSUE, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// slackHandler
+// ---------------------------------------------------------------------------
+
+describe("slackHandler", () => {
+  const MESSAGES_WRAPPER = JSON.stringify({
+    ok: true,
+    messages: [
+      { ts: "1740825600.000000", user: "U12345", text: "Hello team, standup in 5 minutes" },
+      { ts: "1740825660.000000", user: "U67890", text: "On my way, be there shortly" },
+    ],
+    channel: "C_GENERAL",
+  });
+
+  it("includes message count in summary", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(summary).toContain("2 messages");
+  });
+
+  it("includes user identifier in output", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(summary).toContain("U12345");
+  });
+
+  it("includes message text excerpt", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(summary).toContain("standup in 5 minutes");
+  });
+
+  it("formats timestamp as readable date", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(summary).toMatch(/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}\]/);
+  });
+
+  it("includes channel identifier when present", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(summary).toContain("C_GENERAL");
+  });
+
+  it("handles bare array of messages", () => {
+    const arr = JSON.stringify([
+      { ts: "1740825600.000000", user: "alice", text: "bare array message" },
+      { ts: "1740825660.000000", user: "bob", text: "another message" },
+      { ts: "1740825720.000000", user: "carol", text: "third message" },
+    ]);
+    const { summary } = slackHandler("mcp__slack__get_messages", arr);
+    expect(summary).toContain("3 messages");
+    expect(summary).toContain("bare array message");
+  });
+
+  it("caps messages at 10 with overflow count", () => {
+    const msgs = Array.from({ length: 15 }, (_, i) => ({
+      ts: String(1740825600 + i),
+      user: "U123",
+      text: `message ${i}`,
+    }));
+    const { summary } = slackHandler("mcp__slack__get_messages", JSON.stringify({ messages: msgs }));
+    expect(summary).toContain("5 more messages");
+  });
+
+  it("uses display_name from user_profile when available", () => {
+    const input = JSON.stringify({
+      messages: [{
+        ts: "1740825600.000000",
+        user: "U12345",
+        user_profile: { display_name: "alice_display" },
+        text: "hello",
+      }],
+    });
+    const { summary } = slackHandler("mcp__slack__get_messages", input);
+    expect(summary).toContain("alice_display");
+  });
+
+  it("truncates long message text at 200 chars", () => {
+    const input = JSON.stringify({
+      messages: [{ ts: "1740825600.000000", user: "U1", text: "x".repeat(300) }],
+    });
+    const { summary } = slackHandler("mcp__slack__get_messages", input);
+    expect(summary).toContain("…");
+  });
+
+  it("falls back gracefully for unrecognised JSON shapes", () => {
+    const { summary } = slackHandler("mcp__slack__get_messages", '{"unrelated": true}');
+    expect(summary).toContain("unrelated");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
+    expect(originalSize).toBe(Buffer.byteLength(MESSAGES_WRAPPER, "utf8"));
   });
 });


### PR DESCRIPTION
## Summary

- **`handlers/csv.ts`**: header row + first 5 data rows as `key=value` pairs + row/col count; handles quoted fields with embedded commas; `looksLikeCsv()` enables content-based dispatch for unnamed CSV tools
- **`handlers/linear.ts`**: identifier, title, state, numeric priority (0–4 mapped to labels), description excerpt (200 chars), URL; handles single issue, array, GraphQL `{ data: { issue } }`, and Relay `{ nodes }` shapes
- **`handlers/slack.ts`**: channel, formatted timestamp, user/display_name resolution, message text (200 char cap); handles `{ ok, messages }`, bare arrays, and single message; caps at 10 with overflow count
- **`handlers/index.ts`**: routes `linear`, `slack`, `csv` by name; CSV content-based fallback after JSON check

## Test plan

- [x] `csvHandler`: row/col count, header names, preview rows, overflow, quoted fields, empty input, MCP wrapper, originalSize
- [x] `looksLikeCsv`: true for CSV, false for plain text, false for <3 lines, false for JSON
- [x] `linearHandler`: identifier, title, state, priority label, description, URL, array with count, overflow cap, GraphQL wrapper, Relay nodes, non-JSON fallback, originalSize
- [x] `slackHandler`: message count, user, text, timestamp format, channel, bare array, overflow cap, display_name resolution, long text truncation, unrecognised shape fallback, originalSize
- [x] `getHandler` dispatcher: routes linear, slack, csv by name; CSV content-based route
- [x] 231 tests total, 0 failures