### PR TITLE
chore: v1.0.0 release docs + SECURITY.md

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,72 +4,53 @@ All notable changes to mcp-recall are documented here.
 
 ---
 
-## v1.0.0 — 2026-03-01
+## v1.0.0 — 2026-03-02
 
-Initial release.
+Initial public release.
 
-### Core pipeline
+### Hook pipeline
 
-- **PostToolUse hook** intercepts all `mcp__*` tool outputs (except `mcp__recall__*`), compresses them, stores full content in SQLite, and returns a brief summary to Claude.
-- **SessionStart hook** records each active day and prunes expired entries.
+- **PostToolUse hook** intercepts all `mcp__*` tool outputs and the native `Bash` tool. Compresses, stores full content in SQLite, and returns a brief summary to Claude. Deduplicates identical calls via `sha256(tool_name + input)` — repeated calls return a `[cached]` header without re-compression.
+- **SessionStart hook** records each active day, prunes expired entries, and injects a compact context snapshot before the first message (pinned items, notes, recently accessed items). Capped at 2000 chars with a truncation notice.
 - **Denylist** — built-in glob patterns block credential tools (`*secret*`, `*token*`, `*password*`, `*key*`, `*auth*`, `mcp__1password__*`, etc.). Configurable via `denylist.additional` and `denylist.override_defaults`.
 - **Secret detection** — 10 patterns (PEM headers, SSH private keys, GitHub PATs, OpenAI, Anthropic, AWS, Bearer tokens). Outputs matching any pattern are skipped and logged.
 - **Project key** — stable 16-char SHA256 hash of the git root path; falls back to CWD.
 - **Config** — TOML at `~/.config/mcp-recall/config.toml` (Zod-validated); override via `RECALL_CONFIG_PATH`.
 
-### Compression handlers (v1)
+### Compression handlers
 
-Playwright (accessibility tree), GitHub (key fields), Filesystem (50-line head), JSON (depth-3 truncation), Generic text (500-char truncation).
+| Handler | Matches | Strategy |
+|---------|---------|----------|
+| Bash | native `Bash` tool | CLI-aware: git diff → file-level stats; git log → 20-commit cap; terraform plan → resource actions; fallback → shell |
+| Playwright | `playwright` + `snapshot` in tool name | Interactive elements, visible text, headings. Drops aria noise. |
+| GitHub | `mcp__github__*` | Number, title, state, body (200 chars), labels, URL. First 10 + overflow. |
+| Shell | `bash`, `shell`, `terminal`, `run_command`, `ssh_exec`, `exec_command`, `remote_exec`, `container_exec` | ANSI + SSH noise stripping. Structured JSON support. 50-line stdout cap, 20-line stderr cap. |
+| Linear | `linear` in tool name | Identifier, title, state, priority, description (200 chars), URL. |
+| Slack | `slack` in tool name | Channel, timestamp, user, message text (200 chars). First 10 + overflow. |
+| Tavily | `tavily` in tool name | Query, synthesized answer, per-result title/URL/150-char snippet. Drops raw_content/score. First 10 + overflow. |
+| Filesystem | `mcp__filesystem__*` or `read_file`/`get_file` | Line count + first 50 lines. |
+| CSV | `csv` in tool name or content-based | Headers + first 5 data rows + row/col count. |
+| Generic JSON | Unmatched JSON output | Depth-3 limit, arrays capped at 3 items. |
+| Generic text | Everything else | First 500 chars. |
 
-### MCP tools (v1)
+### MCP server tools
 
-`recall__retrieve`, `recall__search`, `recall__forget`, `recall__list_stored`, `recall__stats`.
+Ten `recall__*` tools available in every Claude session:
 
