### PR TITLE
chore: VACUUM after bulk deletes, PRAGMA optimize on startup

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5121,6 +5121,7 @@ function getDb(path) {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
+  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19578,6 +19578,7 @@ function getDb(path) {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
+  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;
@@ -19690,25 +19691,28 @@ function countAndDelete(db, where, params) {
   }
   return count;
 }
+var VACUUM_THRESHOLD = 50;
 function forgetOutputs(db, project_key, options) {
   const pinGuard = options.force ? "" : "AND pinned = 0";
+  let deleted = 0;
   if (options.all) {
-    return countAndDelete(db, `project_key = ? ${pinGuard}`, [project_key]);
-  }
-  if (options.id) {
-    return countAndDelete(db, "id = ? AND project_key = ?", [options.id, project_key]);
-  }
-  if (options.tool) {
-    return countAndDelete(db, `tool_name = ? AND project_key = ? ${pinGuard}`, [options.tool, project_key]);
-  }
-  if (options.session_id) {
-    return countAndDelete(db, `session_id = ? AND project_key = ? ${pinGuard}`, [options.session_id, project_key]);
-  }
-  if (options.older_than_days !== undefined) {
+    deleted = countAndDelete(db, `project_key = ? ${pinGuard}`, [project_key]);
+  } else if (options.id) {
+    deleted = countAndDelete(db, "id = ? AND project_key = ?", [options.id, project_key]);
+  } else if (options.tool) {
+    deleted = countAndDelete(db, `tool_name = ? AND project_key = ? ${pinGuard}`, [options.tool, project_key]);
+  } else if (options.session_id) {
+    deleted = countAndDelete(db, `session_id = ? AND project_key = ? ${pinGuard}`, [options.session_id, project_key]);
+  } else if (options.older_than_days !== undefined) {
     const cutoff = Math.floor(Date.now() / 1000) - options.older_than_days * 86400;
-    return countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
+    deleted = countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
   }
-  return 0;
+  if (deleted >= VACUUM_THRESHOLD) {
+    try {
+      db.run("VACUUM");
+    } catch {}
+  }
+  return deleted;
 }
 function getStats(db, project_key) {
   const row = db.prepare(`

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -215,6 +215,7 @@ export function getDb(path: string): Database {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
+  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;
@@ -481,31 +482,36 @@ function countAndDelete(db: Database, where: string, params: SQLQueryBindings[])
  * Exactly one selector (`id`, `tool`, `session_id`, `older_than_days`, or `all`) should be set.
  * Returns the number of items deleted.
  */
+/** Minimum number of deleted rows that triggers a VACUUM to reclaim disk space. */
+const VACUUM_THRESHOLD = 50;
+
 export function forgetOutputs(
   db: Database,
   project_key: string,
   options: ForgetOptions
 ): number {
   const pinGuard = options.force ? "" : "AND pinned = 0";
+  let deleted = 0;
 
   if (options.all) {
-    return countAndDelete(db, `project_key = ? ${pinGuard}`, [project_key]);
-  }
-  if (options.id) {
+    deleted = countAndDelete(db, `project_key = ? ${pinGuard}`, [project_key]);
+  } else if (options.id) {
     // Single-item delete: ignore pin guard (explicit ID targets are intentional)
-    return countAndDelete(db, "id = ? AND project_key = ?", [options.id, project_key]);
-  }
-  if (options.tool) {
-    return countAndDelete(db, `tool_name = ? AND project_key = ? ${pinGuard}`, [options.tool, project_key]);
-  }
-  if (options.session_id) {
-    return countAndDelete(db, `session_id = ? AND project_key = ? ${pinGuard}`, [options.session_id, project_key]);
-  }
-  if (options.older_than_days !== undefined) {
+    deleted = countAndDelete(db, "id = ? AND project_key = ?", [options.id, project_key]);
+  } else if (options.tool) {
+    deleted = countAndDelete(db, `tool_name = ? AND project_key = ? ${pinGuard}`, [options.tool, project_key]);
+  } else if (options.session_id) {
+    deleted = countAndDelete(db, `session_id = ? AND project_key = ? ${pinGuard}`, [options.session_id, project_key]);
+  } else if (options.older_than_days !== undefined) {
     const cutoff = Math.floor(Date.now() / 1000) - options.older_than_days * 86400;
-    return countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
+    deleted = countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
   }
-  return 0;
+
+  if (deleted >= VACUUM_THRESHOLD) {
+    try { db.run("VACUUM"); } catch {}
+  }
+
+  return deleted;
 }
 
 /** Returns aggregate storage stats (counts, sizes, compression ratio) for a project. */

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -250,6 +250,26 @@ describe("db", () => {
       const results = searchOutputs(db, "findme", { project_key: PROJECT_KEY });
       expect(results.length).toBe(0);
     });
+
+    it("bulk delete of 50+ items does not throw and returns correct count", () => {
+      for (let i = 0; i < 55; i++) {
+        storeOutput(db, makeInput({ summary: `bulk item ${i}` }));
+      }
+      expect(() => {
+        const deleted = forgetOutputs(db, PROJECT_KEY, { all: true });
+        expect(deleted).toBe(55);
+      }).not.toThrow();
+    });
+
+    it("data integrity is preserved after bulk delete triggers VACUUM", () => {
+      const survivor = storeOutput(db, makeInput({ project_key: "other-project", summary: "keep me" }));
+      for (let i = 0; i < 55; i++) {
+        storeOutput(db, makeInput({ summary: `vacuum-test item ${i}` }));
+      }
+      forgetOutputs(db, PROJECT_KEY, { all: true });
+      expect(retrieveOutput(db, survivor.id)).not.toBeNull();
+      expect(retrieveOutput(db, survivor.id)!.summary).toBe("keep me");
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary
- `getDb()`: adds `PRAGMA optimize` after existing PRAGMAs — hints SQLite to update query planner stats; fast and safe on every open
- `forgetOutputs()`: runs `VACUUM` when ≥ 50 rows are deleted to reclaim disk space; wrapped in try/catch so `:memory:` DBs and any edge cases are silently safe
- 2 new tests: bulk delete (55 items) doesn't throw and returns correct count; data integrity is preserved after VACUUM runs

## Test plan
- [ ] `bun test` — 331 pass
- [ ] `bun run typecheck` — clean
- [ ] Run `recall__forget` with `all: true` on a project with 50+ stored items — no error, DB file size decreases

Closes #57