### PR TITLE
feat: add GitLab, database, and Sentry compression handlers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,18 @@ All notable changes to mcp-recall are documented here.
 
 ---
 
+## v1.4.0 — 2026-03-03
+
+### Three new TypeScript compression handlers
+
+**GitLab** (`mcp__gitlab__*`) — mirrors the GitHub handler with GitLab field names: `iid` (internal ID), `title`, `state`, `description` excerpt (200 chars), `labels` (plain string array), `web_url`. Single items and arrays (first 10 + overflow count).
+
+**Database query results** (tool name contains `postgres`, `mysql`, `sqlite`, or `database`) — handles three common response shapes: node-postgres `{rows, fields}`, bare array of row objects, and `{results}` wrapper. Emits row/column count header, column names, and first 10 rows as `col=value` pairs.
+
+**Sentry error events** (tool name contains `sentry`) — extracts exception type + message, level, environment, release, and abbreviated event ID. Shows the last 8 stack frames (innermost/most relevant). Drops breadcrumbs, SDK metadata, and full request headers — typically reduces 15–50 KB events by 95%+.
+
+---
+
 ## v1.3.0 — 2026-03-03
 
 ### `mcp-recall profiles test`

--- a/README.md
+++ b/README.md
@@ -43,10 +43,13 @@ Sessions that used to hit context limits in 30 minutes routinely run for 3+ hour
                │                        │
                │  Playwright → elements │
                │  GitHub     → fields   │
+               │  GitLab     → fields   │
                │  Shell      → 50 lines │
                │  Linear     → issues   │
                │  Slack      → messages │
                │  Tavily     → answer   │
+               │  Database   → rows     │
+               │  Sentry     → exception│
                │  Filesystem → 50 lines │
                │  CSV        → row/col  │
                │  JSON       → depth 3  │
@@ -244,10 +247,13 @@ Repeated identical tool calls return a cached header instead of re-compressing:
 | Bash | native `Bash` tool | CLI-aware routing on `tool_input.command`: `git diff`/`git show` → changed-files summary with per-file +/- stats; `git log` → 20-commit cap; `terraform plan` → resource action symbols + Plan: summary; everything else → shell handler. |
 | Playwright | tool name contains `playwright` and `snapshot` | Interactive elements (buttons, inputs, links), visible text, headings. Drops aria noise. |
 | GitHub | `mcp__github__*` | Number, title, state, body (200 chars), labels, URL. Lists: first 10 + overflow count. |
+| GitLab | `mcp__gitlab__*` | IID, title, state, description excerpt (200 chars), labels, web URL. Lists: first 10 + overflow count. |
 | Shell | tool name contains `bash`, `shell`, `terminal`, `run_command`, `ssh_exec`, `exec_command`, `remote_exec`, or `container_exec` | Strips ANSI escape codes and SSH post-quantum advisory noise. Parses structured `{stdout, stderr, returncode}` JSON; falls back to plain text. Stdout: first 50 lines + overflow count. Stderr: first 20 lines, shown in a separate section. Exit code in header. |
 | Linear | tool name contains `linear` | Identifier, title, state, priority (numeric → label), description excerpt (200 chars), URL. Handles single, array, GraphQL, and Relay shapes. |
 | Slack | tool name contains `slack` | Channel, formatted timestamp, user/display name, message text (200 chars). Handles `{ok, messages}` wrappers and bare arrays. Lists: first 10 + overflow count. |
 | Tavily | tool name contains `tavily` | Query header, synthesized answer in full, per-result title + URL + 150-char content snippet. Drops `raw_content`, `score`, `response_time`. Lists: first 10 + overflow count. |
+| Database | tool name contains `postgres`, `mysql`, `sqlite`, or `database` | Row/column count header, column names, first 10 rows as col=value pairs. Handles node-postgres `{rows, fields}`, bare array, and `{results}` wrapper shapes. |
+| Sentry | tool name contains `sentry` | Exception type + message, level, environment, release, event ID. Last 8 stack frames (innermost/most relevant). Drops breadcrumbs, SDK info, request headers. |
 | Filesystem | `mcp__filesystem__*` or tool name contains `read_file` / `get_file` | Line count header + first 50 lines + truncation notice. |
 | CSV | tool name contains `csv`, or content-based detection | Column headers + first 5 data rows as key=value pairs + row/col count. Handles quoted fields. |
 | Generic JSON | Any unmatched tool with JSON output | 3-level depth limit, arrays capped at 3 items with overflow count. |
@@ -265,7 +271,7 @@ Credential tools are never stored. Password managers are blocked by explicit nam
 
 Claude Code's `PostToolUse` hook supports output replacement for MCP tools and the `Bash` tool. mcp-recall intercepts both:
 