----
+- **`recall__retrieve`** — fetch stored content by ID; pass `query` for an FTS excerpt focused on the relevant section
+- **`recall__search`** — FTS search (BM25) across all stored outputs; each result includes a content snippet
+- **`recall__forget`** — delete by id / tool / session / age / all; `force: true` overrides pin protection
+- **`recall__list_stored`** — paginated browse; sortable by recent, accessed count, or size
+- **`recall__stats`** — aggregate efficiency report with pin suggestions and stale item alerts
+- **`recall__pin`** — pin/unpin items; pinned items are exempt from expiry and LFU eviction
+- **`recall__note`** — store arbitrary text as project memory; searchable like any stored item
+- **`recall__export`** — JSON dump of all stored items, oldest-first
+- **`recall__session_summary`** — per-session digest: tool breakdown, top accessed, pinned items, notes
+- **`recall__context`** — session orientation: pinned items, notes, recently accessed, last session headline
 
-## v2.0.0 — 2026-03-01
+### Storage
 
-### Features
-
-- **`recall__pin`** — pin/unpin items; pinned items are exempt from expiry, LFU eviction, and bulk-forget (unless `force: true`).
-- **`recall__note`** — store arbitrary text as project memory; searchable and retrievable like any other item.
-- **`recall__export`** — JSON dump of all stored items, oldest-first.
-- **Access tracking** — `access_count` and `last_accessed` on every retrieval; `sort: "accessed"` in `recall__list_stored`; LFU eviction when store exceeds `max_size_mb`.
-- **Auto-dedup** — `sha256(tool_name + input)` fingerprint; identical repeated calls return a `[cached]` header without re-compression or a second DB write.
-- **FTS snippets** — `recall__retrieve(id, query)` returns a focused excerpt via `snippet()` rather than a full content slice.
-
-### Additional handlers
-
-CSV (header + 5 data rows), Linear (identifier, title, state, priority, URL), Slack (channel, timestamp, user, text; capped at 10 messages).
-
----
-
-## v3.0.0 — 2026-03-02
-
-### Features
-
-- **FTS chunking** — full content split into overlapping 512-char chunks (64-char overlap) stored in a `content_chunks` FTS5 table. `recall__retrieve(id, query)` uses chunk-based retrieval first (verbatim match) with a legacy `snippet()` fallback for pre-v3 items.
-
----
-
-## v4.0.0 — 2026-03-02
-
-### Features
-
-- **`recall__session_summary`** — digest of a single session or calendar day: item count, compression savings, tool breakdown, top-5 accessed items, pinned items, notes. Filter by `session_id` or `date` (YYYY-MM-DD, defaults today UTC).
-
----
-
-## v5.0.0 — 2026-03-02
-
-### Features
-
-- **`recall__context`** — single-call session orientation: pinned items, unpinned notes, recently accessed items (configurable `days` lookback, default 7), and a one-line last-session headline. Each item appears in exactly one section. Call at the start of every session.
-
----
-
-## v6.0.0 — 2026-03-02
-
-### Features
-
-- **Shell handler** — dedicated compression for `bash`, `shell`, `terminal`, and `run_command` tools. Strips ANSI escape codes. Parses structured `{stdout, stderr, returncode}` JSON; falls back to plain string. Caps stdout at 50 lines and stderr at 20 lines with overflow counts.
+- SQLite + FTS5 at `~/.local/share/mcp-recall/<project-key>.db`
+- FTS chunking — content split into overlapping 512-char chunks for precise snippet retrieval on long documents
+- Access tracking — `access_count` and `last_accessed` per item; LFU eviction when store exceeds `max_size_mb`
+- Session-day expiry — counts active Claude Code days, not calendar days; vacations don't drain your stored context

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -38,7 +38,7 @@ The pre-commit hook (`bun install` wires it automatically) detects staged `src/`
 - New features require tests. Bug fixes require regression tests.
 - Test files: `tests/<module>.test.ts` using Bun's native test runner.
 - Name tests: `"<what> <expected>"` — e.g. `"storeOutput returns hydrated row"`.
