### PR TITLE
docs: embed demo and proof GIFs in demo/README.md

### DIFF
--- a/demo/README.md
+++ b/demo/README.md
@@ -14,6 +14,14 @@ Files in this directory:
 | `sample-stats.txt` | Pre-recorded `recall__stats` output for `demo.tape` Scene 3 |
 | `sample-search.txt` | Pre-recorded `recall__search` output for `demo.tape` Scene 4 |
 
+## demo.gif
+
+![mcp-recall demo](demo.gif)
+
+## proof.gif
+
+![mcp-recall proof](proof.gif)
+
 ## Regenerating the GIFs
 
 Requires [vhs](https://github.com/charmbracelet/vhs):


### PR DESCRIPTION
## Summary

- Embeds `demo.gif` and `proof.gif` directly in `demo/README.md` so they render when browsing the directory on GitHub

## Test plan

- [ ] Both GIFs render inline on the GitHub demo/ directory page