-- **MCP tools** (`mcp__*`) — all compression handlers apply (Playwright, GitHub, filesystem, shell/remote-exec, Linear, Slack, Tavily, CSV, JSON, generic text)
+- **MCP tools** (`mcp__*`) — all compression handlers apply (Playwright, GitHub, GitLab, filesystem, shell/remote-exec, Linear, Slack, Tavily, database query results, Sentry events, CSV, JSON, generic text)
 - **Bash** — CLI-aware handlers: `git diff` → file-level changed-files summary; `git log` → 20-commit cap; `terraform plan` → resource action summary; everything else → 50-line shell cap with ANSI stripping
 
 The remaining built-in tools — `Read`, `Grep`, `Glob` — do not support output replacement. Their full output enters context directly. If large file reads are your biggest context consumer, consider the [filesystem MCP server](https://github.com/modelcontextprotocol/servers) instead of the built-in Read tool.
@@ -334,12 +340,6 @@ See [CONTRIBUTING.md](CONTRIBUTING.md) for project structure, workflow, and how 
 ## What's next
 
 The easiest way to contribute is a TOML profile — no TypeScript, no clone of this repo needed. If you use an MCP that isn't covered, check the [community profiles repo](https://github.com/sakebomb/mcp-recall-profiles) or open a [profile request](https://github.com/sakebomb/mcp-recall/issues/new?template=profile-request.md).
-
-Open requests (profiles preferred):
-
-- [Database results](https://github.com/sakebomb/mcp-recall/issues/51) — column names + first N rows
-- [Sentry](https://github.com/sakebomb/mcp-recall/issues/52) — exception type, message, top stack frames
-- [GitLab](https://github.com/sakebomb/mcp-recall/issues/53) — mirrors the GitHub handler
 
 TypeScript handlers are welcome for tools with complex, non-JSON output (HTML, DOM trees, binary formats) — see [CONTRIBUTING.md](CONTRIBUTING.md).
 

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5682,6 +5682,63 @@ var githubHandler = (_toolName, output) => {
   return { summary: String(parsed), originalSize };
 };
 
+// src/handlers/gitlab.ts
+var DESCRIPTION_EXCERPT_CHARS = 200;
+function summariseItem2(item) {
+  const parts = [];
+  if (typeof item["iid"] === "number")
+    parts.push(`!${item["iid"]}`);
+  else if (typeof item["id"] === "number" && !item["iid"])
+    parts.push(`#${item["id"]}`);
+  if (typeof item["title"] === "string")
+    parts.push(`"${item["title"]}"`);
+  if (typeof item["state"] === "string")
+    parts.push(`[${item["state"]}]`);
+  if (typeof item["name"] === "string" && !item["title"])
+    parts.push(item["name"]);
+  if (typeof item["web_url"] === "string")
+    parts.push(item["web_url"]);
+  const labels = item["labels"];
+  if (Array.isArray(labels) && labels.length > 0) {
+    const names = labels.map((l) => String(l)).join(", ");
+    parts.push(`labels: ${names}`);
+  }
+  const body = item["description"] ?? item["body"];
+  if (typeof body === "string" && body.length > 0) {
+    const excerpt = body.slice(0, DESCRIPTION_EXCERPT_CHARS).trimEnd();
+    const truncated = body.length > DESCRIPTION_EXCERPT_CHARS ? "\u2026" : "";
+    parts.push(`description: ${excerpt}${truncated}`);
+  }
+  return parts.join(" \xB7 ");
+}
+var gitlabHandler = (_toolName, output) => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  if (Array.isArray(parsed)) {
+    const items = parsed;
+    const lines = items.slice(0, 10).map((item) => typeof item === "object" && item !== null ? summariseItem2(item) : String(item));
+    const more = items.length > 10 ? `
+\u2026and ${items.length - 10} more` : "";
+    return { summary: lines.join(`
+`) + more, originalSize };
+  }
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summariseItem2(parsed), originalSize };
+  }
+  return { summary: String(parsed), originalSize };
+};
+
 // src/handlers/filesystem.ts
 var HEAD_LINES = 50;
 var filesystemHandler = (_toolName, output) => {
@@ -6223,8 +6280,154 @@ var tavilyHandler = (_toolName, output) => {
 `), originalSize };
 };
 
+// src/handlers/database.ts
+var MAX_PREVIEW_ROWS = 10;
+var MAX_COLS_DISPLAY = 8;
+function formatRow(index, row, cols) {
+  const pairs = cols.slice(0, MAX_COLS_DISPLAY).map((col) => {
+    const val = row[col];
+    const str = val === null || val === undefined ? "NULL" : String(val);
+    return `${col}=${str.length > 50 ? str.slice(0, 50) + "\u2026" : str}`;
+  }).join(", ");
+  const overflow = cols.length > MAX_COLS_DISPLAY ? ` [+${cols.length - MAX_COLS_DISPLAY} cols]` : "";
+  return `  row ${index + 1}: ${pairs}${overflow}`;
+}
+function extractRows(parsed) {
+  if (typeof parsed === "object" && parsed !== null && Array.isArray(parsed["rows"])) {
+    const obj = parsed;
+    const rows = obj["rows"].filter((r) => typeof r === "object" && r !== null);
+    const fields = obj["fields"];
+    let cols;
+    if (Array.isArray(fields) && fields.length > 0) {
+      cols = fields.map((f) => typeof f === "object" && f !== null && typeof f["name"] === "string" ? String(f["name"]) : "").filter(Boolean);
+    } else {
+      cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+    }
+    return { rows, cols };
+  }
+  if (typeof parsed === "object" && parsed !== null && Array.isArray(parsed["results"])) {
+    const rows = parsed["results"].filter((r) => typeof r === "object" && r !== null);
+    const cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+    return { rows, cols };
+  }
+  if (Array.isArray(parsed)) {
+    const rows = parsed.filter((r) => typeof r === "object" && r !== null);
+    const cols = rows.length > 0 ? Object.keys(rows[0]) : [];
+    return { rows, cols };
+  }
+  return null;
+}
+var databaseHandler = (_toolName, output) => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  const extracted = extractRows(parsed);
+  if (!extracted) {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  const { rows, cols } = extracted;
+  if (rows.length === 0) {
+    return { summary: `[0 rows \xD7 ${cols.length} cols]
+(empty result set)`, originalSize };
+  }
+  const colHeader = `headers: ${cols.slice(0, MAX_COLS_DISPLAY).join(", ")}` + (cols.length > MAX_COLS_DISPLAY ? ` [+${cols.length - MAX_COLS_DISPLAY} more]` : "");
+  const previewRows = rows.slice(0, MAX_PREVIEW_ROWS).map((row, i) => formatRow(i, row, cols));
+  const more = rows.length > MAX_PREVIEW_ROWS ? `
+[\u2026${rows.length - MAX_PREVIEW_ROWS} more rows]` : "";
+  const summary = [
+    `[${rows.length} rows \xD7 ${cols.length} cols]`,
+    colHeader,
+    ...previewRows
+  ].join(`
+`) + more;
+  return { summary, originalSize };
+};
+
+// src/handlers/sentry.ts
+var MAX_FRAMES = 8;
+function formatFrame(frame) {
+  const location = [frame.filename, frame.lineno ? `:${frame.lineno}` : ""].join("");
+  const fn = frame.function ?? "<anonymous>";
+  return `  ${location} in ${fn}`;
+}
+function summariseSentryEvent(event) {
+  const parts = [];
+  const exceptionObj = event["exception"];
+  const values = exceptionObj?.["values"];
+  const firstException = values?.[0];
+  if (firstException) {
+    const type = firstException.type ?? "Error";
+    const msg = firstException.value ?? "(no message)";
+    parts.push(`${type}: ${msg}`);
+  }
+  const meta = [];
+  if (typeof event["level"] === "string")
+    meta.push(`[${event["level"]}]`);
+  if (typeof event["environment"] === "string")
+    meta.push(`env:${event["environment"]}`);
+  if (typeof event["release"] === "string")
+    meta.push(`release:${event["release"]}`);
+  if (typeof event["event_id"] === "string")
+    meta.push(`id:${event["event_id"].slice(0, 8)}`);
+  if (meta.length > 0)
+    parts.push(meta.join(" "));
+  const frames = firstException?.stacktrace?.frames;
+  if (frames && frames.length > 0) {
+    const relevant = frames.slice(-MAX_FRAMES);
+    const skipped = frames.length - relevant.length;
+    const header = skipped > 0 ? `Stack (last ${relevant.length} of ${frames.length} frames):` : `Stack (${frames.length} frame${frames.length === 1 ? "" : "s"}):`;
+    parts.push(header);
+    parts.push(...relevant.map(formatFrame));
+  }
+  return parts.join(`
+`);
+}
+var sentryHandler = (_toolName, output) => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}
+\u2026` : excerpt,
+      originalSize
+    };
+  }
+  if (Array.isArray(parsed)) {
+    const events = parsed;
+    const lines = events.slice(0, 5).map((e) => typeof e === "object" && e !== null ? summariseSentryEvent(e) : String(e));
+    const more = events.length > 5 ? `
+\u2026and ${events.length - 5} more` : "";
+    return { summary: lines.join(`
+---
+`) + more, originalSize };
+  }
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summariseSentryEvent(parsed), originalSize };
+  }
+  return { summary: String(parsed), originalSize };
+};
+
 // src/handlers/csv.ts
