### PR TITLE
feat: CLI-aware compression for native Bash tool outputs

### DIFF
--- a/hooks/hooks.json
+++ b/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__(?!recall__).*",
+        "matcher": "(mcp__(?!recall__).*|Bash)",
         "hooks": [
           {
             "type": "command",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5711,6 +5711,169 @@ ${fmt.body}`,
   };
 };
 
+// src/handlers/bash.ts
+var MAX_LOG_COMMITS = 20;
+var MAX_TERRAFORM_RESOURCES = 10;
+function extractStdout(output) {
+  if (output !== null && typeof output === "object") {
+    const obj = output;
+    if (typeof obj.stdout === "string")
+      return stripSshNoise(stripAnsi(obj.stdout));
+    if (typeof obj.output === "string")
+      return stripSshNoise(stripAnsi(obj.output));
+  }
+  return stripSshNoise(stripAnsi(extractText(output)));
+}
+function extractCommand(input) {
+  if (input !== null && typeof input === "object") {
+    const obj = input;
+    if (typeof obj.command === "string")
+      return obj.command.trim();
+  }
+  return null;
+}
+function parseGitDiff(text) {
+  const files = [];
+  let current = null;
+  for (const line of text.split(`
+`)) {
+    if (line.startsWith("diff --git ")) {
+      if (current)
+        files.push(current);
+      const match = line.match(/diff --git a\/.+ b\/(.+)/);
+      const path = match ? match[1] : line.slice(11);
+      current = { path, additions: 0, deletions: 0, hunks: 0 };
+    } else if (current) {
+      if (line.startsWith("@@ ")) {
+        current.hunks++;
+      } else if (line.startsWith("+") && !line.startsWith("+++")) {
+        current.additions++;
+      } else if (line.startsWith("-") && !line.startsWith("---")) {
+        current.deletions++;
+      }
+    }
+  }
+  if (current)
+    files.push(current);
+  return files;
+}
+var gitDiffHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  if (!stdout.trim()) {
+    return { summary: "[git diff \u2014 no changes]", originalSize };
+  }
+  const files = parseGitDiff(stdout);
+  if (files.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const totalAdded = files.reduce((s, f) => s + f.additions, 0);
+  const totalDeleted = files.reduce((s, f) => s + f.deletions, 0);
+  const header = `git diff \u2014 ${files.length} file${files.length === 1 ? "" : "s"} changed, +${totalAdded} -${totalDeleted}`;
+  const fileLines = files.map((f) => {
+    const stats = `+${f.additions} -${f.deletions}`;
+    const hunks = `(${f.hunks} hunk${f.hunks === 1 ? "" : "s"})`;
+    return `  ${f.path.padEnd(48)}  ${stats.padEnd(10)}  ${hunks}`;
+  });
+  return { summary: [header, ...fileLines].join(`
+`), originalSize };
+};
+var gitLogHandler = (_toolName, output) => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const lines = stdout.trim().split(`
+`).filter((l) => l.trim());
+  if (lines.length === 0) {
+    return { summary: "[git log \u2014 no commits]", originalSize };
+  }
+  const isOneline = lines.every((l) => /^[0-9a-f]{6,40}\s/.test(l.trim()));
+  if (isOneline) {
+    const total2 = lines.length;
+    const shown2 = lines.slice(0, MAX_LOG_COMMITS);
+    const overflow2 = total2 > MAX_LOG_COMMITS ? `
+\u2026 (+${total2 - MAX_LOG_COMMITS} more commits)` : "";
+    const summary = `git log \u2014 ${total2} commit${total2 === 1 ? "" : "s"}
+` + shown2.map((l) => `  ${l}`).join(`
+`) + overflow2;
+    return { summary, originalSize };
+  }
+  const commits = [];
+  let hash = "";
+  let seenBlank = false;
+  for (const line of stdout.split(`
+`)) {
+    if (line.startsWith("commit ")) {
+      hash = line.slice(7, 14);
+      seenBlank = false;
+    } else if (hash && line.trim() === "" && !seenBlank) {
+      seenBlank = true;
+    } else if (hash && seenBlank && line.startsWith("    ") && line.trim()) {
+      const subject = line.trim().slice(0, 72);
+      commits.push(`  ${hash}  ${subject}`);
+      hash = "";
+      seenBlank = false;
+    }
+  }
+  const total = commits.length;
+  const shown = commits.slice(0, MAX_LOG_COMMITS);
+  const overflow = total > MAX_LOG_COMMITS ? `
+\u2026 (+${total - MAX_LOG_COMMITS} more commits)` : "";
+  const header = `git log \u2014 ${total} commit${total === 1 ? "" : "s"}`;
+  return {
+    summary: [header, ...shown].join(`
+`) + overflow,
+    originalSize
+  };
+};
+var TERRAFORM_RESOURCE_RE = /^\s+#\s+(.+?)\s+will\s+be\s+(created|destroyed|updated in-place|replaced)/;
+var TERRAFORM_PLAN_SUMMARY_RE = /^Plan:\s+.+$/m;
+var TERRAFORM_SYMBOL = {
+  created: "+",
+  destroyed: "-",
+  "updated in-place": "~",
+  replaced: "-/+"
+};
+var terraformPlanHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const summaryMatch = stdout.match(TERRAFORM_PLAN_SUMMARY_RE);
+  const summaryLine = summaryMatch ? summaryMatch[0] : null;
+  const resources = [];
+  for (const line of stdout.split(`
+`)) {
+    const match = line.match(TERRAFORM_RESOURCE_RE);
+    if (match) {
+      const [, resource, action] = match;
+      const symbol = TERRAFORM_SYMBOL[action] ?? "?";
+      resources.push(`  ${symbol} ${resource}`);
+    }
+  }
+  if (!summaryLine && resources.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const lines = ["terraform plan"];
+  if (summaryLine)
+    lines.push(`  ${summaryLine}`);
+  lines.push(...resources.slice(0, MAX_TERRAFORM_RESOURCES));
+  if (resources.length > MAX_TERRAFORM_RESOURCES) {
+    lines.push(`  \u2026 (+${resources.length - MAX_TERRAFORM_RESOURCES} more resources)`);
+  }
+  return { summary: lines.join(`
+`), originalSize };
+};
+function getBashHandler(input) {
+  const command = extractCommand(input);
+  if (!command)
+    return shellHandler;
+  if (/^git\s+(diff|show)(\s|$)/.test(command))
+    return gitDiffHandler;
+  if (/^git\s+log(\s|$)/.test(command))
+    return gitLogHandler;
+  if (/^terraform\s+plan(\s|$)/.test(command))
+    return terraformPlanHandler;
+  return shellHandler;
+}
+
 // src/handlers/linear.ts
 var PRIORITY_LABEL = {
   0: "No Priority",
@@ -6022,7 +6185,10 @@ var genericHandler = (_toolName, output) => {
 };
 
 // src/handlers/index.ts
-function getHandler(toolName, output) {
+function getHandler(toolName, output, input) {
+  if (toolName === "Bash") {
+    return getBashHandler(input);
+  }
   if (toolName.includes("playwright") && toolName.includes("snapshot")) {
     return playwrightHandler;
   }
@@ -6092,7 +6258,7 @@ ${cached2.summary}`,
       };
     }
   }