-- All 276 tests must pass before opening a PR.
+- All tests must pass before opening a PR (`bun test`).
 - Call `resetConfig()` in `afterEach` for config tests to prevent cache bleed.
 - Use `":memory:"` for DB tests and call `closeDb()` in `afterEach`.
 

--- a/README.md
+++ b/README.md
@@ -79,8 +79,8 @@ Sessions that used to hit context limits in 30 minutes routinely run for 3+ hour
 
 **Two hooks, one MCP server.**
 
-- `SessionStart` hook — records each active day for session-scoped expiry
-- `PostToolUse` hook — intercepts MCP tool outputs; deduplicates identical calls; compresses, stores, and returns summary
+- `SessionStart` hook — records each active day, prunes expired items, and injects a compact context snapshot before the first message
+- `PostToolUse` hook — intercepts MCP tool outputs and native Bash commands; deduplicates identical calls; compresses, stores, and returns summary
 - `recall` MCP server — exposes ten tools for retrieval, search, memory, and management
 
 > **Scope**: Compression applies to MCP tools only. Claude Code's `PostToolUse` hook can replace MCP tool output via `updatedMCPToolOutput`. Built-in tools (Read, Bash, Grep) don't support output replacement — their full output still enters context directly. See [Scope](#scope) for details and the recommended workaround.
@@ -163,6 +163,14 @@ key = "git_root"
 # non-pinned items are evicted when this limit is exceeded.
 max_size_mb = 500
 
+# Access count threshold for pin suggestions in recall__stats.
+# Items accessed at least this many times will appear as pin candidates.
+pin_recommendation_threshold = 5
+
+# Days since creation before a never-accessed item appears as a stale candidate
+# in recall__stats. Helps identify stored output that was never retrieved.
+stale_item_days = 3
+
 [retrieve]
 # Max bytes returned by recall__retrieve() when no query is provided.
 # Claude can override this per-call via the max_bytes parameter.
@@ -222,6 +230,7 @@ recall__search(query, tool?, limit?)
 ```
 
 - FTS search (BM25 ranking) across all stored tool outputs for the current project
+- Each result includes a `> …excerpt…` snippet from the matching content
 - Filter by tool name with `tool` (substring match — e.g. `"github"` matches all `mcp__github__*` tools)
 - Default `limit`: 5 results
 
@@ -328,7 +337,13 @@ Session stats for current project:
   Saved:             98.2% reduction
   ~Tokens saved:     ~84,000
   Session days:      4
+
+Suggestions:
+  📌 Pin candidates (accessed ≥5×): recall_ab12 mcp__playwright__browser_snapshot
+  🗑  Stale items (never accessed, >3 days): recall_cd34 mcp__github__list_issues
 ```
+
+The Suggestions section is omitted when nothing qualifies — no noise on fresh projects. Thresholds are configurable via `pin_recommendation_threshold` and `stale_item_days`.
 
 ---
 
@@ -425,11 +440,13 @@ Repeated identical tool calls return a cached header instead of re-compressing:
 
 | Handler | Matches | Strategy |
 |---|---|---|
+| Bash | native `Bash` tool | CLI-aware routing on `tool_input.command`: `git diff`/`git show` → changed-files summary with per-file +/- stats; `git log` → 20-commit cap; `terraform plan` → resource action symbols + Plan: summary; everything else → shell handler. |
 | Playwright | tool name contains `playwright` and `snapshot` | Interactive elements (buttons, inputs, links), visible text, headings. Drops aria noise. |
 | GitHub | `mcp__github__*` | Number, title, state, body (200 chars), labels, URL. Lists: first 10 + overflow count. |
-| Shell | tool name contains `bash`, `shell`, `terminal`, or `run_command` | Strips ANSI escape codes. Parses structured `{stdout, stderr, returncode}` JSON; falls back to plain text. Stdout: first 50 lines + overflow count. Stderr: first 20 lines, shown in a separate section. Exit code in header. |
+| Shell | tool name contains `bash`, `shell`, `terminal`, `run_command`, `ssh_exec`, `exec_command`, `remote_exec`, or `container_exec` | Strips ANSI escape codes and SSH post-quantum advisory noise. Parses structured `{stdout, stderr, returncode}` JSON; falls back to plain text. Stdout: first 50 lines + overflow count. Stderr: first 20 lines, shown in a separate section. Exit code in header. |
 | Linear | tool name contains `linear` | Identifier, title, state, priority (numeric → label), description excerpt (200 chars), URL. Handles single, array, GraphQL, and Relay shapes. |
 | Slack | tool name contains `slack` | Channel, formatted timestamp, user/display name, message text (200 chars). Handles `{ok, messages}` wrappers and bare arrays. Lists: first 10 + overflow count. |
+| Tavily | tool name contains `tavily` | Query header, synthesized answer in full, per-result title + URL + 150-char content snippet. Drops `raw_content`, `score`, `response_time`. Lists: first 10 + overflow count. |
 | Filesystem | `mcp__filesystem__*` or tool name contains `read_file` / `get_file` | Line count header + first 50 lines + truncation notice. |
 | CSV | tool name contains `csv`, or content-based detection | Column headers + first 5 data rows as key=value pairs + row/col count. Handles quoted fields. |
 | Generic JSON | Any unmatched tool with JSON output | 3-level depth limit, arrays capped at 3 items with overflow count. |
@@ -463,11 +480,14 @@ Extend the defaults via `denylist.additional`. Replace them entirely via `denyli
 
 ## Scope
 
-**Compression applies to MCP tools only.**
+**Compression applies to MCP tools and the native Bash built-in.**
 
-Claude Code's `PostToolUse` hook can replace MCP tool output via `updatedMCPToolOutput`. Built-in tools (Read, Bash, Grep, Glob) don't support output replacement — their full output still enters context directly and mcp-recall has no way to intercept it.
+Claude Code's `PostToolUse` hook supports output replacement for MCP tools and the `Bash` tool. mcp-recall intercepts both:
 
-If your biggest context consumers are built-in tool calls, consider switching to MCP equivalents where possible — for example, the [filesystem MCP server](https://github.com/modelcontextprotocol/servers) instead of the built-in Read tool.
+- **MCP tools** (`mcp__*`) — all compression handlers apply (Playwright, GitHub, filesystem, shell/remote-exec, Linear, Slack, Tavily, CSV, JSON, generic text)
+- **Bash** — CLI-aware handlers: `git diff` → file-level changed-files summary; `git log` → 20-commit cap; `terraform plan` → resource action summary; everything else → 50-line shell cap with ANSI stripping
+
+The remaining built-in tools — `Read`, `Grep`, `Glob` — do not support output replacement. Their full output enters context directly. If large file reads are your biggest context consumer, consider the [filesystem MCP server](https://github.com/modelcontextprotocol/servers) instead of the built-in Read tool.
 
 ---
 
@@ -642,6 +662,15 @@ Issues and PRs welcome. For significant changes, open an issue first to discuss 
 ### v6 — shipped
 
 - **Shell handler** — dedicated compression for bash/shell/terminal/run_command tools: strips ANSI escape codes, parses structured `{stdout, stderr, returncode}` JSON, caps stdout at 50 lines and stderr at 20 lines with overflow counts.
+
+### v1.0.0 — shipped
+
+- **Tavily handler** — extracts query, synthesized answer, and per-result title/URL/150-char snippet; drops `raw_content`, `score`, `response_time`; caps at 10 results.
+- **Shell handler extended** — covers remote-exec MCP tools (`ssh_exec`, `exec_command`, `remote_exec`, `container_exec`); strips OpenSSH post-quantum advisory noise.
+- **SessionStart context injection** — auto-injects pinned items, notes, and recently accessed items before the first message of every session; capped at 2000 chars.
+- **`recall__search` snippets** — each search result now includes a `> …excerpt…` line from the matching content.
+- **`recall__stats` suggestions** — pin candidates (frequently accessed non-pinned items) and stale item alerts; both thresholds configurable.
+- **Bash compression** — native `Bash` tool intercepted with CLI-aware handlers: `git diff`/`git show`, `git log`, `terraform plan`; everything else falls through to shell handler.
 
 ---
 

--- a/SECURITY.md
+++ b/SECURITY.md
@@ -1,0 +1,66 @@
+# Security Policy
+
+## What mcp-recall stores
+
+All stored data lives locally at `~/.local/share/mcp-recall/`. Nothing is sent to any
+external service. The SQLite database contains full MCP tool outputs — treat it with the
+same care as your shell history.
+
+To wipe stored data:
+
+```
+recall__forget(all: true, confirmed: true)
+```
+
+Or directly:
+
+```bash
+rm -rf ~/.local/share/mcp-recall/
+```
+
+## Secret detection
+
+Before writing any tool output to disk, mcp-recall scans the content for these patterns:
+
+| Pattern | Catches |
+|---------|---------|
+| PEM headers | `-----BEGIN RSA PRIVATE KEY-----` etc. |
+| SSH private keys | OpenSSH private key blocks |
+| GitHub PATs | `ghp_*`, `github_pat_*` (classic and fine-grained) |
+| OpenAI API keys | `sk-*` |
+| Anthropic API keys | `sk-ant-*` |
+| AWS access key IDs | `AKIA*`, `ASIA*` |
+| Generic Bearer tokens | `Authorization: Bearer ...` |
+
+On a match: the output is skipped, nothing is written to disk, a warning is logged to
+stderr, and the full uncompressed output passes through to Claude unchanged.
+
+## Denylist
+
+These tool name patterns are **never stored**, regardless of content:
+
+`mcp__recall__*`, `mcp__1password__*`, `*secret*`, `*token*`, `*password*`,
+`*credential*`, `*key*`, `*auth*`, `*env*`
+
+To add your own patterns:
+
+```toml
+[denylist]
+additional = ["mcp__myservice__get_credentials"]
+```
+
+## Limitations
+
+Detection is pattern-based. It won't catch:
+
+- Custom or internal secret formats
+- Secrets encoded in base64 or other encodings
+- Secrets embedded in structured fields (e.g. a JSON value that happens to be a password)
+
+When in doubt, add the tool to the denylist rather than relying on content scanning.
+
+## Reporting a vulnerability
+
+Please use [GitHub private vulnerability reporting](https://github.com/sakebomb/mcp-recall/security/advisories/new).
+
+For non-sensitive issues, open a regular [GitHub issue](https://github.com/sakebomb/mcp-recall/issues).


### PR DESCRIPTION
## Summary
- **README**: Scope section rewritten (Bash is intercepted), SessionStart description updated, handler table adds Bash + Tavily rows + Shell remote-exec patterns, `recall__search` snippet note, `recall__stats` suggestions note, config section adds `pin_recommendation_threshold` + `stale_item_days`, Roadmap v1.0.0 entry
- **CHANGELOG**: Collapsed internal v1–v6 iterations into a single clean v1.0.0 entry documenting the full shipped feature set
- **CONTRIBUTING.md**: Removed hardcoded test count — `bun test` is the source of truth
- **SECURITY.md**: New file — secret detection scope, denylist, limitations, private vulnerability reporting link

## Test plan
- [x] README Scope section accurately describes what is/isn't intercepted
- [x] No duplicate `[store]` TOML headers in config example
- [x] CHANGELOG v1.0.0 entry covers all shipped features (handlers, tools, storage)
- [x] SECURITY.md private reporting link points to correct GitHub URL
- [x] `bun test` — 329 pass, 0 fail (no code changes in this PR)