### PR TITLE
chore: remove closed issues from todo

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,18 +16,9 @@ _nothing scheduled — see backlog below_
 
 | # | Title | Priority | Notes |
 |---|-------|----------|-------|
-| #50 | Notion community handler | P2 | Good first issue |
 | #51 | Database results handler | P2 | Good first issue |
 | #52 | Sentry handler | P2 | Good first issue |
 | #53 | GitLab handler | P2 | Good first issue |
-| #79 | Stripe profile | P2 | Good first issue — strong candidate to author ourselves |
-| #80 | Airtable profile | P2 | Good first issue |
-| #81 | Grafana profile | P2 | Good first issue |
-| #82 | Datadog profile | P2 | Good first issue |
-| #83 | Xero profile | P2 | Good first issue |
-| #84 | Chargebee profile | P2 | Good first issue |
-| #85 | Microsoft Teams profile | P2 | Good first issue |
-| #86 | Shopify profile | P2 | Good first issue |
 | Claude Code | Runtime config via `/mcp` | — | On hold |
 | OpenCode | `tool.execute.after` output mod | — | On hold, v2.0 |
 | Layer 2 | `recall__register_profile` MCP tool | — | On hold, v2.0 — when MCPs self-describe |


### PR DESCRIPTION
## Summary
- Removes #50 (Notion) and #79–#86 (Stripe/Airtable/Grafana/Datadog/Xero/Chargebee/Teams/Shopify) from todo.md — all authored and merged into mcp-recall-profiles
- Only #51, #52, #53 remain as open good-first-issues

## Test plan
- [ ] No code changes — docs/task file only