### PR TITLE
chore: GitHub Actions CI — tests, typecheck, bundle freshness

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,51 @@
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+    branches: [main]
+
+jobs:
+  test:
+    name: Test & typecheck
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Typecheck
+        run: bun run typecheck
+
+      - name: Tests
+        run: bun test
+
+  bundle-freshness:
+    name: Bundle freshness
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: oven-sh/setup-bun@v2
+        with:
+          bun-version: latest
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Rebuild bundle
+        run: bun run build
+
+      - name: Check dist/ is up to date
+        run: |
+          if ! git diff --exit-code plugins/mcp-recall/dist/ plugins/mcp-recall/hooks/; then
+            echo ""
+            echo "dist/ is out of sync with src/. Run 'bun run build' and commit the result."
+            exit 1
+          fi


### PR DESCRIPTION
## Summary
- Adds `.github/workflows/ci.yml` with two jobs running on push to `main` and all PRs
- **Test & typecheck**: `bun install --frozen-lockfile` → `tsc --noEmit` → `bun test`
- **Bundle freshness**: `bun run build` → `git diff --exit-code plugins/mcp-recall/dist/` — fails if `dist/` is out of sync with `src/`

## Test plan
- [x] Workflow syntax is valid YAML
- [x] Uses `oven-sh/setup-bun@v2` — the official Bun GitHub Action
- [x] `--frozen-lockfile` prevents silent dependency drift in CI
- [x] Bundle freshness catches the case where someone edits `src/` without running `bun run build` (the pre-commit hook handles this locally, CI catches it if bypassed)
- [x] No untrusted input interpolated in any `run:` step

Closes #35