-var MAX_PREVIEW_ROWS = 5;
+var MAX_PREVIEW_ROWS2 = 5;
 function splitCsvRow(row) {
   const fields = [];
   let current = "";
@@ -6253,14 +6456,14 @@ var csvHandler = (_toolName, output) => {
   const headerCols = splitCsvRow(lines[0]);
   const dataRows = lines.slice(1);
   const totalRows = dataRows.length;
-  const previewLines = dataRows.slice(0, MAX_PREVIEW_ROWS).map((line, i) => {
+  const previewLines = dataRows.slice(0, MAX_PREVIEW_ROWS2).map((line, i) => {
     const vals = splitCsvRow(line);
     const pairs = headerCols.slice(0, 5).map((col, ci) => `${col}=${vals[ci] ?? ""}`).join(", ");
     const overflow = headerCols.length > 5 ? ` [+${headerCols.length - 5} cols]` : "";
     return `  row ${i + 1}: ${pairs}${overflow}`;
   });
-  const more = totalRows > MAX_PREVIEW_ROWS ? `
-[\u2026${totalRows - MAX_PREVIEW_ROWS} more rows]` : "";
+  const more = totalRows > MAX_PREVIEW_ROWS2 ? `
+[\u2026${totalRows - MAX_PREVIEW_ROWS2} more rows]` : "";
   const summary = [
     `[${totalRows} rows \xD7 ${headerCols.length} cols]`,
     `headers: ${headerCols.slice(0, 10).join(", ")}${headerCols.length > 10 ? ` [+${headerCols.length - 10} more]` : ""}`,
@@ -6642,6 +6845,9 @@ function getHandler(toolName, output, input) {
   if (toolName.startsWith("mcp__github__")) {
     return githubHandler;
   }
+  if (toolName.startsWith("mcp__gitlab__")) {
+    return gitlabHandler;
+  }
   if (toolName.startsWith("mcp__filesystem__") || toolName.includes("read_file") || toolName.includes("get_file")) {
     return filesystemHandler;
   }
@@ -6656,6 +6862,12 @@ function getHandler(toolName, output, input) {
   }
   if (toolName.includes("tavily")) {
     return tavilyHandler;
+  }
+  if (toolName.includes("postgres") || toolName.includes("mysql") || toolName.includes("sqlite") || toolName.includes("database")) {
+    return databaseHandler;
+  }
+  if (toolName.includes("sentry")) {
+    return sentryHandler;
   }
   if (toolName.includes("csv")) {
     return csvHandler;

--- a/src/handlers/database.ts
+++ b/src/handlers/database.ts
@@ -1,0 +1,135 @@
+/**
+ * Database handler — summarises query results from postgres, mysql, sqlite MCPs.
+ * Handles three common response shapes:
+ *   1. node-postgres: { rows: [...], fields: [{ name: "col" }, ...] }
+ *   2. bare array of row objects: [{ col: val, ... }, ...]
+ *   3. results wrapper: { results: [...] }
+ *
+ * Emits: row/column count header, column names, first 10 rows as col=value pairs,
+ * and a truncation notice when more rows exist.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const MAX_PREVIEW_ROWS = 10;
+const MAX_COLS_DISPLAY = 8;
+
+type RowObject = Record<string, unknown>;
+
+function formatRow(index: number, row: RowObject, cols: string[]): string {
+  const pairs = cols
+    .slice(0, MAX_COLS_DISPLAY)
+    .map((col) => {
+      const val = row[col];
+      const str = val === null || val === undefined ? "NULL" : String(val);
+      return `${col}=${str.length > 50 ? str.slice(0, 50) + "…" : str}`;
+    })
+    .join(", ");
+  const overflow = cols.length > MAX_COLS_DISPLAY ? ` [+${cols.length - MAX_COLS_DISPLAY} cols]` : "";
+  return `  row ${index + 1}: ${pairs}${overflow}`;
+}
+
+function extractRows(parsed: unknown): { rows: RowObject[]; cols: string[] } | null {
+  // node-postgres shape: { rows: [...], fields: [{ name: "..." }, ...] }
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    Array.isArray((parsed as Record<string, unknown>)["rows"])
+  ) {
+    const obj = parsed as Record<string, unknown>;
+    const rows = (obj["rows"] as unknown[]).filter(
+      (r): r is RowObject => typeof r === "object" && r !== null
+    );
+    const fields = obj["fields"];
+    let cols: string[];
+    if (Array.isArray(fields) && fields.length > 0) {
+      cols = (fields as unknown[])
+        .map((f) =>
+          typeof f === "object" && f !== null && typeof (f as Record<string, unknown>)["name"] === "string"
+            ? String((f as Record<string, unknown>)["name"])
+            : ""
+        )
+        .filter(Boolean);
+    } else {
+      cols = rows.length > 0 ? Object.keys(rows[0]!) : [];
+    }
+    return { rows, cols };
+  }
+
+  // results wrapper: { results: [...] }
+  if (
+    typeof parsed === "object" &&
+    parsed !== null &&
+    Array.isArray((parsed as Record<string, unknown>)["results"])
+  ) {
+    const rows = ((parsed as Record<string, unknown>)["results"] as unknown[]).filter(
+      (r): r is RowObject => typeof r === "object" && r !== null
+    );
+    const cols = rows.length > 0 ? Object.keys(rows[0]!) : [];
+    return { rows, cols };
+  }
+
+  // bare array of row objects
+  if (Array.isArray(parsed)) {
+    const rows = (parsed as unknown[]).filter(
+      (r): r is RowObject => typeof r === "object" && r !== null
+    );
+    const cols = rows.length > 0 ? Object.keys(rows[0]!) : [];
+    return { rows, cols };
+  }
+
+  return null;
+}
+
+export const databaseHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  const extracted = extractRows(parsed);
+  if (!extracted) {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  const { rows, cols } = extracted;
+
+  if (rows.length === 0) {
+    return { summary: `[0 rows × ${cols.length} cols]\n(empty result set)`, originalSize };
+  }
+
+  const colHeader =
+    `headers: ${cols.slice(0, MAX_COLS_DISPLAY).join(", ")}` +
+    (cols.length > MAX_COLS_DISPLAY ? ` [+${cols.length - MAX_COLS_DISPLAY} more]` : "");
+
+  const previewRows = rows.slice(0, MAX_PREVIEW_ROWS).map((row, i) => formatRow(i, row, cols));
+
+  const more =
+    rows.length > MAX_PREVIEW_ROWS
+      ? `\n[…${rows.length - MAX_PREVIEW_ROWS} more rows]`
+      : "";
+
+  const summary = [
+    `[${rows.length} rows × ${cols.length} cols]`,
+    colHeader,
+    ...previewRows,
+  ].join("\n") + more;
+
+  return { summary, originalSize };
+};

--- a/src/handlers/gitlab.ts
+++ b/src/handlers/gitlab.ts
@@ -1,0 +1,78 @@
+/**
+ * GitLab handler — summarises GitLab API responses into key fields
+ * (iid, title, state, description excerpt, labels, web_url). Handles both
+ * single objects and arrays. Field names differ from GitHub: iid not number,
+ * description not body, web_url not html_url, labels is a plain string array.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const DESCRIPTION_EXCERPT_CHARS = 200;
+
+type JsonObject = Record<string, unknown>;
+
+function summariseItem(item: JsonObject): string {
+  const parts: string[] = [];
+
+  if (typeof item["iid"] === "number") parts.push(`!${item["iid"]}`);
+  else if (typeof item["id"] === "number" && !item["iid"]) parts.push(`#${item["id"]}`);
+
+  if (typeof item["title"] === "string") parts.push(`"${item["title"]}"`);
+  if (typeof item["state"] === "string") parts.push(`[${item["state"]}]`);
+  if (typeof item["name"] === "string" && !item["title"]) parts.push(item["name"]);
+
+  if (typeof item["web_url"] === "string") parts.push(item["web_url"]);
+
+  const labels = item["labels"];
+  if (Array.isArray(labels) && labels.length > 0) {
+    const names = labels.map((l) => String(l)).join(", ");
+    parts.push(`labels: ${names}`);
+  }
+
+  const body = item["description"] ?? item["body"];
+  if (typeof body === "string" && body.length > 0) {
+    const excerpt = body.slice(0, DESCRIPTION_EXCERPT_CHARS).trimEnd();
+    const truncated = body.length > DESCRIPTION_EXCERPT_CHARS ? "…" : "";
+    parts.push(`description: ${excerpt}${truncated}`);
+  }
+
+  return parts.join(" · ");
+}
+
+export const gitlabHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  if (Array.isArray(parsed)) {
+    const items = parsed as unknown[];
+    const lines = items
+      .slice(0, 10)
+      .map((item) =>
+        typeof item === "object" && item !== null
+          ? summariseItem(item as JsonObject)
+          : String(item)
+      );
+    const more = items.length > 10 ? `\n…and ${items.length - 10} more` : "";
+    return { summary: lines.join("\n") + more, originalSize };
+  }
+
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summariseItem(parsed as JsonObject), originalSize };
+  }
+
+  return { summary: String(parsed), originalSize };
+};

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -1,12 +1,15 @@
 import type { Handler } from "./types";
 import { playwrightHandler } from "./playwright";
 import { githubHandler } from "./github";
+import { gitlabHandler } from "./gitlab";
 import { filesystemHandler } from "./filesystem";
 import { shellHandler } from "./shell";
 import { getBashHandler } from "./bash";
 import { linearHandler } from "./linear";
 import { slackHandler } from "./slack";
 import { tavilyHandler } from "./tavily";
+import { databaseHandler } from "./database";
+import { sentryHandler } from "./sentry";
 import { csvHandler, looksLikeCsv } from "./csv";
 import { jsonHandler } from "./json";
 import { genericHandler } from "./generic";
@@ -24,16 +27,19 @@ export { extractText } from "./types";
  *   2. User / community profile match       → profile handler (beats TypeScript handlers)
  *   3. Playwright browser_snapshot          → playwright handler
  *   4. GitHub tools                         → github handler
- *   5. Filesystem tools                     → filesystem handler
- *   6. Shell/bash/remote-exec               → shell handler
- *   7. Linear tools                         → linear handler
- *   8. Slack tools                          → slack handler
- *   9. Tavily search/research               → tavily handler
- *  10. CSV tools (name-based)               → csv handler
- *  11. Bundled profile match                → profile handler
- *  12. Unmatched with JSON output           → json handler
- *  13. CSV content-based fallback           → csv handler
- *  14. Everything else                      → generic handler
+ *   5. GitLab tools                         → gitlab handler
+ *   6. Filesystem tools                     → filesystem handler
+ *   7. Shell/bash/remote-exec               → shell handler
+ *   8. Linear tools                         → linear handler
+ *   9. Slack tools                          → slack handler
+ *  10. Tavily search/research               → tavily handler
+ *  11. Database query tools                 → database handler
+ *  12. Sentry tools                         → sentry handler
+ *  13. CSV tools (name-based)               → csv handler
+ *  14. Bundled profile match                → profile handler
+ *  15. Unmatched with JSON output           → json handler
+ *  16. CSV content-based fallback           → csv handler
+ *  17. Everything else                      → generic handler
  *
  * `input` (tool_input) is used for the Bash tool to route on the command string.
  */
@@ -53,6 +59,10 @@ export function getHandler(toolName: string, output: unknown, input?: unknown): 
 
   if (toolName.startsWith("mcp__github__")) {
     return githubHandler;
+  }
+
+  if (toolName.startsWith("mcp__gitlab__")) {
+    return gitlabHandler;
   }
 
   if (
@@ -86,6 +96,19 @@ export function getHandler(toolName: string, output: unknown, input?: unknown): 
 
   if (toolName.includes("tavily")) {
     return tavilyHandler;
+  }
+
+  if (
+    toolName.includes("postgres") ||
+    toolName.includes("mysql") ||
+    toolName.includes("sqlite") ||
+    toolName.includes("database")
+  ) {
+    return databaseHandler;
+  }
+
+  if (toolName.includes("sentry")) {
+    return sentryHandler;
   }
 
   if (toolName.includes("csv")) {

--- a/src/handlers/sentry.ts
+++ b/src/handlers/sentry.ts
@@ -1,0 +1,110 @@
+/**
+ * Sentry handler — summarises Sentry error events by extracting the exception
+ * type/message, the last N stack frames (innermost = most relevant), and key
+ * metadata (level, environment, release, event_id).
+ *
+ * Drops: breadcrumbs, SDK info, full request headers, extra frames.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+const MAX_FRAMES = 8;
+
+type JsonObject = Record<string, unknown>;
+
+interface StackFrame {
+  filename?: string;
+  function?: string;
+  lineno?: number;
+  colno?: number;
+  in_app?: boolean;
+}
+
+interface ExceptionValue {
+  type?: string;
+  value?: string;
+  stacktrace?: { frames?: StackFrame[] };
+}
+
+function formatFrame(frame: StackFrame): string {
+  const location = [frame.filename, frame.lineno ? `:${frame.lineno}` : ""].join("");
+  const fn = frame.function ?? "<anonymous>";
+  return `  ${location} in ${fn}`;
+}
+
+function summariseSentryEvent(event: JsonObject): string {
+  const parts: string[] = [];
+
+  // Exception type + value
+  const exceptionObj = event["exception"] as JsonObject | undefined;
+  const values = exceptionObj?.["values"] as ExceptionValue[] | undefined;
+  const firstException = values?.[0];
+
+  if (firstException) {
+    const type = firstException.type ?? "Error";
+    const msg = firstException.value ?? "(no message)";
+    parts.push(`${type}: ${msg}`);
+  }
+
+  // Metadata line
+  const meta: string[] = [];
+  if (typeof event["level"] === "string") meta.push(`[${event["level"]}]`);
+  if (typeof event["environment"] === "string") meta.push(`env:${event["environment"]}`);
+  if (typeof event["release"] === "string") meta.push(`release:${event["release"]}`);
+  if (typeof event["event_id"] === "string") meta.push(`id:${event["event_id"].slice(0, 8)}`);
+  if (meta.length > 0) parts.push(meta.join(" "));
+
+  // Stack frames — ordered innermost-last, so take the last MAX_FRAMES
+  const frames = firstException?.stacktrace?.frames;
+  if (frames && frames.length > 0) {
+    const relevant = frames.slice(-MAX_FRAMES);
+    const skipped = frames.length - relevant.length;
+    const header =
+      skipped > 0
+        ? `Stack (last ${relevant.length} of ${frames.length} frames):`
+        : `Stack (${frames.length} frame${frames.length === 1 ? "" : "s"}):`;
+    parts.push(header);
+    parts.push(...relevant.map(formatFrame));
+  }
+
+  return parts.join("\n");
+}
+
+export const sentryHandler: Handler = (
+  _toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    const excerpt = raw.slice(0, 500).trimEnd();
+    return {
+      summary: excerpt.length < raw.length ? `${excerpt}\n…` : excerpt,
+      originalSize,
+    };
+  }
+
+  // Handle array of events (e.g. list_issues returns multiple events)
+  if (Array.isArray(parsed)) {
+    const events = parsed as unknown[];
+    const lines = events
+      .slice(0, 5)
+      .map((e) =>
+        typeof e === "object" && e !== null
+          ? summariseSentryEvent(e as JsonObject)
+          : String(e)
+      );
+    const more = events.length > 5 ? `\n…and ${events.length - 5} more` : "";
+    return { summary: lines.join("\n---\n") + more, originalSize };
+  }
+
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summariseSentryEvent(parsed as JsonObject), originalSize };
+  }
+
+  return { summary: String(parsed), originalSize };
+};

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1,6 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { playwrightHandler } from "../src/handlers/playwright";
 import { githubHandler } from "../src/handlers/github";
+import { gitlabHandler } from "../src/handlers/gitlab";
 import { filesystemHandler } from "../src/handlers/filesystem";
 import { shellHandler, stripAnsi, stripSshNoise } from "../src/handlers/shell";
 import { csvHandler, looksLikeCsv } from "../src/handlers/csv";
@@ -11,6 +12,8 @@ import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
 import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler } from "../src/handlers/bash";
 import { tavilyHandler } from "../src/handlers/tavily";
+import { databaseHandler } from "../src/handlers/database";
+import { sentryHandler } from "../src/handlers/sentry";
 
 // ---------------------------------------------------------------------------
 // extractText
@@ -1036,5 +1039,280 @@ describe("tavilyHandler", () => {
     expect(getHandler("mcp__tavily__tavily_search", "{}")).toBe(tavilyHandler);
     expect(getHandler("mcp__tavily__tavily_research", "{}")).toBe(tavilyHandler);
     expect(getHandler("mcp__tavily__tavily_extract", "{}")).toBe(tavilyHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitlabHandler
+// ---------------------------------------------------------------------------
+
+describe("gitlabHandler", () => {
+  const SINGLE_ISSUE = JSON.stringify({
+    iid: 12,
+    title: "Fix the pipeline",
+    state: "opened",
+    web_url: "https://gitlab.com/org/repo/-/issues/12",
+    labels: ["bug", "P1"],
+    description: "The pipeline fails on merge requests targeting the main branch.",
+  });
+
+  it("summarises a single issue with iid", () => {
+    const { summary } = gitlabHandler("mcp__gitlab__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("!12");
+    expect(summary).toContain('"Fix the pipeline"');
+    expect(summary).toContain("[opened]");
+  });
+
+  it("includes web_url", () => {
+    const { summary } = gitlabHandler("mcp__gitlab__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("https://gitlab.com/org/repo/-/issues/12");
+  });
+
+  it("includes labels as plain strings", () => {
+    const { summary } = gitlabHandler("mcp__gitlab__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("bug");
+    expect(summary).toContain("P1");
+  });
+
+  it("includes description excerpt", () => {
+    const { summary } = gitlabHandler("mcp__gitlab__get_issue", SINGLE_ISSUE);
+    expect(summary).toContain("pipeline fails on merge requests");
+  });
+
+  it("truncates long descriptions with ellipsis", () => {
+    const item = JSON.stringify({ iid: 1, title: "T", state: "opened", description: "x".repeat(300) });
+    const { summary } = gitlabHandler("mcp__gitlab__get_issue", item);
+    expect(summary).toContain("…");
+  });
+
+  it("summarises an array of items", () => {
+    const arr = JSON.stringify([
+      { iid: 1, title: "First MR", state: "merged" },
+      { iid: 2, title: "Second MR", state: "opened" },
+    ]);
+    const { summary } = gitlabHandler("mcp__gitlab__list_merge_requests", arr);
+    expect(summary).toContain("!1");
+    expect(summary).toContain("!2");
+  });
+
+  it("truncates arrays longer than 10 items", () => {
+    const items = Array.from({ length: 15 }, (_, i) => ({ iid: i + 1, title: `Item ${i + 1}`, state: "opened" }));
+    const { summary } = gitlabHandler("mcp__gitlab__list_issues", JSON.stringify(items));
+    expect(summary).toContain("5 more");
+  });
+
+  it("falls back gracefully for non-JSON text", () => {
+    const { summary } = gitlabHandler("mcp__gitlab__get_file", "plain text response");
+    expect(summary).toContain("plain text response");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = gitlabHandler("mcp__gitlab__get_issue", SINGLE_ISSUE);
+    expect(originalSize).toBe(Buffer.byteLength(SINGLE_ISSUE, "utf8"));
+  });
+
+  it("routes gitlab tools to gitlab handler", () => {
+    expect(getHandler("mcp__gitlab__list_issues", "{}")).toBe(gitlabHandler);
+    expect(getHandler("mcp__gitlab__get_merge_request", "{}")).toBe(gitlabHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// databaseHandler
+// ---------------------------------------------------------------------------
+
+describe("databaseHandler", () => {
+  const NODE_PG = JSON.stringify({
+    rows: [
+      { id: 1, name: "Alice", email: "alice@example.com" },
+      { id: 2, name: "Bob", email: "bob@example.com" },
+    ],
+    fields: [{ name: "id" }, { name: "name" }, { name: "email" }],
+    rowCount: 2,
+  });
+
+  const BARE_ARRAY = JSON.stringify([
+    { id: 1, status: "active", amount: 100 },
+    { id: 2, status: "closed", amount: 200 },
+    { id: 3, status: "active", amount: 300 },
+  ]);
+
+  const RESULTS_WRAPPER = JSON.stringify({
+    results: [
+      { user_id: 10, score: 99 },
+      { user_id: 11, score: 88 },
+    ],
+  });
+
+  it("handles node-postgres shape with fields array", () => {
+    const { summary } = databaseHandler("mcp__postgres__query", NODE_PG);
+    expect(summary).toContain("2 rows");
+    expect(summary).toContain("3 cols");
+    expect(summary).toContain("id");
+    expect(summary).toContain("Alice");
+  });
+
+  it("handles bare array of row objects", () => {
+    const { summary } = databaseHandler("mcp__postgres__query", BARE_ARRAY);
+    expect(summary).toContain("3 rows");
+    expect(summary).toContain("status");
+    expect(summary).toContain("active");
+  });
+
+  it("handles results wrapper shape", () => {
+    const { summary } = databaseHandler("mcp__mysql__execute", RESULTS_WRAPPER);
+    expect(summary).toContain("2 rows");
+    expect(summary).toContain("user_id");
+    expect(summary).toContain("99");
+  });
+
+  it("includes column names header", () => {
+    const { summary } = databaseHandler("mcp__postgres__query", NODE_PG);
+    expect(summary).toContain("headers:");
+    expect(summary).toContain("name");
+    expect(summary).toContain("email");
+  });
+
+  it("returns empty result set message for zero rows", () => {
+    const empty = JSON.stringify({ rows: [], fields: [{ name: "id" }] });
+    const { summary } = databaseHandler("mcp__postgres__query", empty);
+    expect(summary).toContain("0 rows");
+    expect(summary).toContain("empty result set");
+  });
+
+  it("caps preview at 10 rows with overflow count", () => {
+    const rows = Array.from({ length: 15 }, (_, i) => ({ id: i + 1, val: `v${i}` }));
+    const input = JSON.stringify({ rows, fields: [{ name: "id" }, { name: "val" }] });
+    const { summary } = databaseHandler("mcp__postgres__query", input);
+    expect(summary).toContain("5 more rows");
+  });
+
+  it("falls back gracefully for non-JSON text", () => {
+    const { summary } = databaseHandler("mcp__postgres__query", "ERROR: relation not found");
+    expect(summary).toContain("ERROR: relation not found");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = databaseHandler("mcp__postgres__query", NODE_PG);
+    expect(originalSize).toBe(Buffer.byteLength(NODE_PG, "utf8"));
+  });
+
+  it("routes postgres tools to database handler", () => {
+    expect(getHandler("mcp__postgres__query", "{}")).toBe(databaseHandler);
+    expect(getHandler("mcp__postgres-fitgait__query", "{}")).toBe(databaseHandler);
+  });
+
+  it("routes mysql tools to database handler", () => {
+    expect(getHandler("mcp__mysql__execute", "{}")).toBe(databaseHandler);
+  });
+
+  it("routes sqlite tools to database handler", () => {
+    expect(getHandler("mcp__sqlite__run_query", "{}")).toBe(databaseHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// sentryHandler
+// ---------------------------------------------------------------------------
+
+const SENTRY_EVENT = JSON.stringify({
+  event_id: "abc123def456",
+  level: "error",
+  environment: "production",
+  release: "app@2.1.0",
+  exception: {
+    values: [
+      {
+        type: "TypeError",
+        value: "Cannot read properties of undefined (reading 'id')",
+        stacktrace: {
+          frames: [
+            { filename: "node_modules/express/lib/router.js", function: "next", lineno: 136 },
+            { filename: "src/middleware/auth.ts", function: "verifyToken", lineno: 42 },
+            { filename: "src/routes/users.ts", function: "getUser", lineno: 88 },
+            { filename: "src/controllers/user.ts", function: "fetchById", lineno: 23 },
+          ],
+        },
+      },
+    ],
+  },
+  breadcrumbs: { values: Array.from({ length: 100 }, (_, i) => ({ message: `breadcrumb ${i}` })) },
+  sdk: { name: "sentry.javascript.node", version: "7.0.0", packages: [] },
+  request: { headers: { "x-forwarded-for": "1.2.3.4", authorization: "Bearer token123" } },
+});
+
+describe("sentryHandler", () => {
+  it("includes exception type and value", () => {
+    const { summary } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(summary).toContain("TypeError");
+    expect(summary).toContain("Cannot read properties of undefined");
+  });
+
+  it("includes level, environment, and release", () => {
+    const { summary } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(summary).toContain("[error]");
+    expect(summary).toContain("env:production");
+    expect(summary).toContain("release:app@2.1.0");
+  });
+
+  it("includes abbreviated event_id", () => {
+    const { summary } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(summary).toContain("id:abc123de");
+  });
+
+  it("includes stack frame filenames and line numbers", () => {
+    const { summary } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(summary).toContain("src/routes/users.ts");
+    expect(summary).toContain(":88");
+    expect(summary).toContain("getUser");
+  });
+
+  it("drops breadcrumbs and SDK info — summary is much smaller than original", () => {
+    const { summary, originalSize } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(Buffer.byteLength(summary, "utf8")).toBeLessThan(originalSize * 0.2);
+  });
+
+  it("caps stack frames at MAX_FRAMES showing last (innermost) frames", () => {
+    const manyFrames = Array.from({ length: 20 }, (_, i) => ({
+      filename: `src/file${i}.ts`,
+      function: `fn${i}`,
+      lineno: i * 10,
+    }));
+    const input = JSON.stringify({
+      level: "error",
+      exception: {
+        values: [{ type: "Error", value: "boom", stacktrace: { frames: manyFrames } }],
+      },
+    });
+    const { summary } = sentryHandler("mcp__sentry__get_issue", input);
+    // Should show last 8 frames (indices 12-19)
+    expect(summary).toContain("src/file19.ts");
+    expect(summary).toContain("src/file12.ts");
+    expect(summary).not.toContain("src/file11.ts");
+  });
+
+  it("handles array of events", () => {
+    const arr = JSON.stringify([
+      { level: "error", exception: { values: [{ type: "TypeError", value: "msg 1", stacktrace: { frames: [] } }] } },
+      { level: "warning", exception: { values: [{ type: "RangeError", value: "msg 2", stacktrace: { frames: [] } }] } },
+    ]);
+    const { summary } = sentryHandler("mcp__sentry__list_issues", arr);
+    expect(summary).toContain("TypeError");
+    expect(summary).toContain("RangeError");
+  });
+
+  it("falls back gracefully for non-JSON text", () => {
+    const { summary } = sentryHandler("mcp__sentry__get_issue", "plain error text");
+    expect(summary).toContain("plain error text");
+  });
+
+  it("reports originalSize in bytes", () => {
+    const { originalSize } = sentryHandler("mcp__sentry__get_issue", SENTRY_EVENT);
+    expect(originalSize).toBe(Buffer.byteLength(SENTRY_EVENT, "utf8"));
+  });
+
+  it("routes sentry tools to sentry handler", () => {
+    expect(getHandler("mcp__sentry__get_issue", "{}")).toBe(sentryHandler);
+    expect(getHandler("mcp__sentry__list_issues", "{}")).toBe(sentryHandler);
   });
 });


### PR DESCRIPTION
## Summary
- **GitLab** (`mcp__gitlab__*`) — mirrors GitHub handler: iid, title, state, description excerpt, labels, web_url. Closes #53
- **Database** (postgres/mysql/sqlite/database) — row/col count + first 10 rows as col=value. Handles node-postgres `{rows,fields}`, bare array, and `{results}` wrapper shapes. Closes #51
- **Sentry** (`mcp__sentry__*`) — exception type+message, level, env, release, event_id, last 8 stack frames (innermost). Drops breadcrumbs/SDK/headers. Closes #52

## Test plan
- [x] 31 new tests across 3 handlers (476 total, all passing)
- [x] `bun run typecheck` clean
- [x] Dispatch routing tests for each handler
- [x] README handler table and diagram updated
- [x] CHANGELOG entry for v1.4.0