### PR TITLE
feat: Tavily web search compression handler

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -6076,6 +6076,76 @@ ${lines.join(`
   };
 };
 
+// src/handlers/tavily.ts
+var SNIPPET_CHARS = 150;
+var MAX_RESULTS = 10;
+function summariseResult(result) {
+  const parts = [];
+  if (typeof result["title"] === "string" && result["title"].length > 0) {
+    parts.push(result["title"]);
+  }
+  if (typeof result["url"] === "string") {
+    parts.push(result["url"]);
+  }
+  const content = typeof result["content"] === "string" ? result["content"] : "";
+  if (content.length > 0) {
+    const snippet = content.slice(0, SNIPPET_CHARS).trimEnd();
+    const truncated = content.length > SNIPPET_CHARS ? "\u2026" : "";
+    parts.push(`${snippet}${truncated}`);
+  }
+  return parts.join(" \xB7 ");
+}
+var tavilyHandler = (_toolName, output) => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  if (typeof parsed !== "object" || parsed === null) {
+    return { summary: String(parsed), originalSize };
+  }
+  const obj = parsed;
+  const lines = [];
+  if (typeof obj["query"] === "string" && obj["query"].length > 0) {
+    lines.push(`Query: ${obj["query"]}`);
+  }
+  if (typeof obj["answer"] === "string" && obj["answer"].length > 0) {
+    lines.push(`Answer: ${obj["answer"]}`);
+  }
+  const results = Array.isArray(obj["results"]) ? obj["results"] : [];
+  if (results.length > 0) {
+    const shown = results.slice(0, MAX_RESULTS);
+    const more = results.length > MAX_RESULTS ? results.length - MAX_RESULTS : 0;
+    lines.push(`Results (${results.length}):`);
+    for (const result of shown) {
+      if (typeof result === "object" && result !== null) {
+        lines.push(`  ${summariseResult(result)}`);
+      }
+    }
+    if (more > 0) {
+      lines.push(`  \u2026and ${more} more`);
+    }
+  }
+  if (lines.length === 0) {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  return { summary: lines.join(`
+`), originalSize };
+};
+
 // src/handlers/csv.ts
 var MAX_PREVIEW_ROWS = 5;
 function splitCsvRow(row) {
@@ -6206,6 +6276,9 @@ function getHandler(toolName, output, input) {
   }
   if (toolName.includes("slack")) {
     return slackHandler;
+  }
+  if (toolName.includes("tavily")) {
+    return tavilyHandler;
   }
   if (toolName.includes("csv")) {
     return csvHandler;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -6,6 +6,7 @@ import { shellHandler } from "./shell";
 import { getBashHandler } from "./bash";
 import { linearHandler } from "./linear";
 import { slackHandler } from "./slack";
+import { tavilyHandler } from "./tavily";
 import { csvHandler, looksLikeCsv } from "./csv";
 import { jsonHandler } from "./json";
 import { genericHandler } from "./generic";
@@ -25,10 +26,11 @@ export { extractText } from "./types";
  *   5. Shell/bash/remote-exec        → shell handler
  *   6. Linear tools                  → linear handler
  *   7. Slack tools                   → slack handler
- *   8. CSV tools (name-based)        → csv handler
- *   9. Unmatched with JSON output    → json handler
- *  10. CSV content-based fallback    → csv handler
- *  11. Everything else               → generic handler
+ *   8. Tavily search/research        → tavily handler
+ *   9. CSV tools (name-based)        → csv handler
+ *  10. Unmatched with JSON output    → json handler
+ *  11. CSV content-based fallback    → csv handler
+ *  12. Everything else               → generic handler
  *
  * `input` (tool_input) is used for the Bash tool to route on the command string.
  */
@@ -73,6 +75,10 @@ export function getHandler(toolName: string, output: unknown, input?: unknown): 
 
   if (toolName.includes("slack")) {
     return slackHandler;
+  }
+
+  if (toolName.includes("tavily")) {
+    return tavilyHandler;
   }
 
   if (toolName.includes("csv")) {

--- a/src/handlers/tavily.ts
+++ b/src/handlers/tavily.ts
@@ -1,0 +1,95 @@
+/**
+ * Tavily handler — summarises web search/research/extract results.
+ * Keeps the synthesized answer in full, extracts title + URL + 150-char
+ * content snippet per result. Drops raw_content, score, and response_time
+ * entirely. Caps at 10 results.
+ *
+ * Handles: tavily_search, tavily_research, tavily_extract, tavily_crawl.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const SNIPPET_CHARS = 150;
+const MAX_RESULTS = 10;
+
+type JsonObject = Record<string, unknown>;
+
+function summariseResult(result: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof result["title"] === "string" && result["title"].length > 0) {
+    parts.push(result["title"]);
+  }
+  if (typeof result["url"] === "string") {
+    parts.push(result["url"]);
+  }
+  const content = typeof result["content"] === "string" ? result["content"] : "";
+  if (content.length > 0) {
+    const snippet = content.slice(0, SNIPPET_CHARS).trimEnd();
+    const truncated = content.length > SNIPPET_CHARS ? "…" : "";
+    parts.push(`${snippet}${truncated}`);
+  }
+  return parts.join(" · ");
+}
+
+export const tavilyHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  if (typeof parsed !== "object" || parsed === null) {
+    return { summary: String(parsed), originalSize };
+  }
+
+  const obj = parsed as JsonObject;
+  const lines: string[] = [];
+
+  // Query header
+  if (typeof obj["query"] === "string" && obj["query"].length > 0) {
+    lines.push(`Query: ${obj["query"]}`);
+  }
+
+  // Synthesized answer — include in full, it's already a summary
+  if (typeof obj["answer"] === "string" && obj["answer"].length > 0) {
+    lines.push(`Answer: ${obj["answer"]}`);
+  }
+
+  // Results array
+  const results = Array.isArray(obj["results"]) ? (obj["results"] as unknown[]) : [];
+  if (results.length > 0) {
+    const shown = results.slice(0, MAX_RESULTS);
+    const more = results.length > MAX_RESULTS ? results.length - MAX_RESULTS : 0;
+    lines.push(`Results (${results.length}):`);
+    for (const result of shown) {
+      if (typeof result === "object" && result !== null) {
+        lines.push(`  ${summariseResult(result as JsonObject)}`);
+      }
+    }
+    if (more > 0) {
+      lines.push(`  …and ${more} more`);
+    }
+  }
+
+  // Graceful fallback if shape was unexpected
+  if (lines.length === 0) {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  return { summary: lines.join("\n"), originalSize };
+};

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -10,6 +10,7 @@ import { jsonHandler } from "../src/handlers/json";
 import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
 import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler } from "../src/handlers/bash";
+import { tavilyHandler } from "../src/handlers/tavily";
 
 // ---------------------------------------------------------------------------
 // extractText
@@ -931,5 +932,109 @@ describe("terraformPlanHandler", () => {
     const { summary } = terraformPlanHandler("Bash", plainOutput);
     // Falls back to shellHandler — no terraform-specific content, just plain output
     expect(summary).toContain("lines");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// tavilyHandler
+// ---------------------------------------------------------------------------
+
+const TAVILY_SEARCH = JSON.stringify({
+  query: "bun runtime benchmarks",
+  answer: "Bun is a fast all-in-one JavaScript runtime. Benchmarks show it is 3x faster than Node.js for many workloads.",
+  results: [
+    {
+      title: "Bun vs Node.js Performance",
+      url: "https://example.com/bun-benchmarks",
+      content: "Bun achieves significant speed improvements over Node.js in HTTP throughput and startup time.",
+      raw_content: "FULL PAGE CONTENT ".repeat(500),
+      score: 0.98,
+    },
+    {
+      title: "Runtime Comparison 2026",
+      url: "https://example.com/comparison",
+      content: "Comparing Bun, Deno, and Node.js across a variety of workloads including I/O and CPU tasks.",
+      raw_content: "FULL PAGE CONTENT ".repeat(500),
+      score: 0.91,
+    },
+  ],
+  response_time: 1.23,
+});
+
+describe("tavilyHandler", () => {
+  it("includes the query in the summary", () => {
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(summary).toContain("bun runtime benchmarks");
+  });
+
+  it("includes the synthesized answer in full", () => {
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(summary).toContain("3x faster than Node.js");
+  });
+
+  it("includes result titles and URLs", () => {
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(summary).toContain("Bun vs Node.js Performance");
+    expect(summary).toContain("https://example.com/bun-benchmarks");
+  });
+
+  it("includes a content snippet for each result", () => {
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(summary).toContain("significant speed improvements");
+  });
+
+  it("drops raw_content and score — summary is much smaller than original", () => {
+    const { summary, originalSize } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(Buffer.byteLength(summary, "utf8")).toBeLessThan(originalSize * 0.1);
+  });
+
+  it("truncates content snippets at 150 characters", () => {
+    const longContent = "x".repeat(300);
+    const input = JSON.stringify({
+      query: "test",
+      results: [{ title: "T", url: "https://example.com", content: longContent, raw_content: "", score: 1 }],
+    });
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", input);
+    expect(summary).toContain("…");
+  });
+
+  it("caps results at 10 with overflow count", () => {
+    const manyResults = Array.from({ length: 15 }, (_, i) => ({
+      title: `Result ${i}`,
+      url: `https://example.com/${i}`,
+      content: `Content for result ${i}`,
+      raw_content: "",
+      score: 0.9,
+    }));
+    const input = JSON.stringify({ query: "test", results: manyResults });
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", input);
+    expect(summary).toContain("5 more");
+    expect(summary).not.toContain("Result 14");
+  });
+
+  it("works without an answer field", () => {
+    const input = JSON.stringify({
+      query: "no answer",
+      results: [{ title: "T", url: "https://example.com", content: "some content", raw_content: "", score: 1 }],
+    });
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", input);
+    expect(summary).toContain("no answer");
+    expect(summary).toContain("some content");
+  });
+
+  it("falls back gracefully for non-JSON output", () => {
+    const { summary } = tavilyHandler("mcp__tavily__tavily_search", "plain text response");
+    expect(summary).toContain("plain text response");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = tavilyHandler("mcp__tavily__tavily_search", TAVILY_SEARCH);
+    expect(originalSize).toBe(Buffer.byteLength(TAVILY_SEARCH, "utf8"));
+  });
+
+  it("routes tavily tools to tavily handler", () => {
+    expect(getHandler("mcp__tavily__tavily_search", "{}")).toBe(tavilyHandler);
+    expect(getHandler("mcp__tavily__tavily_research", "{}")).toBe(tavilyHandler);
+    expect(getHandler("mcp__tavily__tavily_extract", "{}")).toBe(tavilyHandler);
   });
 });


### PR DESCRIPTION
## Summary
- Adds `src/handlers/tavily.ts` — extracts query, synthesized answer, and per-result title/URL/150-char snippet; drops `raw_content`, `score`, and `response_time` entirely; caps at 10 results with overflow count
- Wires into dispatch table at position 8 (after Slack, before CSV) matching any tool name containing `tavily`
- Covers all four Tavily tools: `tavily_search`, `tavily_research`, `tavily_extract`, `tavily_crawl`

## Test plan
- [x] `bun test` — 329 pass, 0 fail
- [x] Query header included in output
- [x] Synthesized answer included in full
- [x] Result titles and URLs present
- [x] Content snippets truncated at 150 chars with ellipsis
- [x] `raw_content` dropped — summary is <10% of original size
- [x] 10-result cap with overflow count
- [x] Works without `answer` field (tavily_extract shape)
- [x] Graceful fallback for non-JSON output
- [x] Dispatcher routing: `tavily_search`, `tavily_research`, `tavily_extract` all route to `tavilyHandler`