### PR TITLE
feat: add shell/bash compression handler

### DIFF
--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -2,6 +2,7 @@ import type { Handler } from "./types";
 import { playwrightHandler } from "./playwright";
 import { githubHandler } from "./github";
 import { filesystemHandler } from "./filesystem";
+import { shellHandler } from "./shell";
 import { linearHandler } from "./linear";
 import { slackHandler } from "./slack";
 import { csvHandler, looksLikeCsv } from "./csv";
@@ -19,12 +20,13 @@ export { extractText } from "./types";
  *   1. Playwright browser_snapshot → playwright handler
  *   2. GitHub tools               → github handler
  *   3. Filesystem tools           → filesystem handler
- *   4. Linear tools               → linear handler
- *   5. Slack tools                → slack handler
- *   6. CSV tools (name-based)     → csv handler
- *   7. Unmatched with JSON output → json handler
- *   8. CSV content-based fallback → csv handler
- *   9. Everything else            → generic handler
+ *   4. Shell/bash tools           → shell handler
+ *   5. Linear tools               → linear handler
+ *   6. Slack tools                → slack handler
+ *   7. CSV tools (name-based)     → csv handler
+ *   8. Unmatched with JSON output → json handler
+ *   9. CSV content-based fallback → csv handler
+ *  10. Everything else            → generic handler
  */
 export function getHandler(toolName: string, output: unknown): Handler {
   if (toolName.includes("playwright") && toolName.includes("snapshot")) {
@@ -41,6 +43,15 @@ export function getHandler(toolName: string, output: unknown): Handler {
     toolName.includes("get_file")
   ) {
     return filesystemHandler;
+  }
+
+  if (
+    toolName.includes("bash") ||
+    toolName.includes("shell") ||
+    toolName.includes("terminal") ||
+    toolName.includes("run_command")
+  ) {
+    return shellHandler;
   }
 
   if (toolName.includes("linear")) {

--- a/src/handlers/shell.ts
+++ b/src/handlers/shell.ts
@@ -1,0 +1,100 @@
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const HEAD_STDOUT = 50;
+const HEAD_STDERR = 20;
+
+// Covers colors, cursor movement, erase sequences, and other common escapes.
+// eslint-disable-next-line no-control-regex
+const ANSI_RE = /[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nqry=><~]/g;
+
+export function stripAnsi(text: string): string {
+  return text.replace(ANSI_RE, "");
+}
+
+function trimTrailingEmpty(lines: string[]): string[] {
+  let end = lines.length;
+  while (end > 0 && lines[end - 1]!.trim() === "") end--;
+  return lines.slice(0, end);
+}
+
+function formatLines(
+  text: string,
+  max: number
+): { header: string; body: string } {
+  const lines = trimTrailingEmpty(text.split("\n"));
+  const total = lines.length;
+  const truncated = total > max;
+  const head = lines.slice(0, max).join("\n");
+  const overflow = truncated ? `\n… (+${total - max} more lines)` : "";
+  return {
+    header: `${total} line${total === 1 ? "" : "s"}`,
+    body: `${head}${overflow}`,
+  };
+}
+
+interface ShellOutput {
+  stdout?: string;
+  stderr?: string;
+  output?: string;   // alternate field name used by some servers
+  returncode?: number;
+  exit_code?: number;
+}
+
+function parseStructured(raw: string): ShellOutput | null {
+  try {
+    const parsed = JSON.parse(raw);
+    if (
+      parsed !== null &&
+      typeof parsed === "object" &&
+      !Array.isArray(parsed) &&
+      ("stdout" in parsed || "stderr" in parsed || "output" in parsed)
+    ) {
+      return parsed as ShellOutput;
+    }
+  } catch {
+    // not JSON
+  }
+  return null;
+}
+
+export const shellHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  const structured = parseStructured(raw);
+
+  if (structured) {
+    const stdout = stripAnsi(structured.stdout ?? structured.output ?? "");
+    const stderr = stripAnsi(structured.stderr ?? "");
+    const exitCode = structured.returncode ?? structured.exit_code;
+
+    const exitStr = exitCode !== undefined ? `exit:${exitCode} · ` : "";
+    const stdoutFmt = formatLines(stdout, HEAD_STDOUT);
+    const hasStderr = stderr.trim().length > 0;
+    const stderrFmt = hasStderr ? formatLines(stderr, HEAD_STDERR) : null;
+
+    const stderrDesc = stderrFmt ? ` · ${stderrFmt.header} stderr` : "";
+    const header = `[bash · ${exitStr}${stdoutFmt.header} stdout${stderrDesc}]`;
+
+    const parts: string[] = [header];
+    if (stdout.trim()) parts.push(stdoutFmt.body);
+    if (stderrFmt) {
+      parts.push("stderr:");
+      parts.push(stderrFmt.body);
+    }
+
+    return { summary: parts.join("\n"), originalSize };
+  }
+
+  // Plain string — treat as stdout
+  const text = stripAnsi(raw);
+  const fmt = formatLines(text, HEAD_STDOUT);
+  return {
+    summary: `[bash · ${fmt.header}]\n${fmt.body}`,
+    originalSize,
+  };
+};

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -2,6 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { playwrightHandler } from "../src/handlers/playwright";
 import { githubHandler } from "../src/handlers/github";
 import { filesystemHandler } from "../src/handlers/filesystem";
+import { shellHandler, stripAnsi } from "../src/handlers/shell";
 import { csvHandler, looksLikeCsv } from "../src/handlers/csv";
 import { linearHandler } from "../src/handlers/linear";
 import { slackHandler } from "../src/handlers/slack";
@@ -564,5 +565,100 @@ describe("slackHandler", () => {
   it("reports originalSize in bytes", () => {
     const { originalSize } = slackHandler("mcp__slack__get_messages", MESSAGES_WRAPPER);
     expect(originalSize).toBe(Buffer.byteLength(MESSAGES_WRAPPER, "utf8"));
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripAnsi
+// ---------------------------------------------------------------------------
+
+describe("stripAnsi", () => {
+  it("removes color escape sequences", () => {
+    expect(stripAnsi("\x1b[32mhello\x1b[0m")).toBe("hello");
+  });
+
+  it("removes bold and reset sequences", () => {
+    expect(stripAnsi("\x1b[1mbold\x1b[0m text")).toBe("bold text");
+  });
+
+  it("leaves plain text unchanged", () => {
+    expect(stripAnsi("plain output")).toBe("plain output");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// shellHandler
+// ---------------------------------------------------------------------------
+
+describe("shellHandler", () => {
+  it("includes line count in header for plain output", () => {
+    const input = "line1\nline2\nline3";
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("3 lines");
+  });
+
+  it("strips ANSI codes from plain output", () => {
+    const input = "\x1b[32mgreen text\x1b[0m\nnormal text";
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("green text");
+    expect(summary).not.toContain("\x1b[");
+  });
+
+  it("truncates at 50 lines with overflow count", () => {
+    const input = Array.from({ length: 60 }, (_, i) => `line${i + 1}`).join("\n");
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("line1");
+    expect(summary).toContain("+10 more lines");
+    expect(summary).not.toContain("line60");
+  });
+
+  it("handles structured stdout/stderr output", () => {
+    const input = JSON.stringify({ stdout: "hello world", stderr: "", returncode: 0 });
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("hello world");
+    expect(summary).toContain("exit:0");
+  });
+
+  it("shows exit code in header", () => {
+    const input = JSON.stringify({ stdout: "output", returncode: 1 });
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("exit:1");
+  });
+
+  it("shows stderr section when stderr is non-empty", () => {
+    const input = JSON.stringify({ stdout: "ok", stderr: "warning: something", returncode: 0 });
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("stderr:");
+    expect(summary).toContain("warning: something");
+  });
+
+  it("handles alternate output field name", () => {
+    const input = JSON.stringify({ output: "result text", exit_code: 0 });
+    const { summary } = shellHandler("mcp__bash__execute", input);
+    expect(summary).toContain("result text");
+    expect(summary).toContain("exit:0");
+  });
+
+  it("handles empty output gracefully", () => {
+    const { summary } = shellHandler("mcp__bash__execute", "");
+    expect(summary).toContain("0 lines");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const input = "line1\nline2";
+    const { originalSize } = shellHandler("mcp__bash__execute", input);
+    expect(originalSize).toBe(Buffer.byteLength(input, "utf8"));
+  });
+
+  it("routes bash tools to shell handler", () => {
+    expect(getHandler("mcp__bash__execute", "output")).toBe(shellHandler);
+  });
+
+  it("routes shell tools to shell handler", () => {
+    expect(getHandler("mcp__shell__run", "output")).toBe(shellHandler);
+  });
+
+  it("routes terminal tools to shell handler", () => {
+    expect(getHandler("mcp__terminal__execute", "output")).toBe(shellHandler);
   });
 });


### PR DESCRIPTION
## Summary

- Adds `src/handlers/shell.ts` — handles MCP tools whose names contain `bash`, `shell`, `terminal`, or `run_command`
- Strips ANSI escape codes; caps stdout at 50 lines and stderr at 20 lines with overflow counts
- Parses structured `{ stdout, stderr, returncode/exit_code }` JSON (most bash MCP servers); falls back to plain string treatment
- Handles `output` as an alternate field name for stdout
- Inserted at step 4 in the dispatcher (after filesystem, before linear)

## Test plan

- [x] `bun test` — 276 tests, 0 failures
- [x] 15 new tests: `stripAnsi` (3), `shellHandler` (9 — ANSI stripping, line cap, structured output, exit code, stderr, `output` field, empty, originalSize), dispatcher routing (3)