### PR TITLE
feat: pin suggestions and stale item alerts in recall__stats

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -4938,7 +4938,9 @@ var RecallConfigSchema = exports_external.object({
   store: exports_external.object({
     expire_after_session_days: exports_external.number().positive(),
     key: exports_external.enum(["git_root", "cwd"]),
-    max_size_mb: exports_external.number().positive()
+    max_size_mb: exports_external.number().positive(),
+    pin_recommendation_threshold: exports_external.number().int().positive(),
+    stale_item_days: exports_external.number().int().positive()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -4953,7 +4955,9 @@ var DEFAULTS = {
   store: {
     expire_after_session_days: 7,
     key: "git_root",
-    max_size_mb: 500
+    max_size_mb: 500,
+    pin_recommendation_threshold: 5,
+    stale_item_days: 3
   },
   retrieve: {
     default_max_bytes: 8192

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19722,6 +19722,25 @@ function getStats(db, project_key) {
   const compression_ratio = row.total_original_bytes > 0 ? row.total_summary_bytes / row.total_original_bytes : 0;
   return { ...row, compression_ratio };
 }
+function getSuggestions(db, project_key, opts = {}) {
+  const threshold = opts.pin_threshold ?? 5;
+  const staleDays = opts.stale_days ?? 3;
+  const limit = opts.limit ?? 3;
+  const staleCutoff = Math.floor(Date.now() / 1000) - staleDays * 86400;
+  const pin_candidates = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND access_count >= ?
+    ORDER BY access_count DESC
+    LIMIT ?
+  `).all(project_key, threshold, limit);
+  const stale_candidates = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND access_count = 0 AND created_at < ?
+    ORDER BY created_at ASC
+    LIMIT ?
+  `).all(project_key, staleCutoff, limit);
+  return { pin_candidates, stale_candidates };
+}
 function getContext(db, project_key, opts = {}) {
   const days = opts.days ?? 7;
   const limit = opts.limit ?? 5;
@@ -20766,7 +20785,9 @@ var RecallConfigSchema = exports_external.object({
   store: exports_external.object({
     expire_after_session_days: exports_external.number().positive(),
     key: exports_external.enum(["git_root", "cwd"]),
-    max_size_mb: exports_external.number().positive()
+    max_size_mb: exports_external.number().positive(),
+    pin_recommendation_threshold: exports_external.number().int().positive(),
+    stale_item_days: exports_external.number().int().positive()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -20781,7 +20802,9 @@ var DEFAULTS = {
   store: {
     expire_after_session_days: 7,
     key: "git_root",
-    max_size_mb: 500
+    max_size_mb: 500,
+    pin_recommendation_threshold: 5,
+    stale_item_days: 3
   },
   retrieve: {
     default_max_bytes: 8192
@@ -21085,7 +21108,7 @@ function toolSessionSummary(db, projectKey, args) {
   return lines.join(`
 `);
 }
-function toolStats(db, projectKey) {
+function toolStats(db, projectKey, args = {}) {
   const stats = getStats(db, projectKey);
   const sessionDays = getSessionDays(db);
   if (stats.total_items === 0) {
@@ -21103,6 +21126,30 @@ function toolStats(db, projectKey) {
     `  ~Tokens saved:     ~${tokensSaved.toLocaleString()}`,
     `  Session days:      ${sessionDays.length}`
   ];
+  const suggestions = getSuggestions(db, projectKey, {
+    pin_threshold: args.pin_threshold,
+    stale_days: args.stale_days
+  });
+  const hasSuggestions = suggestions.pin_candidates.length > 0 || suggestions.stale_candidates.length > 0;
+  if (hasSuggestions) {
+    lines.push("", "Suggestions:");
+    if (suggestions.pin_candidates.length > 0) {
+      lines.push("  \uD83D\uDCCC Consider pinning:");
+      for (const item of suggestions.pin_candidates) {
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  accessed ${item.access_count}\xD7`);
+      }
+    }
+    if (suggestions.stale_candidates.length > 0) {
+      if (suggestions.pin_candidates.length > 0)
+        lines.push("");
+      lines.push("  \uD83D\uDDD1  Never accessed (consider forgetting):");
+      const now = Math.floor(Date.now() / 1000);
+      for (const item of suggestions.stale_candidates) {
+        const ageDays = Math.floor((now - item.created_at) / 86400);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
+      }
+    }
+  }
   return lines.join(`
 `);
 }
@@ -21162,9 +21209,15 @@ server.tool("recall__list_stored", "Browse stored items by recency, access frequ
 }, async (args) => ({
   content: [{ type: "text", text: toolListStored(db, projectKey, args) }]
 }));
-server.tool("recall__stats", "Aggregate session efficiency stats \u2014 total savings, compression ratio, token savings, session days. Use to understand the big picture.", {}, async () => ({
-  content: [{ type: "text", text: toolStats(db, projectKey) }]
-}));
+server.tool("recall__stats", "Aggregate session efficiency stats \u2014 total savings, compression ratio, token savings, session days. Use to understand the big picture.", {}, async () => {
+  const config2 = loadConfig();
+  return {
+    content: [{ type: "text", text: toolStats(db, projectKey, {
+      pin_threshold: config2.store.pin_recommendation_threshold,
+      stale_days: config2.store.stale_item_days
+    }) }]
+  };
+});
 server.tool("recall__session_summary", "Digest of a single session's activity \u2014 tools called, compression savings, most-accessed items, pinned items, notes. Defaults to today. Use at session start for orientation or handoff.", {
   session_id: exports_external.string().optional().describe("Filter by specific Claude session ID (exact match)"),
   date: exports_external.string().optional().describe("Filter by date in YYYY-MM-DD format (defaults to today)")

--- a/src/config.ts
+++ b/src/config.ts
@@ -9,6 +9,8 @@ const RecallConfigSchema = z.object({
     expire_after_session_days: z.number().positive(),
     key: z.enum(["git_root", "cwd"]),
     max_size_mb: z.number().positive(),
+    pin_recommendation_threshold: z.number().int().positive(),
+    stale_item_days: z.number().int().positive(),
   }),
   retrieve: z.object({
     default_max_bytes: z.number().positive(),
@@ -28,6 +30,8 @@ const DEFAULTS: RecallConfig = {
     expire_after_session_days: 7,
     key: "git_root",
     max_size_mb: 500,
+    pin_recommendation_threshold: 5,
+    stale_item_days: 3,
   },
   retrieve: {
     default_max_bytes: 8192,

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -531,6 +531,56 @@ export function getStats(db: Database, project_key: string): Stats {
   return { ...row, compression_ratio };
 }
 
+/** Options for {@link getSuggestions}. */
+export interface SuggestionsOptions {
+  /** Access-count threshold above which a non-pinned item is a pin candidate (default 5). */
+  pin_threshold?: number;
+  /** Items with zero accesses older than this many days are stale candidates (default 3). */
+  stale_days?: number;
+  /** Maximum items to return per category (default 3). */
+  limit?: number;
+}
+
+/** Output of {@link getSuggestions}: two categorised item lists. */
+export interface SuggestionsData {
+  /** Non-pinned items accessed at or above the pin threshold. */
+  pin_candidates: StoredOutput[];
+  /** Non-pinned items that have never been accessed and are older than `stale_days`. */
+  stale_candidates: StoredOutput[];
+}
+
+/**
+ * Returns pin candidates (frequently accessed, not yet pinned) and stale
+ * candidates (never accessed, older than `stale_days`) for the project.
+ * Both lists are capped at `limit` items to avoid overwhelming output.
+ */
+export function getSuggestions(
+  db: Database,
+  project_key: string,
+  opts: SuggestionsOptions = {}
+): SuggestionsData {
+  const threshold = opts.pin_threshold ?? 5;
+  const staleDays = opts.stale_days ?? 3;
+  const limit = opts.limit ?? 3;
+  const staleCutoff = Math.floor(Date.now() / 1000) - staleDays * 86400;
+
+  const pin_candidates = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND access_count >= ?
+    ORDER BY access_count DESC
+    LIMIT ?
+  `).all(project_key, threshold, limit) as StoredOutput[];
+
+  const stale_candidates = db.prepare(`
+    SELECT * FROM stored_outputs
+    WHERE project_key = ? AND pinned = 0 AND access_count = 0 AND created_at < ?
+    ORDER BY created_at ASC
+    LIMIT ?
+  `).all(project_key, staleCutoff, limit) as StoredOutput[];
+
+  return { pin_candidates, stale_candidates };
+}
+
 /**
  * Returns a session-orientation snapshot in four isolated sections:
  * pinned items, unpinned notes, recently accessed items (within `opts.days`),

--- a/src/server.ts
+++ b/src/server.ts
@@ -18,6 +18,7 @@ import { StdioServerTransport } from "@modelcontextprotocol/sdk/server/stdio.js"
 import { z } from "zod";
 import { getProjectKey } from "./project-key";
 import { getDb, defaultDbPath } from "./db/index";
+import { loadConfig } from "./config";
 import {
   toolRetrieve,
   toolSearch,
@@ -142,9 +143,15 @@ server.tool(
   "recall__stats",
   "Aggregate session efficiency stats — total savings, compression ratio, token savings, session days. Use to understand the big picture.",
   {},
-  async () => ({
-    content: [{ type: "text", text: toolStats(db, projectKey) }],
-  })
+  async () => {
+    const config = loadConfig();
+    return {
+      content: [{ type: "text", text: toolStats(db, projectKey, {
+        pin_threshold: config.store.pin_recommendation_threshold,
+        stale_days: config.store.stale_item_days,
+      }) }],
+    };
+  }
 );
 
 server.tool(

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -14,6 +14,7 @@ import {
   listOutputs,
   forgetOutputs,
   getStats,
+  getSuggestions,
   getSessionDays,
   getSessionSummary,
   getContext,
@@ -458,7 +459,18 @@ export function toolSessionSummary(
 // recall__stats
 // ---------------------------------------------------------------------------
 
-export function toolStats(db: Database, projectKey: string): string {
+export interface StatsArgs {
+  /** Access-count threshold for pin candidates (default: config or 5). */
+  pin_threshold?: number;
+  /** Days without any access before an item is flagged as stale (default: config or 3). */
+  stale_days?: number;
+}
+
+export function toolStats(
+  db: Database,
+  projectKey: string,
+  args: StatsArgs = {}
+): string {
   const stats = getStats(db, projectKey);
   const sessionDays = getSessionDays(db);
 
@@ -481,6 +493,35 @@ export function toolStats(db: Database, projectKey: string): string {
     `  ~Tokens saved:     ~${tokensSaved.toLocaleString()}`,
     `  Session days:      ${sessionDays.length}`,
   ];
+
+  const suggestions = getSuggestions(db, projectKey, {
+    pin_threshold: args.pin_threshold,
+    stale_days: args.stale_days,
+  });
+
+  const hasSuggestions =
+    suggestions.pin_candidates.length > 0 || suggestions.stale_candidates.length > 0;
+
+  if (hasSuggestions) {
+    lines.push("", "Suggestions:");
+
+    if (suggestions.pin_candidates.length > 0) {
+      lines.push("  📌 Consider pinning:");
+      for (const item of suggestions.pin_candidates) {
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  accessed ${item.access_count}×`);
+      }
+    }
+
+    if (suggestions.stale_candidates.length > 0) {
+      if (suggestions.pin_candidates.length > 0) lines.push("");
+      lines.push("  🗑  Never accessed (consider forgetting):");
+      const now = Math.floor(Date.now() / 1000);
+      for (const item of suggestions.stale_candidates) {
+        const ageDays = Math.floor((now - item.created_at) / 86400);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
+      }
+    }
+  }
 
   return lines.join("\n");
 }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -25,6 +25,8 @@ describe("loadConfig", () => {
     expect(config.store.expire_after_session_days).toBe(7);
     expect(config.store.key).toBe("git_root");
     expect(config.store.max_size_mb).toBe(500);
+    expect(config.store.pin_recommendation_threshold).toBe(5);
+    expect(config.store.stale_item_days).toBe(3);
     expect(config.retrieve.default_max_bytes).toBe(8192);
     expect(config.denylist.additional).toEqual([]);
     expect(config.denylist.override_defaults).toEqual([]);

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -272,6 +272,62 @@ describe("MCP tool handlers", () => {
       const result = toolStats(db, PROJECT_KEY);
       expect(result).toContain("Tokens saved");
     });
+
+    it("omits Suggestions section when no candidates qualify", () => {
+      storeOutput(db, makeInput());
+      // access_count=0, just created — not stale yet, not a pin candidate
+      const result = toolStats(db, PROJECT_KEY, { pin_threshold: 5, stale_days: 3 });
+      expect(result).not.toContain("Suggestions");
+    });
+
+    it("shows pin candidates when access_count meets threshold", () => {
+      const stored = storeOutput(db, makeInput());
+      recordAccess(db, stored.id);
+      const result = toolStats(db, PROJECT_KEY, { pin_threshold: 1 });
+      expect(result).toContain("Suggestions");
+      expect(result).toContain("Consider pinning");
+      expect(result).toContain(stored.id);
+      expect(result).toContain("accessed 1×");
+    });
+
+    it("shows stale candidates when items are old and never accessed", () => {
+      const stored = storeOutput(db, makeInput());
+      // Backdate by 5 days so it's stale under a 3-day threshold
+      const fiveDaysAgo = Math.floor(Date.now() / 1000) - 5 * 86400;
+      db.prepare(`UPDATE stored_outputs SET created_at = ? WHERE id = ?`)
+        .run(fiveDaysAgo, stored.id);
+
+      const result = toolStats(db, PROJECT_KEY, { stale_days: 3 });
+      expect(result).toContain("Suggestions");
+      expect(result).toContain("Never accessed");
+      expect(result).toContain(stored.id);
+      expect(result).toContain("days ago");
+    });
+
+    it("shows both categories when both qualify", () => {
+      // Pin candidate
+      const pinItem = storeOutput(db, makeInput());
+      recordAccess(db, pinItem.id);
+
+      // Stale candidate
+      const staleItem = storeOutput(db, makeInput());
+      const fiveDaysAgo = Math.floor(Date.now() / 1000) - 5 * 86400;
+      db.prepare(`UPDATE stored_outputs SET created_at = ? WHERE id = ?`)
+        .run(fiveDaysAgo, staleItem.id);
+
+      const result = toolStats(db, PROJECT_KEY, { pin_threshold: 1, stale_days: 3 });
+      expect(result).toContain("Consider pinning");
+      expect(result).toContain("Never accessed");
+    });
+
+    it("does not suggest already-pinned items", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      recordAccess(db, stored.id);
+      // Even with high access_count, pinned items should not appear as pin candidates
+      const result = toolStats(db, PROJECT_KEY, { pin_threshold: 1 });
+      expect(result).not.toContain("Consider pinning");
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- Reinstates `pin_recommendation_threshold` (default 5) and adds `stale_item_days` (default 3) to the `[store]` config section — both configurable in `~/.config/mcp-recall/config.toml`
- Adds `getSuggestions(db, project_key, opts)` to `src/db/index.ts` returning pin candidates (non-pinned items with `access_count >= threshold`) and stale candidates (never-accessed items older than `stale_days`), each list capped at 3
- `recall__stats` appends a `Suggestions` section when either list is non-empty; entirely omitted when nothing qualifies — no noise on fresh projects
- `server.ts` loads config and passes threshold values through to `toolStats`

## Test plan
- [x] `bun test` — 299 pass, 0 fail
- [x] No suggestions when no items qualify (fresh item, default thresholds)
- [x] Pin candidates shown when `access_count >= pin_threshold`
- [x] Stale candidates shown when item is old enough and never accessed
- [x] Both sections shown when both categories have qualifying items
- [x] Already-pinned items excluded from pin candidates
- [x] Config defaults asserted for both new fields

Closes #40