-  const handler = getHandler(tool_name, tool_response);
+  const handler = getHandler(tool_name, tool_response, tool_input);
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
   if (summarySize >= originalSize) {

--- a/plugins/mcp-recall/hooks/hooks.json
+++ b/plugins/mcp-recall/hooks/hooks.json
@@ -13,7 +13,7 @@
     ],
     "PostToolUse": [
       {
-        "matcher": "mcp__(?!recall__).*",
+        "matcher": "(mcp__(?!recall__).*|Bash)",
         "hooks": [
           {
             "type": "command",

--- a/src/handlers/bash.ts
+++ b/src/handlers/bash.ts
@@ -1,0 +1,232 @@
+/**
+ * Bash handler — routes native Bash tool outputs to CLI-aware compressors.
+ * Inspects `tool_input.command` to detect git diff/log, terraform plan, etc.
+ * Falls back to the shell handler for unrecognised commands.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+import { shellHandler, stripAnsi, stripSshNoise } from "./shell";
+
+const MAX_LOG_COMMITS = 20;
+const MAX_TERRAFORM_RESOURCES = 10;
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Extracts the plain stdout string from a native Bash tool response
+ * `{exit_code, stdout, stderr}` or falls back to extractText for other shapes.
+ */
+function extractStdout(output: unknown): string {
+  if (output !== null && typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (typeof obj.stdout === "string") return stripSshNoise(stripAnsi(obj.stdout));
+    if (typeof obj.output === "string") return stripSshNoise(stripAnsi(obj.output));
+  }
+  return stripSshNoise(stripAnsi(extractText(output)));
+}
+
+function extractCommand(input: unknown): string | null {
+  if (input !== null && typeof input === "object") {
+    const obj = input as Record<string, unknown>;
+    if (typeof obj.command === "string") return obj.command.trim();
+  }
+  return null;
+}
+
+// ---------------------------------------------------------------------------
+// git diff / git show
+// ---------------------------------------------------------------------------
+
+interface FileDiff {
+  path: string;
+  additions: number;
+  deletions: number;
+  hunks: number;
+}
+
+function parseGitDiff(text: string): FileDiff[] {
+  const files: FileDiff[] = [];
+  let current: FileDiff | null = null;
+
+  for (const line of text.split("\n")) {
+    if (line.startsWith("diff --git ")) {
+      if (current) files.push(current);
+      const match = line.match(/diff --git a\/.+ b\/(.+)/);
+      const path = match ? match[1]! : line.slice(11);
+      current = { path, additions: 0, deletions: 0, hunks: 0 };
+    } else if (current) {
+      if (line.startsWith("@@ ")) {
+        current.hunks++;
+      } else if (line.startsWith("+") && !line.startsWith("+++")) {
+        current.additions++;
+      } else if (line.startsWith("-") && !line.startsWith("---")) {
+        current.deletions++;
+      }
+    }
+  }
+  if (current) files.push(current);
+  return files;
+}
+
+export const gitDiffHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  if (!stdout.trim()) {
+    return { summary: "[git diff — no changes]", originalSize };
+  }
+
+  const files = parseGitDiff(stdout);
+
+  if (files.length === 0) {
+    // Binary diff, submodule change, or unusual output — fall back to shell
+    return shellHandler(toolName, output);
+  }
+
+  const totalAdded = files.reduce((s, f) => s + f.additions, 0);
+  const totalDeleted = files.reduce((s, f) => s + f.deletions, 0);
+  const header = `git diff — ${files.length} file${files.length === 1 ? "" : "s"} changed, +${totalAdded} -${totalDeleted}`;
+
+  const fileLines = files.map((f) => {
+    const stats = `+${f.additions} -${f.deletions}`;
+    const hunks = `(${f.hunks} hunk${f.hunks === 1 ? "" : "s"})`;
+    return `  ${f.path.padEnd(48)}  ${stats.padEnd(10)}  ${hunks}`;
+  });
+
+  return { summary: [header, ...fileLines].join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
+// git log
+// ---------------------------------------------------------------------------
+
+export const gitLogHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  const lines = stdout.trim().split("\n").filter((l) => l.trim());
+  if (lines.length === 0) {
+    return { summary: "[git log — no commits]", originalSize };
+  }
+
+  // Detect --oneline / --format="%h %s" style: every line starts with a short hash
+  const isOneline = lines.every((l) => /^[0-9a-f]{6,40}\s/.test(l.trim()));
+
+  if (isOneline) {
+    const total = lines.length;
+    const shown = lines.slice(0, MAX_LOG_COMMITS);
+    const overflow =
+      total > MAX_LOG_COMMITS ? `\n… (+${total - MAX_LOG_COMMITS} more commits)` : "";
+    const summary =
+      `git log — ${total} commit${total === 1 ? "" : "s"}\n` +
+      shown.map((l) => `  ${l}`).join("\n") +
+      overflow;
+    return { summary, originalSize };
+  }
+
+  // Full format: extract short hash + subject line from each "commit <hash>" block
+  const commits: string[] = [];
+  let hash = "";
+  let seenBlank = false;
+
+  for (const line of stdout.split("\n")) {
+    if (line.startsWith("commit ")) {
+      hash = line.slice(7, 14);
+      seenBlank = false;
+    } else if (hash && line.trim() === "" && !seenBlank) {
+      seenBlank = true;
+    } else if (hash && seenBlank && line.startsWith("    ") && line.trim()) {
+      const subject = line.trim().slice(0, 72);
+      commits.push(`  ${hash}  ${subject}`);
+      hash = "";
+      seenBlank = false;
+    }
+  }
+
+  const total = commits.length;
+  const shown = commits.slice(0, MAX_LOG_COMMITS);
+  const overflow =
+    total > MAX_LOG_COMMITS ? `\n… (+${total - MAX_LOG_COMMITS} more commits)` : "";
+  const header = `git log — ${total} commit${total === 1 ? "" : "s"}`;
+  return {
+    summary: [header, ...shown].join("\n") + overflow,
+    originalSize,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// terraform plan
+// ---------------------------------------------------------------------------
+
+const TERRAFORM_RESOURCE_RE =
+  /^\s+#\s+(.+?)\s+will\s+be\s+(created|destroyed|updated in-place|replaced)/;
+const TERRAFORM_PLAN_SUMMARY_RE = /^Plan:\s+.+$/m;
+const TERRAFORM_SYMBOL: Record<string, string> = {
+  created: "+",
+  destroyed: "-",
+  "updated in-place": "~",
+  replaced: "-/+",
+};
+
+export const terraformPlanHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  const summaryMatch = stdout.match(TERRAFORM_PLAN_SUMMARY_RE);
+  const summaryLine = summaryMatch ? summaryMatch[0] : null;
+
+  const resources: string[] = [];
+  for (const line of stdout.split("\n")) {
+    const match = line.match(TERRAFORM_RESOURCE_RE);
+    if (match) {
+      const [, resource, action] = match as [string, string, string];
+      const symbol = TERRAFORM_SYMBOL[action] ?? "?";
+      resources.push(`  ${symbol} ${resource}`);
+    }
+  }
+
+  if (!summaryLine && resources.length === 0) {
+    // Not a recognisable plan output — fall back to shell
+    return shellHandler(toolName, output);
+  }
+
+  const lines = ["terraform plan"];
+  if (summaryLine) lines.push(`  ${summaryLine}`);
+  lines.push(...resources.slice(0, MAX_TERRAFORM_RESOURCES));
+  if (resources.length > MAX_TERRAFORM_RESOURCES) {
+    lines.push(`  … (+${resources.length - MAX_TERRAFORM_RESOURCES} more resources)`);
+  }
+
+  return { summary: lines.join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
+// Dispatcher
+// ---------------------------------------------------------------------------
+
+/**
+ * Returns the appropriate handler for a native Bash tool call based on the
+ * command string in `tool_input`. Falls back to the shell handler when no
+ * CLI-specific handler matches.
+ */
+export function getBashHandler(input: unknown): Handler {
+  const command = extractCommand(input);
+  if (!command) return shellHandler;
+
+  if (/^git\s+(diff|show)(\s|$)/.test(command)) return gitDiffHandler;
+  if (/^git\s+log(\s|$)/.test(command)) return gitLogHandler;
+  if (/^terraform\s+plan(\s|$)/.test(command)) return terraformPlanHandler;
+
+  return shellHandler;
+}

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -3,6 +3,7 @@ import { playwrightHandler } from "./playwright";
 import { githubHandler } from "./github";
 import { filesystemHandler } from "./filesystem";
 import { shellHandler } from "./shell";
+import { getBashHandler } from "./bash";
 import { linearHandler } from "./linear";
 import { slackHandler } from "./slack";
 import { csvHandler, looksLikeCsv } from "./csv";
@@ -17,18 +18,26 @@ export { extractText } from "./types";
  * Returns the appropriate compression handler for a given MCP tool name.
  *
  * Dispatch order:
- *   1. Playwright browser_snapshot → playwright handler
- *   2. GitHub tools               → github handler
- *   3. Filesystem tools           → filesystem handler
- *   4. Shell/bash/remote-exec     → shell handler
- *   5. Linear tools               → linear handler
- *   6. Slack tools                → slack handler
- *   7. CSV tools (name-based)     → csv handler
- *   8. Unmatched with JSON output → json handler
- *   9. CSV content-based fallback → csv handler
- *  10. Everything else            → generic handler
+ *   1. Native Bash tool              → bash handler (CLI-aware, routes on command)
+ *   2. Playwright browser_snapshot   → playwright handler
+ *   3. GitHub tools                  → github handler
+ *   4. Filesystem tools              → filesystem handler
+ *   5. Shell/bash/remote-exec        → shell handler
+ *   6. Linear tools                  → linear handler
+ *   7. Slack tools                   → slack handler
+ *   8. CSV tools (name-based)        → csv handler
+ *   9. Unmatched with JSON output    → json handler
+ *  10. CSV content-based fallback    → csv handler
+ *  11. Everything else               → generic handler
+ *
+ * `input` (tool_input) is used for the Bash tool to route on the command string.
  */
-export function getHandler(toolName: string, output: unknown): Handler {
+export function getHandler(toolName: string, output: unknown, input?: unknown): Handler {
+  // Native Bash tool — inspect tool_input.command for CLI-aware routing
+  if (toolName === "Bash") {
+    return getBashHandler(input);
+  }
+
   if (toolName.includes("playwright") && toolName.includes("snapshot")) {
     return playwrightHandler;
   }

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -69,7 +69,7 @@ export function handlePostToolUse(raw: string): HookOutput {
   }
 
   // 5. Compress
-  const handler = getHandler(tool_name, tool_response);
+  const handler = getHandler(tool_name, tool_response, tool_input);
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -9,6 +9,7 @@ import { slackHandler } from "../src/handlers/slack";
 import { jsonHandler } from "../src/handlers/json";
 import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
+import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler } from "../src/handlers/bash";
 
 // ---------------------------------------------------------------------------
 // extractText
@@ -737,5 +738,198 @@ describe("stripSshNoise", () => {
     expect(summary).not.toContain("stderr:");
     expect(summary).not.toContain("post-quantum");
     expect(summary).toContain("Hello, world!");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// getBashHandler dispatcher
+// ---------------------------------------------------------------------------
+
+describe("getBashHandler", () => {
+  it("routes Bash tool to shell handler when no command", () => {
+    expect(getHandler("Bash", "output", undefined)).toBe(getBashHandler(undefined));
+  });
+
+  it("routes git diff to gitDiffHandler", () => {
+    expect(getBashHandler({ command: "git diff HEAD" })).toBe(gitDiffHandler);
+  });
+
+  it("routes git show to gitDiffHandler", () => {
+    expect(getBashHandler({ command: "git show abc123" })).toBe(gitDiffHandler);
+  });
+
+  it("routes git log to gitLogHandler", () => {
+    expect(getBashHandler({ command: "git log --oneline -10" })).toBe(gitLogHandler);
+  });
+
+  it("routes terraform plan to terraformPlanHandler", () => {
+    expect(getBashHandler({ command: "terraform plan -out=tfplan" })).toBe(terraformPlanHandler);
+  });
+
+  it("routes unrecognised commands to shellHandler", () => {
+    expect(getBashHandler({ command: "npm test" })).toBe(shellHandler);
+  });
+
+  it("getHandler routes Bash tool name to bash dispatcher", () => {
+    const handler = getHandler("Bash", "output", { command: "git diff HEAD" });
+    expect(handler).toBe(gitDiffHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitDiffHandler
+// ---------------------------------------------------------------------------
+
+const SAMPLE_DIFF = `diff --git a/src/foo.ts b/src/foo.ts
+index abc123..def456 100644
+--- a/src/foo.ts
++++ b/src/foo.ts
+@@ -10,7 +10,7 @@ function doThing() {
+ context line
+-old line
++new line
+ context line
+@@ -50,3 +50,5 @@
+ more context
++added line 1
++added line 2
+diff --git a/src/bar.ts b/src/bar.ts
+index 111111..222222 100644
+--- a/src/bar.ts
++++ b/src/bar.ts
+@@ -1,3 +1,2 @@
+ keep
+-remove this
+`;
+
+describe("gitDiffHandler", () => {
+  it("shows file count and line stats in header", () => {
+    const { summary } = gitDiffHandler("Bash", { stdout: SAMPLE_DIFF, stderr: "", exit_code: 0 });
+    expect(summary).toContain("2 files changed");
+    expect(summary).toContain("+3");
+    expect(summary).toContain("-2");
+  });
+
+  it("lists each changed file with per-file stats", () => {
+    const { summary } = gitDiffHandler("Bash", { stdout: SAMPLE_DIFF, stderr: "", exit_code: 0 });
+    expect(summary).toContain("src/foo.ts");
+    expect(summary).toContain("src/bar.ts");
+  });
+
+  it("shows hunk count per file", () => {
+    const { summary } = gitDiffHandler("Bash", { stdout: SAMPLE_DIFF, stderr: "", exit_code: 0 });
+    expect(summary).toContain("2 hunks");
+    expect(summary).toContain("1 hunk");
+  });
+
+  it("returns no-changes message for empty diff", () => {
+    const { summary } = gitDiffHandler("Bash", { stdout: "", stderr: "", exit_code: 0 });
+    expect(summary).toContain("no changes");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: SAMPLE_DIFF, stderr: "", exit_code: 0 };
+    const { originalSize } = gitDiffHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitLogHandler
+// ---------------------------------------------------------------------------
+
+const ONELINE_LOG = `abc1234 Fix authentication bug in login flow
+def5678 Add new user profile feature
+7890abc Update dependencies to latest versions
+`;
+
+const FULL_LOG = `commit abc1234567890abcdef
+Author: Jane Dev <jane@example.com>
+Date:   Sun Mar 2 10:00:00 2026 -0800
+
+    Fix authentication bug in login flow
+
+    More details about the fix.
+
+commit def5678901234abcde
+Author: John Dev <john@example.com>
+Date:   Sat Mar 1 09:00:00 2026 -0800
+
+    Add new user profile feature
+`;
+
+describe("gitLogHandler", () => {
+  it("handles --oneline format with commit count header", () => {
+    const { summary } = gitLogHandler("Bash", { stdout: ONELINE_LOG, stderr: "", exit_code: 0 });
+    expect(summary).toContain("3 commits");
+    expect(summary).toContain("Fix authentication bug");
+  });
+
+  it("handles full format and extracts subject lines", () => {
+    const { summary } = gitLogHandler("Bash", { stdout: FULL_LOG, stderr: "", exit_code: 0 });
+    expect(summary).toContain("2 commits");
+    expect(summary).toContain("Fix authentication bug in login flow");
+    expect(summary).toContain("Add new user profile feature");
+  });
+
+  it("truncates at 20 commits with overflow count", () => {
+    const manyCommits = Array.from({ length: 25 }, (_, i) => `abc${String(i).padStart(4, "0")} commit ${i}`).join("\n");
+    const { summary } = gitLogHandler("Bash", { stdout: manyCommits, stderr: "", exit_code: 0 });
+    expect(summary).toContain("+5 more commits");
+  });
+
+  it("returns no-commits message for empty log", () => {
+    const { summary } = gitLogHandler("Bash", { stdout: "", stderr: "", exit_code: 0 });
+    expect(summary).toContain("no commits");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// terraformPlanHandler
+// ---------------------------------------------------------------------------
+
+const SAMPLE_PLAN = `
+Terraform used the selected providers to generate the following execution
+plan. Resource actions are indicated with the following symbols:
+  + create
+  ~ update in-place
+  - destroy
+
+Terraform will perform the following actions:
+
+  # aws_instance.web will be created
+  + resource "aws_instance" "web" {
+      + ami = "ami-12345678"
+    }
+
+  # aws_security_group.main will be updated in-place
+  ~ resource "aws_security_group" "main" {
+      ~ ingress = []
+    }
+
+  # aws_s3_bucket.old will be destroyed
+  - resource "aws_s3_bucket" "old" {}
+
+Plan: 2 to add, 1 to change, 1 to destroy.
+`;
+
+describe("terraformPlanHandler", () => {
+  it("includes the Plan: summary line", () => {
+    const { summary } = terraformPlanHandler("Bash", { stdout: SAMPLE_PLAN, stderr: "", exit_code: 0 });
+    expect(summary).toContain("Plan: 2 to add, 1 to change, 1 to destroy");
+  });
+
+  it("lists each resource with action symbol", () => {
+    const { summary } = terraformPlanHandler("Bash", { stdout: SAMPLE_PLAN, stderr: "", exit_code: 0 });
+    expect(summary).toContain("+ aws_instance.web");
+    expect(summary).toContain("~ aws_security_group.main");
+    expect(summary).toContain("- aws_s3_bucket.old");
+  });
+
+  it("falls back to shell handler for non-plan output", () => {
+    const plainOutput = { stdout: "Initializing the backend...\nSuccess!", stderr: "", exit_code: 0 };
+    const { summary } = terraformPlanHandler("Bash", plainOutput);
+    // Falls back to shellHandler — no terraform-specific content, just plain output
+    expect(summary).toContain("lines");
   });
 });


### PR DESCRIPTION
## Summary
- Extends the `PostToolUse` hook matcher from `mcp__*`-only to also capture the native `Bash` tool (`(mcp__(?!recall__).*|Bash)`)
- Adds `src/handlers/bash.ts` with a `getBashHandler(input)` factory that inspects `tool_input.command` and routes to three CLI-aware handlers:
  - **`gitDiffHandler`** — file-level summary showing files changed, +/- lines per file, and hunk count (falls back to shell on binary/unrecognised diffs)
  - **`gitLogHandler`** — capped at 20 commits; handles both `--oneline` and full format; extracts short hash + subject line
  - **`terraformPlanHandler`** — extracts `Plan: X to add…` summary + per-resource action symbols (`+`/`~`/`-`); falls back to shell for non-plan output
- All unrecognised commands fall through to `shellHandler` (ANSI stripping, 50-line cap, structured JSON support)
- Wires `tool_input` through `getHandler(toolName, output, input?)` with no breaking changes to existing handlers

## Test plan
- [x] `bun test` — 318 pass, 0 fail
- [x] Dispatcher routing: git diff/show → gitDiffHandler, git log → gitLogHandler, terraform plan → terraformPlanHandler, other → shellHandler, Bash with no input → shellHandler
- [x] `gitDiffHandler`: file count + stats header, per-file listing, hunk count, empty diff message, originalSize
- [x] `gitLogHandler`: oneline format, full format, 20-commit truncation, empty log message
- [x] `terraformPlanHandler`: Plan: line, per-resource symbols, fallback for non-plan output
- [x] End-to-end smoke test: `git diff` via hook → 48% reduction, clean file summary

Closes #25