### PR TITLE
chore: update todo for v1.3.0

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,11 +16,18 @@ _nothing scheduled — see backlog below_
 
 | # | Title | Priority | Notes |
 |---|-------|----------|-------|
-| #49 | Jira community handler | P2 | Good first issue — point at CONTRIBUTING.md |
 | #50 | Notion community handler | P2 | Good first issue |
 | #51 | Database results handler | P2 | Good first issue |
 | #52 | Sentry handler | P2 | Good first issue |
 | #53 | GitLab handler | P2 | Good first issue |
+| #79 | Stripe profile | P2 | Good first issue — strong candidate to author ourselves |
+| #80 | Airtable profile | P2 | Good first issue |
+| #81 | Grafana profile | P2 | Good first issue |
+| #82 | Datadog profile | P2 | Good first issue |
+| #83 | Xero profile | P2 | Good first issue |
+| #84 | Chargebee profile | P2 | Good first issue |
+| #85 | Microsoft Teams profile | P2 | Good first issue |
+| #86 | Shopify profile | P2 | Good first issue |
 | Claude Code | Runtime config via `/mcp` | — | On hold |
 | OpenCode | `tool.execute.after` output mod | — | On hold, v2.0 |
 | Layer 2 | `recall__register_profile` MCP tool | — | On hold, v2.0 — when MCPs self-describe |


### PR DESCRIPTION
## Summary

- Remove closed #49 (Jira — now bundled in community profiles)
- Add #79–#86 (Stripe, Airtable, Grafana, Datadog, Xero, Chargebee, Teams, Shopify profile issues)

## Test plan

- [ ] No code changes — todo.md only