### PR TITLE
feat: add recall__context tool for session orientation

### DIFF
--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -64,6 +64,23 @@ export interface Stats {
   compression_ratio: number;
 }
 
+export interface ContextOptions {
+  days?: number;   // lookback window for recently accessed (default 7)
+  limit?: number;  // max items in recently accessed section (default 5)
+}
+
+export interface ContextData {
+  pinned: StoredOutput[];
+  notes: StoredOutput[];
+  recent: StoredOutput[];
+  last_session: {
+    date: string;
+    stored_count: number;
+    total_original_bytes: number;
+    total_summary_bytes: number;
+  } | null;
+}
+
 export interface SessionSummaryOptions {
   session_id?: string;
   date?: string; // YYYY-MM-DD, defaults to today (UTC)
@@ -455,6 +472,60 @@ export function getStats(db: Database, project_key: string): Stats {
       : 0;
 
   return { ...row, compression_ratio };
+}
+
+export function getContext(
+  db: Database,
+  project_key: string,
+  opts: ContextOptions = {}
+): ContextData {
+  const days = opts.days ?? 7;
+  const limit = opts.limit ?? 5;
+  const cutoff = Math.floor(Date.now() / 1000) - days * 86400;
+  const today = new Date().toISOString().slice(0, 10);
+
+  // 1. All pinned items, most recently accessed first
+  const pinned = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 1
+    ORDER BY last_accessed DESC NULLS LAST, created_at DESC
+  `).all(project_key) as StoredOutput[];
+
+  // 2. Unpinned notes, newest first (capped to avoid noise)
+  const notes = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND tool_name = 'recall__note'
+    ORDER BY created_at DESC
+    LIMIT 10
+  `).all(project_key) as StoredOutput[];
+
+  // 3. Unpinned non-notes recently accessed, most recent first
+  const recent = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND tool_name != 'recall__note'
+      AND last_accessed >= ?
+    ORDER BY last_accessed DESC
+    LIMIT ?
+  `).all(project_key, cutoff, limit) as StoredOutput[];
+
+  // 4. Last session headline (most recent past date in sessions table)
+  const sessionDays = getSessionDays(db);
+  const pastDays = sessionDays.filter((d) => d < today);
+  let last_session = null;
+  if (pastDays.length > 0) {
+    const lastDate = pastDays[0]!;
+    const summary = getSessionSummary(db, project_key, { date: lastDate });
+    if (summary.stored_count > 0) {
+      last_session = {
+        date: lastDate,
+        stored_count: summary.stored_count,
+        total_original_bytes: summary.total_original_bytes,
+        total_summary_bytes: summary.total_summary_bytes,
+      };
+    }
+  }
+
+  return { pinned, notes, recent, last_session };
 }
 
 export function getSessionSummary(

--- a/src/server.ts
+++ b/src/server.ts
@@ -11,6 +11,7 @@
  *   recall__list_stored      — paginated item browser
  *   recall__stats            — aggregate session efficiency report
  *   recall__session_summary  — digest of a single session's activity
+ *   recall__context          — session orientation: pinned, notes, recent, last session
  */
 import { McpServer } from "@modelcontextprotocol/sdk/server/mcp.js";
 import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js";
@@ -27,6 +28,7 @@ import {
   toolListStored,
   toolStats,
   toolSessionSummary,
+  toolContext,
 } from "./tools";
 
 const projectKey = getProjectKey(process.cwd());
@@ -160,6 +162,24 @@ server.tool(
   },
   async (args) => ({
     content: [{ type: "text", text: toolSessionSummary(db, projectKey, args) }],
+  })
+);
+
+server.tool(
+  "recall__context",
+  "Session orientation: pinned items, recent notes, recently accessed items, and last session headline. Call at the start of a session to quickly re-orient to prior work.",
+  {
+    days: z
+      .number()
+      .optional()
+      .describe("Lookback window for recently accessed items in days (default 7)"),
+    limit: z
+      .number()
+      .optional()
+      .describe("Max recently accessed items to show (default 5)"),
+  },
+  async (args) => ({
+    content: [{ type: "text", text: toolContext(db, projectKey, args) }],
   })
 );
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -16,6 +16,7 @@ import {
   getStats,
   getSessionDays,
   getSessionSummary,
+  getContext,
   storeOutput,
   type StoredOutput,
   type ForgetOptions,
@@ -297,6 +298,79 @@ export function toolListStored(
   const separator = "-".repeat(header.length);
 
   return [header, separator, ...rows].join("\n");
+}
+
+// ---------------------------------------------------------------------------
+// recall__context
+// ---------------------------------------------------------------------------
+
+export interface ContextArgs {
+  days?: number;
+  limit?: number;
+}
+
+export function toolContext(
+  db: Database,
+  projectKey: string,
+  args: ContextArgs
+): string {
+  const data = getContext(db, projectKey, args);
+  const today = new Date().toISOString().slice(0, 10);
+
+  const isEmpty =
+    data.pinned.length === 0 &&
+    data.notes.length === 0 &&
+    data.recent.length === 0 &&
+    data.last_session === null;
+
+  if (isEmpty) {
+    return `[recall: no context available yet — use recall tools to build up your context store]`;
+  }
+
+  const lines: string[] = [
+    `Context — ${today}`,
+    "═".repeat(36),
+  ];
+
+  if (data.pinned.length > 0) {
+    lines.push("", `Pinned (${data.pinned.length}):`);
+    for (const item of data.pinned) {
+      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > 100 ? "…" : "";
+      lines.push(`  📌 ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}`);
+      lines.push(`    ${excerpt}${ellipsis}`);
+    }
+  }
+
+  if (data.notes.length > 0) {
+    lines.push("", `Notes (${data.notes.length}):`);
+    for (const note of data.notes) {
+      const excerpt = note.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = note.summary.length > 100 ? "…" : "";
+      lines.push(`  ${note.id}  ${formatDate(note.created_at)}`);
+      lines.push(`    ${excerpt}${ellipsis}`);
+    }
+  }
+
+  if (data.recent.length > 0) {
+    const days = args.days ?? 7;
+    lines.push("", `Recently accessed (last ${days} day${days === 1 ? "" : "s"}, ${data.recent.length} item${data.recent.length === 1 ? "" : "s"}):`);
+    for (const item of data.recent) {
+      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > 100 ? "…" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ×${item.access_count}`);
+      lines.push(`    ${excerpt}${ellipsis}`);
+    }
+  }
+
+  if (data.last_session) {
+    const s = data.last_session;
+    const reductionStr = reductionPct(s.total_original_bytes, s.total_summary_bytes);
+    lines.push("", `Last session (${s.date}):`);
+    lines.push(`  ${s.stored_count} item${s.stored_count === 1 ? "" : "s"} stored · ${formatBytes(s.total_original_bytes)} → ${formatBytes(s.total_summary_bytes)} (${reductionStr} reduction)`);
+  }
+
+  return lines.join("\n");
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -1,5 +1,5 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
-import { getDb, closeDb, storeOutput, pinOutput, recordSession, type StoreInput } from "../src/db/index";
+import { getDb, closeDb, storeOutput, pinOutput, recordAccess, recordSession, type StoreInput } from "../src/db/index";
 import {
   toolRetrieve,
   toolSearch,
@@ -10,6 +10,7 @@ import {
   toolListStored,
   toolStats,
   toolSessionSummary,
+  toolContext,
 } from "../src/tools";
 import { resetConfig } from "../src/config";
 import type { Database } from "bun:sqlite";
@@ -489,6 +490,74 @@ describe("MCP tool handlers", () => {
       const result = toolSessionSummary(db, PROJECT_KEY, { session_id: "sess-aaa" });
       expect(result).toContain("sess-aaa");
       expect(result).toContain("1 item");
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // toolContext
+  // -------------------------------------------------------------------------
+
+  describe("toolContext", () => {
+    it("returns no-context message when store is empty", () => {
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("no context available");
+    });
+
+    it("shows pinned items", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("Pinned (1)");
+      expect(result).toContain("📌");
+      expect(result).toContain(stored.id);
+    });
+
+    it("shows notes", () => {
+      storeOutput(db, makeInput({ tool_name: "recall__note", summary: "(note): Auth findings" }));
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("Notes (1)");
+      expect(result).toContain("Auth findings");
+    });
+
+    it("shows recently accessed items", () => {
+      const stored = storeOutput(db, makeInput());
+      recordAccess(db, stored.id); // sets last_accessed to now
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("Recently accessed");
+      expect(result).toContain(stored.id);
+    });
+
+    it("excludes items not accessed within the days window", () => {
+      const stored = storeOutput(db, makeInput());
+      // Set last_accessed to 8 days ago (outside default 7-day window)
+      const oldAccess = Math.floor(Date.now() / 1000) - 8 * 86400;
+      db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ? WHERE id = ?")
+        .run(oldAccess, stored.id);
+      const result = toolContext(db, PROJECT_KEY, { days: 7 });
+      expect(result).not.toContain(stored.id);
+    });
+
+    it("shows last session headline", () => {
+      const yesterday = new Date(Date.now() - 86400 * 1000).toISOString().slice(0, 10);
+      const startOfYesterday = Math.floor(new Date(`${yesterday}T00:00:00Z`).getTime() / 1000);
+      db.prepare(
+        `INSERT INTO stored_outputs (id,project_key,session_id,tool_name,summary,full_content,original_size,summary_size,created_at)
+         VALUES ('recall_ctx_prev1',?,?,?,?,?,4096,64,?)`
+      ).run(PROJECT_KEY, "sess-prev", "mcp__tool", "prev summary", "prev content", startOfYesterday + 3600);
+      recordSession(db, yesterday);
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain(`Last session (${yesterday})`);
+      expect(result).toContain("1 item");
+    });
+
+    it("pinned items appear in Pinned section, not in Recently accessed", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      recordAccess(db, stored.id);
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("Pinned (1)");
+      // Only pinned item exists; recently accessed query excludes pinned=1
+      expect(result).not.toContain("Recently accessed");
     });
   });
 });


### PR DESCRIPTION
## Summary

- Adds `recall__context` — single-call session orientation surfacing pinned items, unpinned notes, recently accessed items (default 7-day window), and last session headline
- Each item appears in exactly one section (pinned items never duplicate into recently accessed)
- `getContext` in `src/db/index.ts` runs 4 focused SQL queries; reuses existing `getSessionDays` + `getSessionSummary` for the last session headline

## Test plan

- [x] `bun test` — 261 tests, 0 failures
- [x] 7 new tests: empty store, pinned, notes, recently accessed, outside-window exclusion, last session headline, pinned items excluded from recent section