### PR TITLE
feat: extend shell handler to cover remote-exec tools and strip SSH noise

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5455,6 +5455,25 @@ var ANSI_RE = /[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-nq
 function stripAnsi(text) {
   return text.replace(ANSI_RE, "");
 }
+var SSH_NOISE_RE = /^\*\* .+/;
+function stripSshNoise(text) {
+  const lines = text.split(`
+`);
+  const filtered = lines.filter((line) => !SSH_NOISE_RE.test(line));
+  const result = [];
+  let prevBlank = false;
+  for (const line of filtered) {
+    const blank = line.trim() === "";
+    if (blank && prevBlank)
+      continue;
+    result.push(line);
+    prevBlank = blank;
+  }
+  while (result.length > 0 && result[0].trim() === "")
+    result.shift();
+  return result.join(`
+`);
+}
 function trimTrailingEmpty(lines) {
   let end = lines.length;
   while (end > 0 && lines[end - 1].trim() === "")
@@ -5489,8 +5508,8 @@ var shellHandler = (_toolName, output) => {
   const originalSize = Buffer.byteLength(raw, "utf8");
   const structured = parseStructured(raw);
   if (structured) {
-    const stdout = stripAnsi(structured.stdout ?? structured.output ?? "");
-    const stderr = stripAnsi(structured.stderr ?? "");
+    const stdout = stripSshNoise(stripAnsi(structured.stdout ?? structured.output ?? ""));
+    const stderr = stripSshNoise(stripAnsi(structured.stderr ?? ""));
     const exitCode = structured.returncode ?? structured.exit_code;
     const exitStr = exitCode !== undefined ? `exit:${exitCode} \xB7 ` : "";
     const stdoutFmt = formatLines(stdout, HEAD_STDOUT);
@@ -5508,7 +5527,7 @@ var shellHandler = (_toolName, output) => {
     return { summary: parts.join(`
 `), originalSize };
   }
-  const text = stripAnsi(raw);
+  const text = stripSshNoise(stripAnsi(raw));
   const fmt = formatLines(text, HEAD_STDOUT);
   return {
     summary: `[bash \xB7 ${fmt.header}]
@@ -5838,7 +5857,7 @@ function getHandler(toolName, output) {
   if (toolName.startsWith("mcp__filesystem__") || toolName.includes("read_file") || toolName.includes("get_file")) {
     return filesystemHandler;
   }
-  if (toolName.includes("bash") || toolName.includes("shell") || toolName.includes("terminal") || toolName.includes("run_command")) {
+  if (toolName.includes("bash") || toolName.includes("shell") || toolName.includes("terminal") || toolName.includes("run_command") || toolName.includes("ssh_exec") || toolName.includes("exec_command") || toolName.includes("remote_exec") || toolName.includes("container_exec")) {
     return shellHandler;
   }
   if (toolName.includes("linear")) {

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -20,7 +20,7 @@ export { extractText } from "./types";
  *   1. Playwright browser_snapshot → playwright handler
  *   2. GitHub tools               → github handler
  *   3. Filesystem tools           → filesystem handler
- *   4. Shell/bash tools           → shell handler
+ *   4. Shell/bash/remote-exec     → shell handler
  *   5. Linear tools               → linear handler
  *   6. Slack tools                → slack handler
  *   7. CSV tools (name-based)     → csv handler
@@ -49,7 +49,11 @@ export function getHandler(toolName: string, output: unknown): Handler {
     toolName.includes("bash") ||
     toolName.includes("shell") ||
     toolName.includes("terminal") ||
-    toolName.includes("run_command")
+    toolName.includes("run_command") ||
+    toolName.includes("ssh_exec") ||
+    toolName.includes("exec_command") ||
+    toolName.includes("remote_exec") ||
+    toolName.includes("container_exec")
   ) {
     return shellHandler;
   }

--- a/src/handlers/shell.ts
+++ b/src/handlers/shell.ts
@@ -1,7 +1,9 @@
 /**
- * Shell handler — strips ANSI escape codes and caps stdout at 50 lines /
- * stderr at 20 lines. Handles structured `{stdout, stderr, returncode}` JSON
- * as well as plain string output.
+ * Shell handler — strips ANSI escape codes and SSH banner noise, then caps
+ * stdout at 50 lines / stderr at 20 lines. Handles structured
+ * `{stdout, stderr, returncode}` JSON as well as plain string output.
+ * Routes bash, shell, terminal, run_command, ssh_exec, exec_command,
+ * remote_exec, and container_exec tool name patterns.
  */
 import type { CompressionResult, Handler } from "./types";
 import { extractText } from "./types";
@@ -15,6 +17,34 @@ const ANSI_RE = /[\x1b\x9b][\[()#;?]*(?:[0-9]{1,4}(?:;[0-9]{0,4})*)?[0-9A-ORZcf-
 
 export function stripAnsi(text: string): string {
   return text.replace(ANSI_RE, "");
+}
+
+// Matches SSH warning/notice lines emitted by OpenSSH (e.g. post-quantum
+// key-exchange advisories that appear before the actual command output).
+const SSH_NOISE_RE = /^\*\* .+/;
+
+/**
+ * Removes SSH banner noise lines (lines starting with `** `) and collapses
+ * any resulting consecutive blank lines into one. Applied after stripAnsi.
+ */
+export function stripSshNoise(text: string): string {
+  const lines = text.split("\n");
+  const filtered = lines.filter((line) => !SSH_NOISE_RE.test(line));
+
+  // Collapse runs of blank lines to a single blank line.
+  const result: string[] = [];
+  let prevBlank = false;
+  for (const line of filtered) {
+    const blank = line.trim() === "";
+    if (blank && prevBlank) continue;
+    result.push(line);
+    prevBlank = blank;
+  }
+
+  // Trim leading blank lines.
+  while (result.length > 0 && result[0]!.trim() === "") result.shift();
+
+  return result.join("\n");
 }
 
 function trimTrailingEmpty(lines: string[]): string[] {
@@ -73,8 +103,8 @@ export const shellHandler: Handler = (
   const structured = parseStructured(raw);
 
   if (structured) {
-    const stdout = stripAnsi(structured.stdout ?? structured.output ?? "");
-    const stderr = stripAnsi(structured.stderr ?? "");
+    const stdout = stripSshNoise(stripAnsi(structured.stdout ?? structured.output ?? ""));
+    const stderr = stripSshNoise(stripAnsi(structured.stderr ?? ""));
     const exitCode = structured.returncode ?? structured.exit_code;
 
     const exitStr = exitCode !== undefined ? `exit:${exitCode} · ` : "";
@@ -96,7 +126,7 @@ export const shellHandler: Handler = (
   }
 
   // Plain string — treat as stdout
-  const text = stripAnsi(raw);
+  const text = stripSshNoise(stripAnsi(raw));
   const fmt = formatLines(text, HEAD_STDOUT);
   return {
     summary: `[bash · ${fmt.header}]\n${fmt.body}`,

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -2,7 +2,7 @@ import { describe, it, expect } from "bun:test";
 import { playwrightHandler } from "../src/handlers/playwright";
 import { githubHandler } from "../src/handlers/github";
 import { filesystemHandler } from "../src/handlers/filesystem";
-import { shellHandler, stripAnsi } from "../src/handlers/shell";
+import { shellHandler, stripAnsi, stripSshNoise } from "../src/handlers/shell";
 import { csvHandler, looksLikeCsv } from "../src/handlers/csv";
 import { linearHandler } from "../src/handlers/linear";
 import { slackHandler } from "../src/handlers/slack";
@@ -660,5 +660,82 @@ describe("shellHandler", () => {
 
   it("routes terminal tools to shell handler", () => {
     expect(getHandler("mcp__terminal__execute", "output")).toBe(shellHandler);
+  });
+
+  it("routes ssh_exec tools to shell handler", () => {
+    expect(getHandler("mcp__mcp-remote-exec__ssh_exec_command", "output")).toBe(shellHandler);
+  });
+
+  it("routes exec_command tools to shell handler", () => {
+    expect(getHandler("mcp__mcp-remote-exec__proxmox_container_exec_command", "output")).toBe(shellHandler);
+  });
+
+  it("routes remote_exec tools to shell handler", () => {
+    expect(getHandler("mcp__remote_exec__run", "output")).toBe(shellHandler);
+  });
+
+  it("routes container_exec tools to shell handler", () => {
+    expect(getHandler("mcp__docker__container_exec", "output")).toBe(shellHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripSshNoise
+// ---------------------------------------------------------------------------
+
+describe("stripSshNoise", () => {
+  const PQ_WARNING = [
+    "** WARNING: connection is not using a post-quantum key exchange algorithm.",
+    "** This session may be vulnerable to \"store now, decrypt later\" attacks.",
+    "** The server may need to be upgraded. See https://openssh.com/pq.html for details.",
+  ].join("\n");
+
+  it("removes post-quantum SSH warning lines", () => {
+    const result = stripSshNoise(PQ_WARNING);
+    expect(result).toBe("");
+  });
+
+  it("preserves real output after the warning block", () => {
+    const input = `${PQ_WARNING}\nuid=0(root) gid=0(root) groups=0(root)`;
+    const result = stripSshNoise(input);
+    expect(result).toBe("uid=0(root) gid=0(root) groups=0(root)");
+  });
+
+  it("collapses blank lines left behind by removed noise", () => {
+    const input = `${PQ_WARNING}\n\nreal output`;
+    const result = stripSshNoise(input);
+    expect(result).toBe("real output");
+  });
+
+  it("leaves plain output unchanged", () => {
+    const input = "uid=0(root) gid=0(root)";
+    expect(stripSshNoise(input)).toBe(input);
+  });
+
+  it("does not strip lines with ** that are real output", () => {
+    // Lines that start with ** followed by a space are stripped; lines that
+    // just contain ** or start with ** without a trailing space are kept.
+    const input = "**bold text** still present";
+    expect(stripSshNoise(input)).toBe(input);
+  });
+
+  it("shellHandler strips SSH noise from plain string output", () => {
+    const input = `${PQ_WARNING}\nHello, world!`;
+    const { summary } = shellHandler("mcp__mcp-remote-exec__ssh_exec_command", input);
+    expect(summary).toContain("Hello, world!");
+    expect(summary).not.toContain("post-quantum");
+  });
+
+  it("shellHandler strips SSH noise from structured stderr", () => {
+    const input = JSON.stringify({
+      stdout: "Hello, world!",
+      stderr: PQ_WARNING,
+      returncode: 0,
+    });
+    const { summary } = shellHandler("mcp__mcp-remote-exec__ssh_exec_command", input);
+    // SSH noise in stderr should be stripped — no stderr section should appear
+    expect(summary).not.toContain("stderr:");
+    expect(summary).not.toContain("post-quantum");
+    expect(summary).toContain("Hello, world!");
   });
 });


### PR DESCRIPTION
## Summary
- Adds `stripSshNoise()` to `src/handlers/shell.ts` — removes OpenSSH post-quantum advisory lines (lines starting with `** `) and collapses resulting blank lines; applied in both the structured JSON and plain-string code paths of `shellHandler`
- Extends `getHandler` routing in `src/handlers/index.ts` to match `ssh_exec`, `exec_command`, `remote_exec`, and `container_exec` tool name patterns, so all Remote Exec MCP outputs (`mcp__mcp-remote-exec__ssh_exec_command`, `mcp__mcp-remote-exec__proxmox_container_exec_command`, etc.) are compressed by the shell handler
- Adds 11 new tests: 4 dispatcher routing assertions + 7-test `stripSshNoise` suite including end-to-end `shellHandler` integration tests

## Test plan
- [x] `bun test` — 287 pass, 0 fail
- [x] `stripSshNoise` unit tests cover: warning-only input, warning + real output, blank-line collapse, plain output unchanged, `**bold**` false-positive guard
- [x] Integration tests confirm `shellHandler` strips SSH noise from both plain string and structured `stderr` inputs
- [x] Routing tests confirm all four new tool name patterns map to `shellHandler`

Closes #38