### PR TITLE
feat: pre-commit hook to keep plugin dist/ in sync with src/

### DIFF
--- a/.githooks/pre-commit
+++ b/.githooks/pre-commit
@@ -1,0 +1,9 @@
+#!/usr/bin/env bash
+set -e
+
+# Rebuild plugin dist/ if any src/ TypeScript files are staged.
+if git diff --cached --name-only | grep -q '^src/'; then
+  echo "[pre-commit] src/ changed — rebuilding plugins/mcp-recall/dist/"
+  bun run build
+  git add plugins/mcp-recall/dist/
+fi

--- a/package.json
+++ b/package.json
@@ -9,7 +9,8 @@
     "test": "bun test",
     "dev": "bun --watch src/server.ts",
     "typecheck": "tsc --noEmit",
-    "build": "bun build src/server.ts --target bun --outfile plugins/mcp-recall/dist/server.js && bun build src/cli.ts --target bun --outfile plugins/mcp-recall/dist/cli.js"
+    "build": "bun build src/server.ts --target bun --outfile plugins/mcp-recall/dist/server.js && bun build src/cli.ts --target bun --outfile plugins/mcp-recall/dist/cli.js",
+    "prepare": "git config core.hooksPath .githooks"
   },
   "dependencies": {
     "@modelcontextprotocol/sdk": "^1.27.1",

--- a/tasks/archive.md
+++ b/tasks/archive.md
@@ -148,3 +148,26 @@ Completed work.
 - Merged via PR #30
 
 **v6 total: 276 tests, 0 failures**
+
+---
+
+## 2026-03-02 (continued) — Marketplace Install + Pre-commit Hook
+
+### Marketplace Install
+
+- `plugins/mcp-recall/.claude-plugin/plugin.json` — metadata only (name, description, author) per marketplace convention
+- `plugins/mcp-recall/.mcp.json` — MCP server config: `{"recall": {"command": "bun", "args": ["${CLAUDE_PLUGIN_ROOT}/dist/server.js"]}}`
+- `plugins/mcp-recall/hooks/hooks.json` — SessionStart + PostToolUse hooks targeting `bin/recall`
+- `plugins/mcp-recall/bin/recall` — wrapper calling `dist/cli.js`
+- `plugins/mcp-recall/dist/server.js` + `dist/cli.js` — bundled via `bun build --target bun`; npm deps inlined, `bun:sqlite` stays external
+- Root `.claude-plugin/plugin.json` — removed `mcpServers` (metadata-only per marketplace convention)
+- `.gitignore` — added `!plugins/mcp-recall/dist/` negation to track distribution bundles
+- `package.json` — added `build` script
+- `README.md` — updated Install section with two-command marketplace flow
+- Merged via PR #32
+
+### Pre-commit Hook
+
+- `.githooks/pre-commit` — detects staged `src/` changes; auto-runs `bun run build` and stages `plugins/mcp-recall/dist/`; no-op otherwise
+- `package.json` — added `prepare` script: `git config core.hooksPath .githooks` (wires hook on `bun install`)
+- Merged via PR #33


### PR DESCRIPTION
## Summary

- Adds `.githooks/pre-commit`: detects staged `src/` files, auto-runs `bun run build`, stages `plugins/mcp-recall/dist/` — no-op otherwise
- Adds `prepare` script to `package.json`: runs `git config core.hooksPath .githooks` on `bun install` so new contributors get the hook automatically

## Test plan

- [ ] Stage a `src/` change → hook triggers, rebuilds `dist/`, exits 0
- [ ] Stage only non-`src/` files → hook is silent no-op, exits 0
- [ ] `bun run build` still works independently
- [ ] All 276 tests pass