### PR TITLE
feat: add recall__session_summary tool

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -64,6 +64,24 @@ export interface Stats {
   compression_ratio: number;
 }
 
+export interface SessionSummaryOptions {
+  session_id?: string;
+  date?: string; // YYYY-MM-DD, defaults to today (UTC)
+}
+
+export interface SessionSummaryData {
+  label: string;
+  stored_count: number;
+  total_original_bytes: number;
+  total_summary_bytes: number;
+  tool_counts: Array<{ tool_name: string; count: number }>;
+  accessed_count: number;
+  total_accesses: number;
+  top_accessed: Array<{ id: string; tool_name: string; summary: string; access_count: number }>;
+  pinned: Array<{ id: string; tool_name: string; summary: string }>;
+  notes: Array<{ id: string; summary: string }>;
+}
+
 // ---------------------------------------------------------------------------
 // Schema + migrations
 // ---------------------------------------------------------------------------
@@ -437,6 +455,76 @@ export function getStats(db: Database, project_key: string): Stats {
       : 0;
 
   return { ...row, compression_ratio };
+}
+
+export function getSessionSummary(
+  db: Database,
+  project_key: string,
+  opts: SessionSummaryOptions = {}
+): SessionSummaryData {
+  let filter: string;
+  let filterParams: unknown[];
+  let label: string;
+
+  if (opts.session_id) {
+    filter = "session_id = ?";
+    filterParams = [opts.session_id];
+    label = opts.session_id;
+  } else {
+    const date = opts.date ?? new Date().toISOString().slice(0, 10);
+    const startOfDay = Math.floor(new Date(`${date}T00:00:00Z`).getTime() / 1000);
+    const endOfDay = startOfDay + 86400;
+    filter = "created_at >= ? AND created_at < ?";
+    filterParams = [startOfDay, endOfDay];
+    label = date;
+  }
+
+  const base = `WHERE project_key = ? AND ${filter}`;
+  const bp = [project_key, ...filterParams];
+
+  const agg = db.prepare(`
+    SELECT
+      COUNT(*) as stored_count,
+      COALESCE(SUM(original_size), 0) as total_original_bytes,
+      COALESCE(SUM(summary_size), 0) as total_summary_bytes,
+      COUNT(CASE WHEN access_count > 0 THEN 1 END) as accessed_count,
+      COALESCE(SUM(access_count), 0) as total_accesses
+    FROM stored_outputs ${base}
+  `).get(...bp) as {
+    stored_count: number;
+    total_original_bytes: number;
+    total_summary_bytes: number;
+    accessed_count: number;
+    total_accesses: number;
+  };
+
+  const tool_counts = db.prepare(`
+    SELECT tool_name, COUNT(*) as count
+    FROM stored_outputs ${base}
+    GROUP BY tool_name
+    ORDER BY count DESC
+  `).all(...bp) as Array<{ tool_name: string; count: number }>;
+
+  const top_accessed = db.prepare(`
+    SELECT id, tool_name, summary, access_count
+    FROM stored_outputs ${base} AND access_count > 0
+    ORDER BY access_count DESC
+    LIMIT 5
+  `).all(...bp) as Array<{ id: string; tool_name: string; summary: string; access_count: number }>;
+
+  const pinned = db.prepare(`
+    SELECT id, tool_name, summary
+    FROM stored_outputs ${base} AND pinned = 1
+    ORDER BY created_at DESC
+  `).all(...bp) as Array<{ id: string; tool_name: string; summary: string }>;
+
+  const notes = db.prepare(`
+    SELECT id, summary
+    FROM stored_outputs ${base} AND tool_name = 'recall__note'
+    ORDER BY created_at DESC
+  `).all(...bp) as Array<{ id: string; summary: string }>;
+
+  return { label, ...agg, tool_counts, top_accessed, pinned, notes };
 }
 
 export function pruneExpired(

--- a/src/server.ts
+++ b/src/server.ts
@@ -2,14 +2,15 @@
  * mcp-recall MCP server.
  *
  * Tools exposed:
- *   recall__retrieve     — fetch stored content, FTS-scoped
- *   recall__search       — FTS across all stored outputs
- *   recall__pin          — pin/unpin an item from expiry and eviction
- *   recall__note         — store arbitrary text as a recall note
- *   recall__export       — JSON dump of all stored items
- *   recall__forget       — delete stored items
- *   recall__list_stored  — paginated item browser
- *   recall__stats        — aggregate session efficiency report
+ *   recall__retrieve         — fetch stored content, FTS-scoped
+ *   recall__search           — FTS across all stored outputs
+ *   recall__pin              — pin/unpin an item from expiry and eviction
+ *   recall__note             — store arbitrary text as a recall note
+ *   recall__export           — JSON dump of all stored items
+ *   recall__forget           — delete stored items
+ *   recall__list_stored      — paginated item browser
+ *   recall__stats            — aggregate session efficiency report
+ *   recall__session_summary  — digest of a single session's activity
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -25,6 +26,7 @@ import {
   toolForget,
   toolListStored,
   toolStats,
+  toolSessionSummary,
 } from "./tools";
 
 const projectKey = getProjectKey(process.cwd());
@@ -140,6 +142,24 @@ server.tool(
   {},
   async () => ({
     content: [{ type: "text", text: toolStats(db, projectKey) }],
+  })
+);
+
+server.tool(
+  "recall__session_summary",
+  "Digest of a single session's activity — tools called, compression savings, most-accessed items, pinned items, notes. Defaults to today. Use at session start for orientation or handoff.",
+  {
+    session_id: z
+      .string()
+      .optional()
+      .describe("Filter by specific Claude session ID (exact match)"),
+    date: z
+      .string()
+      .optional()
+      .describe("Filter by date in YYYY-MM-DD format (defaults to today)"),
+  },
+  async (args) => ({
+    content: [{ type: "text", text: toolSessionSummary(db, projectKey, args) }],
   })
 );
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -15,6 +15,7 @@ import {
   forgetOutputs,
   getStats,
   getSessionDays,
+  getSessionSummary,
   storeOutput,
   type StoredOutput,
   type ForgetOptions,
@@ -296,6 +297,77 @@ export function toolListStored(
   const separator = "-".repeat(header.length);
 
   return [header, separator, ...rows].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// recall__session_summary
+// ---------------------------------------------------------------------------
+
+export interface SessionSummaryArgs {
+  session_id?: string;
+  date?: string;
+}
+
+export function toolSessionSummary(
+  db: Database,
+  projectKey: string,
+  args: SessionSummaryArgs
+): string {
+  const data = getSessionSummary(db, projectKey, args);
+
+  if (data.stored_count === 0) {
+    return `[recall: no items stored for ${data.label}]`;
+  }
+
+  const reductionStr = reductionPct(data.total_original_bytes, data.total_summary_bytes);
+
+  const lines: string[] = [
+    `Session Summary — ${data.label}`,
+    "─".repeat(36),
+    `Stored: ${data.stored_count} item${data.stored_count === 1 ? "" : "s"} · ${formatBytes(data.total_original_bytes)} → ${formatBytes(data.total_summary_bytes)} (${reductionStr} reduction)`,
+    `Retrieved: ${data.accessed_count} item${data.accessed_count === 1 ? "" : "s"} · ${data.total_accesses} total access${data.total_accesses === 1 ? "" : "es"}`,
+    "",
+    "Tools stored:",
+  ];
+
+  const TOP_TOOLS = 5;
+  for (const t of data.tool_counts.slice(0, TOP_TOOLS)) {
+    lines.push(`  ${t.tool_name.padEnd(44)}×${t.count}`);
+  }
+  if (data.tool_counts.length > TOP_TOOLS) {
+    lines.push(`  + ${data.tool_counts.length - TOP_TOOLS} more`);
+  }
+
+  if (data.top_accessed.length > 0) {
+    lines.push("", "Most accessed:");
+    for (const item of data.top_accessed) {
+      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > 100 ? "…" : "";
+      lines.push(`  ${item.id} (×${item.access_count}) ${item.tool_name}`);
+      lines.push(`    ${excerpt}${ellipsis}`);
+    }
+  }
+
+  if (data.pinned.length > 0) {
+    lines.push("", `Pinned: ${data.pinned.length}`);
+    for (const item of data.pinned) {
+      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > 100 ? "…" : "";
+      lines.push(`  📌 ${item.id}  ${item.tool_name}`);
+      lines.push(`    ${excerpt}${ellipsis}`);
+    }
+  }
+
+  if (data.notes.length > 0) {
+    lines.push("", `Notes: ${data.notes.length}`);
+    for (const note of data.notes) {
+      const excerpt = note.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = note.summary.length > 100 ? "…" : "";
+      lines.push(`  ${note.id} — ${excerpt}${ellipsis}`);
+    }
+  }
+
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -9,6 +9,7 @@ import {
   toolForget,
   toolListStored,
   toolStats,
+  toolSessionSummary,
 } from "../src/tools";
 import { resetConfig } from "../src/config";
 import type { Database } from "bun:sqlite";
@@ -418,6 +419,76 @@ describe("MCP tool handlers", () => {
       pinOutput(db, stored.id, PROJECT_KEY, true);
       const result = toolListStored(db, PROJECT_KEY, {});
       expect(result).toContain("📌");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolSessionSummary
+  // -------------------------------------------------------------------------
+
+  describe("toolSessionSummary", () => {
+    const today = new Date().toISOString().slice(0, 10);
+
+    it("returns no-data message when nothing stored for the date", () => {
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: "2000-01-01" });
+      expect(result).toContain("no items stored");
+      expect(result).toContain("2000-01-01");
+    });
+
+    it("shows stored count and compression stats", () => {
+      storeOutput(db, makeInput({ original_size: 4096 }));
+      storeOutput(db, makeInput({ original_size: 8192 }));
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: today });
+      expect(result).toContain("2 items");
+      expect(result).toContain("→");
+      expect(result).toContain("reduction");
+    });
+
+    it("shows tool breakdown sorted by count", () => {
+      storeOutput(db, makeInput({ tool_name: "mcp__playwright__browser_snapshot" }));
+      storeOutput(db, makeInput({ tool_name: "mcp__playwright__browser_snapshot" }));
+      storeOutput(db, makeInput({ tool_name: "mcp__github__list_issues" }));
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: today });
+      expect(result).toContain("mcp__playwright__browser_snapshot");
+      expect(result).toContain("×2");
+      expect(result).toContain("mcp__github__list_issues");
+      // playwright should appear before github (higher count)
+      expect(result.indexOf("mcp__playwright__browser_snapshot")).toBeLessThan(
+        result.indexOf("mcp__github__list_issues")
+      );
+    });
+
+    it("shows most accessed items", () => {
+      const stored = storeOutput(db, makeInput());
+      db.prepare("UPDATE stored_outputs SET access_count = 3 WHERE id = ?").run(stored.id);
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: today });
+      expect(result).toContain("Most accessed");
+      expect(result).toContain(stored.id);
+      expect(result).toContain("×3");
+    });
+
+    it("shows pinned items", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: today });
+      expect(result).toContain("Pinned: 1");
+      expect(result).toContain("📌");
+      expect(result).toContain(stored.id);
+    });
+
+    it("shows notes separately", () => {
+      storeOutput(db, makeInput({ tool_name: "recall__note", summary: "(note): Auth findings" }));
+      const result = toolSessionSummary(db, PROJECT_KEY, { date: today });
+      expect(result).toContain("Notes: 1");
+      expect(result).toContain("Auth findings");
+    });
+
+    it("filters by session_id", () => {
+      storeOutput(db, makeInput({ session_id: "sess-aaa" }));
+      storeOutput(db, makeInput({ session_id: "sess-bbb" }));
+      const result = toolSessionSummary(db, PROJECT_KEY, { session_id: "sess-aaa" });
+      expect(result).toContain("sess-aaa");
+      expect(result).toContain("1 item");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `recall__session_summary` — a digest of a single session's activity (tools called, compression savings, most-accessed items, pinned items, notes)
- Defaults to today (UTC date range); accepts `session_id` (exact Claude session) or `date` (YYYY-MM-DD) params
- `getSessionSummary` in `src/db/index.ts` runs 5 focused SQL queries; `toolSessionSummary` in `src/tools.ts` formats the output

## Test plan

- [x] `bun test` — 254 tests, 0 failures
- [x] 7 new tests: no-data message, stored count/sizes, tool breakdown order, most accessed, pinned, notes, session_id filter