### PR TITLE
feat: show content snippet in recall__search results

### DIFF
--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20887,11 +20887,20 @@ function toolSearch(db, projectKey, args) {
   if (items.length === 0) {
     return `[recall: no results for "${args.query}"]`;
   }
+  const SNIPPET_MAX = 150;
   const lines = items.map((item, i) => {
     const excerpt = item.summary.slice(0, 120).replace(/\n/g, " ");
     const ellipsis = item.summary.length > 120 ? "\u2026" : "";
-    return `${i + 1}. ${item.id} \xB7 ${item.tool_name} \xB7 ${formatDate(item.created_at)}
+    const summaryLine = `${i + 1}. ${item.id} \xB7 ${item.tool_name} \xB7 ${formatDate(item.created_at)}
    ${excerpt}${ellipsis}`;
+    const snippet = retrieveSnippet(db, item.id, args.query);
+    if (!snippet)
+      return summaryLine;
+    const snipText = snippet.replace(/\n/g, " ").trim();
+    const capped = snipText.slice(0, SNIPPET_MAX);
+    const trailingEllipsis = snipText.length > SNIPPET_MAX ? "\u2026" : "";
+    return `${summaryLine}
+   > \u2026${capped}${trailingEllipsis}`;
   });
   return `Found ${items.length} result${items.length === 1 ? "" : "s"} for "${args.query}":
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -121,10 +121,20 @@ export function toolSearch(
     return `[recall: no results for "${args.query}"]`;
   }
 
+  const SNIPPET_MAX = 150;
+
   const lines = items.map((item, i) => {
     const excerpt = item.summary.slice(0, 120).replace(/\n/g, " ");
     const ellipsis = item.summary.length > 120 ? "…" : "";
-    return `${i + 1}. ${item.id} · ${item.tool_name} · ${formatDate(item.created_at)}\n   ${excerpt}${ellipsis}`;
+    const summaryLine = `${i + 1}. ${item.id} · ${item.tool_name} · ${formatDate(item.created_at)}\n   ${excerpt}${ellipsis}`;
+
+    const snippet = retrieveSnippet(db, item.id, args.query);
+    if (!snippet) return summaryLine;
+
+    const snipText = snippet.replace(/\n/g, " ").trim();
+    const capped = snipText.slice(0, SNIPPET_MAX);
+    const trailingEllipsis = snipText.length > SNIPPET_MAX ? "…" : "";
+    return `${summaryLine}\n   > …${capped}${trailingEllipsis}`;
   });
 
   return `Found ${items.length} result${items.length === 1 ? "" : "s"} for "${args.query}":\n\n${lines.join("\n\n")}`;

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -114,6 +114,43 @@ describe("MCP tool handlers", () => {
       const result = toolSearch(db, PROJECT_KEY, { query: "result", limit: 2 });
       expect(result).toContain("Found 2 results");
     });
+
+    it("includes a > snippet line when full_content matches the query", () => {
+      storeOutput(db, makeInput({
+        summary: "GitHub issues list",
+        full_content: "Issue #42: implement the frobnication feature for power users",
+      }));
+      const result = toolSearch(db, PROJECT_KEY, { query: "frobnication" });
+      expect(result).toContain(">");
+      expect(result).toContain("frobnication");
+    });
+
+    it("still returns summary when no snippet is found (graceful fallback)", () => {
+      // Item whose full_content is empty — retrieveSnippet returns null
+      storeOutput(db, makeInput({
+        summary: "ghosttoken appears only in summary",
+        full_content: "",
+      }));
+      const result = toolSearch(db, PROJECT_KEY, { query: "ghosttoken" });
+      expect(result).toContain("ghosttoken");
+      // No crash; result is well-formed
+      expect(result).toContain("Found 1 result");
+    });
+
+    it("caps snippet at 150 characters", () => {
+      const longContent = "frobnicate " + "x".repeat(300);
+      storeOutput(db, makeInput({
+        summary: "item with long full content",
+        full_content: longContent,
+      }));
+      const result = toolSearch(db, PROJECT_KEY, { query: "frobnicate" });
+      // Snippet line should be present and capped (full chunk is 512 chars)
+      expect(result).toContain(">");
+      const snippetLine = result.split("\n").find((l) => l.trim().startsWith(">"))!;
+      // Remove the "> …" prefix (4 chars) and trailing "…" to measure content
+      const snippetContent = snippetLine.trim().replace(/^>\s*…/, "").replace(/…$/, "");
+      expect(snippetContent.length).toBeLessThanOrEqual(150);
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Each `recall__search` result now includes a `> …excerpt…` line from the matching `full_content`, using the existing `retrieveSnippet` / chunk-based FTS path already built for `recall__retrieve`
- Snippet capped at 150 characters with trailing ellipsis; gracefully omitted if `retrieveSnippet` returns null (e.g. empty `full_content`)
- `recall__retrieve` behaviour unchanged — only `toolSearch` is modified

## Test plan
- [x] `bun test` — 294 pass, 0 fail
- [x] Snippet appears and contains matching content when `full_content` matches the query
- [x] Graceful fallback: result still shown correctly when `full_content` is empty
- [x] Snippet content is capped at ≤150 characters

Closes #39