### PR TITLE
feat: debug mode (RECALL_DEBUG=1 / config.debug.enabled)

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -4948,6 +4948,9 @@ var RecallConfigSchema = exports_external.object({
   denylist: exports_external.object({
     additional: exports_external.array(exports_external.string()),
     override_defaults: exports_external.array(exports_external.string())
+  }),
+  debug: exports_external.object({
+    enabled: exports_external.boolean()
   })
 });
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
@@ -4965,6 +4968,9 @@ var DEFAULTS = {
   denylist: {
     additional: [],
     override_defaults: []
+  },
+  debug: {
+    enabled: false
   }
 };
 function getConfigPath() {
@@ -5371,6 +5377,14 @@ function toolContext(db, projectKey, args) {
 `);
 }
 
+// src/debug.ts
+function dbg(msg) {
+  if (process.env.RECALL_DEBUG || loadConfig().debug.enabled) {
+    process.stderr.write(`[recall:debug] ${msg}
+`);
+  }
+}
+
 // src/hooks/session-start.ts
 var INJECT_MAX_CHARS = 2000;
 function handleSessionStart(raw) {
@@ -5391,6 +5405,9 @@ function handleSessionStart(raw) {
     }
     process.stdout.write(snapshot + `
 `);
+    dbg(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 injected ${snapshot.length} chars`);
+  } else {
+    dbg(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 nothing to inject`);
   }
 }
 
@@ -6307,9 +6324,11 @@ function handlePostToolUse(raw) {
   const { tool_name, tool_input, tool_response, cwd, session_id } = input;
   const config = loadConfig();
   if (isDenied(tool_name, config)) {
+    dbg(`SKIP denylist \xB7 ${tool_name}`);
     return {};
   }
   const fullContent = extractText(tool_response);
+  dbg(`intercepted ${tool_name} \xB7 ${formatBytes2(Buffer.byteLength(fullContent, "utf8"))}`);
   if (containsSecret(fullContent)) {
     const names = findSecrets(fullContent);
     process.stderr.write(`[recall] skipped ${tool_name}: detected ${names.join(", ")}
@@ -6323,6 +6342,7 @@ function handlePostToolUse(raw) {
     const cached2 = checkDedup(db, projectKey, input_hash);
     if (cached2) {
       const cachedDate = new Date(cached2.created_at * 1000).toISOString().slice(0, 10);
+      dbg(`CACHE HIT \xB7 ${tool_name} \xB7 id=${cached2.id} \xB7 cached ${cachedDate}`);
       const header2 = `[recall:${cached2.id} \xB7 cached \xB7 ${cachedDate}]`;
       return {
         updatedMCPToolOutput: `${header2}
@@ -6332,9 +6352,11 @@ ${cached2.summary}`,
     }
   }
   const handler = getHandler(tool_name, tool_response, tool_input);
+  dbg(`handler: ${handler.name} \xB7 ${tool_name}`);
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
   if (summarySize >= originalSize) {
+    dbg(`SKIP no-compression \xB7 ${tool_name} \xB7 ${formatBytes2(summarySize)} \u2265 ${formatBytes2(originalSize)}`);
     return {};
   }
   const stored = storeOutput(db, {
@@ -6348,6 +6370,7 @@ ${cached2.summary}`,
   });
   evictIfNeeded(db, projectKey, config.store.max_size_mb);
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
+  dbg(`STORED \xB7 ${tool_name} \xB7 id=${stored.id} \xB7 ${formatBytes2(originalSize)}\u2192${formatBytes2(summarySize)} (${reduction}% reduction)`);
   const header = `[recall:${stored.id} \xB7 ${formatBytes2(originalSize)}\u2192${formatBytes2(summarySize)} (${reduction}% reduction)]`;
   return {
     updatedMCPToolOutput: `${header}
@@ -6379,6 +6402,10 @@ async function main() {
         process.exit(1);
     }
   } catch (err) {
+    if (process.env.RECALL_DEBUG) {
+      process.stderr.write(`[recall:debug] STACK: ${err instanceof Error ? err.stack : String(err)}
+`);
+    }
     process.stderr.write(`[recall] error in ${subcommand}: ${err}
 `);
     process.stdout.write(`{}

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20795,6 +20795,9 @@ var RecallConfigSchema = exports_external.object({
   denylist: exports_external.object({
     additional: exports_external.array(exports_external.string()),
     override_defaults: exports_external.array(exports_external.string())
+  }),
+  debug: exports_external.object({
+    enabled: exports_external.boolean()
   })
 });
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
@@ -20812,6 +20815,9 @@ var DEFAULTS = {
   denylist: {
     additional: [],
     override_defaults: []
+  },
+  debug: {
+    enabled: false
   }
 };
 function getConfigPath() {

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -31,6 +31,9 @@ async function main(): Promise<void> {
     }
   } catch (err) {
     // Fail open — a recall error must never break Claude's workflow
+    if (process.env.RECALL_DEBUG) {
+      process.stderr.write(`[recall:debug] STACK: ${err instanceof Error ? err.stack : String(err)}\n`);
+    }
     process.stderr.write(`[recall] error in ${subcommand}: ${err}\n`);
     process.stdout.write("{}\n");
     process.exit(0);

--- a/src/config.ts
+++ b/src/config.ts
@@ -19,6 +19,9 @@ const RecallConfigSchema = z.object({
     additional: z.array(z.string()),
     override_defaults: z.array(z.string()),
   }),
+  debug: z.object({
+    enabled: z.boolean(),
+  }),
 });
 
 const PartialConfigSchema = RecallConfigSchema.deepPartial();
@@ -39,6 +42,9 @@ const DEFAULTS: RecallConfig = {
   denylist: {
     additional: [],
     override_defaults: [],
+  },
+  debug: {
+    enabled: false,
   },
 };
 

--- a/src/debug.ts
+++ b/src/debug.ts
@@ -1,0 +1,7 @@
+import { loadConfig } from "./config";
+
+export function dbg(msg: string): void {
+  if (process.env.RECALL_DEBUG || loadConfig().debug.enabled) {
+    process.stderr.write(`[recall:debug] ${msg}\n`);
+  }
+}

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -5,6 +5,7 @@ import { isDenied } from "../denylist";
 import { containsSecret, findSecrets } from "../secrets";
 import { getHandler, extractText } from "../handlers/index";
 import { getDb, defaultDbPath, storeOutput, checkDedup, evictIfNeeded } from "../db/index";
+import { dbg } from "../debug";
 
 interface PostToolUseInput {
   session_id: string;
@@ -33,11 +34,13 @@ export function handlePostToolUse(raw: string): HookOutput {
 
   // 1. Denylist check
   if (isDenied(tool_name, config)) {
+    dbg(`SKIP denylist · ${tool_name}`);
     return {};
   }
 
   // 2. Extract text and check for secrets
   const fullContent = extractText(tool_response);
+  dbg(`intercepted ${tool_name} · ${formatBytes(Buffer.byteLength(fullContent, "utf8"))}`);
   if (containsSecret(fullContent)) {
     const names = findSecrets(fullContent);
     process.stderr.write(`[recall] skipped ${tool_name}: detected ${names.join(", ")}\n`);
@@ -60,6 +63,7 @@ export function handlePostToolUse(raw: string): HookOutput {
     const cached = checkDedup(db, projectKey, input_hash);
     if (cached) {
       const cachedDate = new Date(cached.created_at * 1000).toISOString().slice(0, 10);
+      dbg(`CACHE HIT · ${tool_name} · id=${cached.id} · cached ${cachedDate}`);
       const header = `[recall:${cached.id} · cached · ${cachedDate}]`;
       return {
         updatedMCPToolOutput: `${header}\n${cached.summary}`,
@@ -70,11 +74,13 @@ export function handlePostToolUse(raw: string): HookOutput {
 
   // 5. Compress
   const handler = getHandler(tool_name, tool_response, tool_input);
+  dbg(`handler: ${handler.name} · ${tool_name}`);
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
 
   // 6. Only store when compression is meaningful
   if (summarySize >= originalSize) {
+    dbg(`SKIP no-compression · ${tool_name} · ${formatBytes(summarySize)} ≥ ${formatBytes(originalSize)}`);
     return {};
   }
 
@@ -94,6 +100,7 @@ export function handlePostToolUse(raw: string): HookOutput {
 
   // 9. Return compressed output to Claude
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
+  dbg(`STORED · ${tool_name} · id=${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)`);
   const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)]`;
   return {
     updatedMCPToolOutput: `${header}\n${summary}`,

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -2,6 +2,7 @@ import { loadConfig } from "../config";
 import { getProjectKey } from "../project-key";
 import { getDb, defaultDbPath, recordSession, pruneExpired, getContext } from "../db/index";
 import { toolContext } from "../tools";
+import { dbg } from "../debug";
 
 interface SessionStartInput {
   session_id: string;
@@ -39,5 +40,8 @@ export function handleSessionStart(raw: string): void {
         "\n… (truncated — call recall__context for the full view)";
     }
     process.stdout.write(snapshot + "\n");
+    dbg(`session-start · project=${projectKey.slice(0, 8)} · injected ${snapshot.length} chars`);
+  } else {
+    dbg(`session-start · project=${projectKey.slice(0, 8)} · nothing to inject`);
   }
 }

--- a/tasks/lessons.md
+++ b/tasks/lessons.md
@@ -11,6 +11,15 @@ Learnings captured after corrections. Updated after any mistake or course correc
 
 ---
 
+## Claude Code Plugin Installation
+
+**Pattern**: Installing a local Claude Code plugin not yet in a marketplace
+**Mistake**: `claude plugin install ./path` only works for marketplace-registered plugins — fails with "Plugin not found in any configured marketplace"
+**Rule**: For local installs, add MCP server to `~/.claude.json` under `mcpServers`, and add hooks to `~/.claude/settings.json` under `hooks`. Use absolute paths (no `CLAUDE_PLUGIN_ROOT`). MCP server schema: `{type:"stdio", command:"bun", args:["/abs/path/dist/server.js"]}`.
+**Date**: 2026-03-02
+
+---
+
 ## Git
 
 **Pattern**: Pushing commits to GitHub repos with email privacy enabled

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,44 +4,51 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-Issue #34 — housekeeping
+### #55 — debug mode (`RECALL_DEBUG=1` + `config.debug.enabled`)
 
-## Planned batches
+**Files:**
 
-### PR A — mechanical fixes (quick wins)
-- [ ] `LICENSE` file (MIT)
-- [ ] `CLAUDE.md` — update phases table (all complete) + tool list (5→10)
-- [ ] `tasks/todo.md` — "v3 complete" → "v6 complete"
-- [ ] `package.json` — add license, repository, bugs, homepage, author, engines, keywords
-- [ ] `.gitignore` — add .DS_Store, .idea/, .vscode/, *.swp etc.
-- [ ] Remove dead `pin_recommendation_threshold` from `src/config.ts` (defined but never used)
-- [ ] `.gitignore` note: `bun.lock` already tracked (text format); `bun.lockb` (binary) correctly ignored — close that checklist item
+| File | Change |
+|------|--------|
+| `src/debug.ts` | NEW — `dbg(msg)`: checks env var OR config, writes `[recall:debug] …` to stderr |
+| `src/config.ts` | Add `[debug]` section to Zod schema + defaults (`enabled: false`) |
+| `src/hooks/post-tool-use.ts` | 5 `dbg()` calls: denylist skip, intercepted size, dedup hit, handler name, no-compression skip, stored |
+| `src/hooks/session-start.ts` | 2 `dbg()` calls: injected Xchars / nothing to inject |
+| `src/cli.ts` | In catch block: print full stack trace when `RECALL_DEBUG` set |
+| `tests/debug.test.ts` | NEW — unit tests for `dbg()`: silent, env-var activation, config activation |
+| `tests/hooks.test.ts` | New describe block: 5 pipeline debug output tests |
+| `tests/config.test.ts` | 2 tests: `debug.enabled` reads from TOML, defaults to false |
 
-### PR B — JSDoc + handler headers
-- [ ] JSDoc for all 19+ exported functions/types in `src/db/index.ts`
-- [ ] File-level header comments for handler files that lack them
+**Key decisions:**
+- Dual activation: `RECALL_DEBUG=1` (temporary) or `[debug] enabled = true` in config.toml (persistent)
+- Secret warning stays always-on (security event) — no change to line 43 in post-tool-use.ts
+- `handler.name` used for logging — all handlers are named const exports, no API change needed
+- Never log tool input values or response content in debug output — names and sizes only
 
-### PR C — README updates
-- [ ] Document `recall__forget` input parameter schema (mode, id, tool, session, age, all, force)
-- [ ] Document `recall__search` input parameters (query, tool, limit)
-- [ ] Fix architecture diagram ("5 recall__* tools" → "10")
-- [ ] Remove `pin_recommendation_threshold` from config docs (or keep if re-implemented)
+**Log format:**
+```
+[recall:debug] intercepted mcp__playwright__snapshot · 56.2KB
+[recall:debug] handler: playwrightHandler · mcp__playwright__snapshot
+[recall:debug] STORED · mcp__playwright__snapshot · id=recall_a1b2c3d4 · 56.2KB→299B (99%)
 
-### PR D — contributor files
-- [ ] `CONTRIBUTING.md`
-- [ ] `CHANGELOG.md` (v1–v6 summary)
-- [ ] `bunfig.toml`
-- [ ] `.github/ISSUE_TEMPLATE/bug_report.md`
-- [ ] `.github/ISSUE_TEMPLATE/feature_request.md`
-- [ ] `.github/PULL_REQUEST_TEMPLATE.md`
+[recall:debug] SKIP denylist · mcp__1password__item_lookup
+[recall:debug] CACHE HIT · mcp__github__get_pr · id=recall_a1b2c3d4 · cached 2026-03-01
+[recall:debug] SKIP no-compression · mcp__small__tool · 80B ≥ 95B
+[recall:debug] session-start · project=abc12345 · injected 1.4KB
+```
 
-### PR E — hooks dedup
-- [ ] Build script copies root `hooks/hooks.json` → `plugins/mcp-recall/hooks/hooks.json`
-- [ ] Delete `plugins/mcp-recall/hooks/hooks.json` as a standalone tracked file
+**Branch:** `feat/debug-mode`
 
-### PR F — release tags
-- [ ] Tag v1.0.0 through v1.6.0 at the appropriate commits
-- [ ] Create GitHub releases for each
+## Recently Completed (2026-03-02)
+
+- Installed plugin manually: MCP server in `~/.claude.json`, hooks in `~/.claude/settings.json`
+- Awaiting first restart + end-to-end test
+
+## Open Issues
+
+| # | Title | Priority | Size | Notes |
+|---|-------|----------|------|-------|
+| #35 | feat: GitHub Actions CI — tests, typecheck, bundle freshness | P2: Medium | M | Deferred — waiting on self-hosted runner setup |
 
 ## Blocked
 

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -75,4 +75,15 @@ describe("loadConfig", () => {
     expect(config.store.max_size_mb).toBe(256);
     expect((config.store as Record<string, unknown>).unknown_key).toBeUndefined();
   });
+
+  it("debug.enabled defaults to false", () => {
+    const config = loadConfig();
+    expect(config.debug.enabled).toBe(false);
+  });
+
+  it("debug.enabled reads true from TOML", () => {
+    writeFileSync(TEST_CONFIG_PATH, "[debug]\nenabled = true\n");
+    const config = loadConfig();
+    expect(config.debug.enabled).toBe(true);
+  });
 });

--- a/tests/debug.test.ts
+++ b/tests/debug.test.ts
@@ -1,0 +1,66 @@
+import { describe, it, expect, afterEach, spyOn } from "bun:test";
+import { writeFileSync, unlinkSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { dbg } from "../src/debug";
+import { resetConfig } from "../src/config";
+
+const TEST_CONFIG_PATH = join(tmpdir(), `mcp-recall-debug-test-${process.pid}.toml`);
+
+function captureStderr(fn: () => void): string {
+  const spy = spyOn(process.stderr, "write");
+  fn();
+  const output = spy.mock.calls.map(([c]) => String(c)).join("");
+  spy.mockRestore();
+  return output;
+}
+
+describe("dbg", () => {
+  afterEach(() => {
+    delete process.env.RECALL_DEBUG;
+    delete process.env.RECALL_CONFIG_PATH;
+    resetConfig();
+    try { unlinkSync(TEST_CONFIG_PATH); } catch {}
+  });
+
+  it("writes nothing when RECALL_DEBUG is unset and config.debug.enabled is false", () => {
+    process.env.RECALL_CONFIG_PATH = TEST_CONFIG_PATH;
+    writeFileSync(TEST_CONFIG_PATH, "[debug]\nenabled = false\n");
+    resetConfig();
+    const output = captureStderr(() => dbg("should not appear"));
+    expect(output).toBe("");
+  });
+
+  it("writes nothing when no config exists and RECALL_DEBUG is unset", () => {
+    process.env.RECALL_CONFIG_PATH = TEST_CONFIG_PATH;
+    // no config file written — ENOENT triggers defaults (debug.enabled = false)
+    const output = captureStderr(() => dbg("should not appear"));
+    expect(output).toBe("");
+  });
+
+  it("writes to stderr when RECALL_DEBUG=1", () => {
+    process.env.RECALL_DEBUG = "1";
+    const output = captureStderr(() => dbg("test message"));
+    expect(output).toBe("[recall:debug] test message\n");
+  });
+
+  it("writes to stderr when RECALL_DEBUG is any truthy string", () => {
+    process.env.RECALL_DEBUG = "true";
+    const output = captureStderr(() => dbg("truthy check"));
+    expect(output).toContain("[recall:debug]");
+  });
+
+  it("writes to stderr when config.debug.enabled is true", () => {
+    process.env.RECALL_CONFIG_PATH = TEST_CONFIG_PATH;
+    writeFileSync(TEST_CONFIG_PATH, "[debug]\nenabled = true\n");
+    resetConfig();
+    const output = captureStderr(() => dbg("config-based debug"));
+    expect(output).toBe("[recall:debug] config-based debug\n");
+  });
+
+  it("output always starts with [recall:debug] prefix", () => {
+    process.env.RECALL_DEBUG = "1";
+    const output = captureStderr(() => dbg("prefix check"));
+    expect(output).toMatch(/^\[recall:debug\]/);
+  });
+});

--- a/tests/denylist.test.ts
+++ b/tests/denylist.test.ts
@@ -12,6 +12,7 @@ const baseConfig: RecallConfig = {
   },
   retrieve: { default_max_bytes: 8192 },
   denylist: { additional: [], override_defaults: [] },
+  debug: { enabled: false },
 };
 
 function withDenylist(

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -366,3 +366,95 @@ describe("handlePostToolUse", () => {
     }
   });
 });
+
+// ---------------------------------------------------------------------------
+// handlePostToolUse — debug output
+// ---------------------------------------------------------------------------
+
+function captureStderr(fn: () => void): string {
+  const spy = spyOn(process.stderr, "write");
+  fn();
+  const output = spy.mock.calls.map(([c]) => String(c)).join("");
+  spy.mockRestore();
+  return output;
+}
+
+describe("handlePostToolUse — debug output", () => {
+  beforeEach(() => {
+    process.env.RECALL_DEBUG = "1";
+    process.env.RECALL_DB_PATH = ":memory:";
+  });
+
+  afterEach(() => {
+    closeDb();
+    resetConfig();
+    delete process.env.RECALL_DEBUG;
+    delete process.env.RECALL_DB_PATH;
+  });
+
+  it("logs SKIP denylist for denied tools", () => {
+    const output = captureStderr(() =>
+      handlePostToolUse(
+        makePostToolUseInput("mcp__1password__item_lookup", { content: [{ type: "text", text: "x" }] })
+      )
+    );
+    expect(output).toContain("SKIP denylist");
+    expect(output).toContain("mcp__1password__item_lookup");
+  });
+
+  it("logs SKIP no-compression when output is too small to compress", () => {
+    const output = captureStderr(() =>
+      handlePostToolUse(
+        makePostToolUseInput("mcp__github__list_issues", { content: [{ type: "text", text: "tiny" }] })
+      )
+    );
+    expect(output).toContain("SKIP no-compression");
+  });
+
+  it("logs CACHE HIT on second call with same tool_input", () => {
+    const input = makePostToolUseInput(
+      "mcp__github__list_issues",
+      { content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }] },
+      { tool_input: { owner: "org", repo: "repo" } }
+    );
+    handlePostToolUse(input);
+    const output = captureStderr(() => handlePostToolUse(input));
+    expect(output).toContain("CACHE HIT");
+    expect(output).toContain("mcp__github__list_issues");
+  });
+
+  it("logs STORED with id and reduction on successful compression", () => {
+    const output = captureStderr(() =>
+      handlePostToolUse(
+        makePostToolUseInput("mcp__github__list_issues", {
+          content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+        })
+      )
+    );
+    expect(output).toContain("STORED");
+    expect(output).toContain("reduction");
+  });
+
+  it("logs handler name on successful compression", () => {
+    const output = captureStderr(() =>
+      handlePostToolUse(
+        makePostToolUseInput("mcp__github__list_issues", {
+          content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+        })
+      )
+    );
+    expect(output).toContain("handler:");
+    expect(output).toContain("githubHandler");
+  });
+
+  it("logs intercepted size after extractText", () => {
+    const output = captureStderr(() =>
+      handlePostToolUse(
+        makePostToolUseInput("mcp__github__list_issues", {
+          content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+        })
+      )
+    );
+    expect(output).toContain("intercepted mcp__github__list_issues");
+  });
+});


### PR DESCRIPTION
## Summary
- Adds `RECALL_DEBUG=1` env var and `[debug] enabled = true` config option that emit structured `[recall:debug]` logs to stderr for every hook pipeline decision
- All 9 steps in `post-tool-use` are now observable: denylist skip, intercepted size, cache hit, handler selected, no-compression skip, stored with id + reduction %
- `session-start` logs injected char count or nothing-to-inject
- Full stack traces surface on hook errors when debug is active
- 14 new tests; 343 total passing

## Test plan
- [ ] `bun test` — 343 pass
- [ ] `bun run typecheck` — clean
- [ ] `RECALL_DEBUG=1 claude` — verify `[recall:debug]` lines appear in stderr during a session
- [ ] Set `[debug] enabled = true` in `~/.config/mcp-recall/config.toml` — verify same output without env var

Closes #55