### PR TITLE
feat: add mcp-recall install, uninstall, and status commands

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -7976,6 +7976,273 @@ Next steps:`);
   }
 }
 
+// src/install/index.ts
+import { existsSync } from "fs";
+import { mkdir, rename, readFile } from "fs/promises";
+import path from "path";
+import os from "os";
+var BOLD = "\x1B[1m";
+var GREEN = "\x1B[32m";
+var YELLOW = "\x1B[33m";
+var RED = "\x1B[31m";
+var DIM = "\x1B[2m";
+var RESET = "\x1B[0m";
+function defaultClaudeJsonPath() {
+  return path.join(os.homedir(), ".claude.json");
+}
+function defaultSettingsPath() {
+  return path.join(os.homedir(), ".claude", "settings.json");
+}
+function detectPaths() {
+  const isBuilt = import.meta.path.endsWith(".js");
+  const distDir = isBuilt ? import.meta.dir : path.resolve(import.meta.dir, "../../plugins/mcp-recall/dist");
+  return {
+    serverJs: path.join(distDir, "server.js"),
+    cliJs: path.join(distDir, "cli.js")
+  };
+}
+async function readJsonFile(filePath) {
+  try {
+    const content = await readFile(filePath, "utf8");
+    return JSON.parse(content);
+  } catch (e) {
+    if (e.code === "ENOENT")
+      return {};
+    throw new Error(`Cannot parse ${filePath}: ${e.message}`);
+  }
+}
+async function writeJsonFile(filePath, data) {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const content = JSON.stringify(data, null, 2) + `
+`;
+  const tmp = filePath + ".tmp";
+  await Bun.write(tmp, content);
+  await rename(tmp, filePath);
+}
+var SESSION_START_MARKER = "session-start";
+var POST_TOOL_USE_MARKER = "post-tool-use";
+var POST_TOOL_USE_MATCHER = "(mcp__(?!recall__).*|Bash)";
+function makeSessionStartEntry(cliJs) {
+  return {
+    hooks: [{ type: "command", command: `bun ${cliJs} session-start`, timeout: 10 }]
+  };
+}
+function makePostToolUseEntry(cliJs) {
+  return {
+    matcher: POST_TOOL_USE_MATCHER,
+    hooks: [{ type: "command", command: `bun ${cliJs} post-tool-use`, timeout: 10 }]
+  };
+}
+function isOurSessionStartHook(entry) {
+  if (!entry || typeof entry !== "object")
+    return false;
+  const hooks = entry["hooks"];
+  if (!Array.isArray(hooks))
+    return false;
+  return hooks.some((h) => {
+    const cmd = h["command"];
+    return typeof cmd === "string" && cmd.includes("recall") && cmd.includes(SESSION_START_MARKER);
+  });
+}
+function isOurPostToolUseHook(entry) {
+  if (!entry || typeof entry !== "object")
+    return false;
+  const e = entry;
+  if (e["matcher"] !== POST_TOOL_USE_MATCHER)
+    return false;
+  const hooks = e["hooks"];
+  if (!Array.isArray(hooks))
+    return false;
+  return hooks.some((h) => {
+    const cmd = h["command"];
+    return typeof cmd === "string" && cmd.includes("recall") && cmd.includes(POST_TOOL_USE_MARKER);
+  });
+}
+async function installCommand(opts = {}) {
+  const {
+    dryRun = false,
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath = defaultSettingsPath()
+  } = opts;
+  const paths = detectPaths();
+  if (!existsSync(paths.serverJs) || !existsSync(paths.cliJs)) {
+    console.error(`${RED}\u2717 Build artifacts not found.${RESET}`);
+    console.error(`  Expected: ${DIM}${paths.serverJs}${RESET}`);
+    console.error(`  Run ${BOLD}bun run build${RESET} first.`);
+    process.exit(1);
+  }
+  if (dryRun) {
+    console.log(`${DIM}dry run \u2014 no files will be modified${RESET}
+`);
+  }
+  let anyChange = false;
+  const claudeJson = await readJsonFile(claudeJsonPath);
+  const mcpServers = claudeJson["mcpServers"] ?? {};
+  const newServer = { type: "stdio", command: "bun", args: [paths.serverJs] };
+  const existing = mcpServers["recall"];
+  const currentServerPath = existing?.["args"]?.[0];
+  if (!existing) {
+    if (!dryRun) {
+      claudeJson["mcpServers"] = { ...mcpServers, recall: newServer };
+      await writeJsonFile(claudeJsonPath, claudeJson);
+    }
+    console.log(`${GREEN}\u2713${RESET} MCP server registered     ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else if (currentServerPath !== paths.serverJs) {
+    if (!dryRun) {
+      claudeJson["mcpServers"] = { ...mcpServers, recall: newServer };
+      await writeJsonFile(claudeJsonPath, claudeJson);
+    }
+    console.log(`${YELLOW}\u21BA${RESET} MCP server path updated    ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else {
+    console.log(`${DIM}\u2139 MCP server already registered${RESET}`);
+  }
+  const settings = await readJsonFile(settingsPath);
+  const hooks = settings["hooks"] ?? {};
+  let settingsChanged = false;
+  const ssHooks = hooks["SessionStart"] ?? [];
+  const ssIdx = ssHooks.findIndex(isOurSessionStartHook);
+  const newSS = makeSessionStartEntry(paths.cliJs);
+  if (ssIdx === -1) {
+    hooks["SessionStart"] = [...ssHooks, newSS];
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}\u2713${RESET} SessionStart hook added    ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    const currentCmd = ssHooks[ssIdx]?.hooks?.[0]?.command;
+    if (currentCmd !== newSS.hooks[0].command) {
+      ssHooks[ssIdx] = newSS;
+      hooks["SessionStart"] = ssHooks;
+      settingsChanged = true;
+      anyChange = true;
+      console.log(`${YELLOW}\u21BA${RESET} SessionStart hook updated   ${DIM}(${settingsPath})${RESET}`);
+    } else {
+      console.log(`${DIM}\u2139 SessionStart hook already registered${RESET}`);
+    }
+  }
+  const ptuHooks = hooks["PostToolUse"] ?? [];
+  const ptuIdx = ptuHooks.findIndex(isOurPostToolUseHook);
+  const newPTU = makePostToolUseEntry(paths.cliJs);
+  if (ptuIdx === -1) {
+    hooks["PostToolUse"] = [...ptuHooks, newPTU];
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}\u2713${RESET} PostToolUse hook added     ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    const currentCmd = ptuHooks[ptuIdx]?.hooks?.[0]?.command;
+    if (currentCmd !== newPTU.hooks[0].command) {
+      ptuHooks[ptuIdx] = newPTU;
+      hooks["PostToolUse"] = ptuHooks;
+      settingsChanged = true;
+      anyChange = true;
+      console.log(`${YELLOW}\u21BA${RESET} PostToolUse hook updated    ${DIM}(${settingsPath})${RESET}`);
+    } else {
+      console.log(`${DIM}\u2139 PostToolUse hook already registered${RESET}`);
+    }
+  }
+  if (settingsChanged && !dryRun) {
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+  }
+  if (anyChange && !dryRun) {
+    console.log(`
+Restart Claude Code to activate mcp-recall.`);
+  }
+}
+async function uninstallCommand(opts = {}) {
+  const {
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath = defaultSettingsPath()
+  } = opts;
+  let anyChange = false;
+  const claudeJson = await readJsonFile(claudeJsonPath);
+  const mcpServers = claudeJson["mcpServers"];
+  if (mcpServers?.["recall"]) {
+    delete mcpServers["recall"];
+    await writeJsonFile(claudeJsonPath, claudeJson);
+    console.log(`${GREEN}\u2713${RESET} Removed mcpServers.recall  ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else {
+    console.log(`${DIM}\u2139 mcpServers.recall not present${RESET}`);
+  }
+  const settings = await readJsonFile(settingsPath);
+  const hooks = settings["hooks"] ?? {};
+  let settingsChanged = false;
+  const ssHooks = hooks["SessionStart"] ?? [];
+  const ssIdx = ssHooks.findIndex(isOurSessionStartHook);
+  if (ssIdx !== -1) {
+    hooks["SessionStart"] = ssHooks.filter((_, i) => i !== ssIdx);
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}\u2713${RESET} Removed SessionStart hook   ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    console.log(`${DIM}\u2139 SessionStart hook not present${RESET}`);
+  }
+  const ptuHooks = hooks["PostToolUse"] ?? [];
+  const ptuIdx = ptuHooks.findIndex(isOurPostToolUseHook);
+  if (ptuIdx !== -1) {
+    hooks["PostToolUse"] = ptuHooks.filter((_, i) => i !== ptuIdx);
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}\u2713${RESET} Removed PostToolUse hook    ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    console.log(`${DIM}\u2139 PostToolUse hook not present${RESET}`);
+  }
+  if (settingsChanged) {
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+  }
+  if (anyChange) {
+    console.log(`
+Restart Claude Code to deactivate mcp-recall.`);
+  }
+}
+async function statusCommand(opts = {}) {
+  const {
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath = defaultSettingsPath()
+  } = opts;
+  const recallPaths = detectPaths();
+  function tick(ok) {
+    return ok ? `${GREEN}\u2713${RESET}` : `${RED}\u2717${RESET}`;
+  }
+  function pad(s, n) {
+    return s + " ".repeat(Math.max(0, n - s.length));
+  }
+  const claudeJson = await readJsonFile(claudeJsonPath);
+  const settings = await readJsonFile(settingsPath);
+  const hooks = settings["hooks"] ?? {};
+  const mcpServers = claudeJson["mcpServers"];
+  const serverRegistered = !!mcpServers?.["recall"];
+  const ssRegistered = (hooks["SessionStart"] ?? []).some(isOurSessionStartHook);
+  const ptuRegistered = (hooks["PostToolUse"] ?? []).some(isOurPostToolUseHook);
+  const serverExists = existsSync(recallPaths.serverJs);
+  const cliExists = existsSync(recallPaths.cliJs);
+  const fullyInstalled = serverRegistered && ssRegistered && ptuRegistered && serverExists && cliExists;
+  const label = fullyInstalled ? `${GREEN}installed${RESET}` : serverRegistered || ssRegistered || ptuRegistered ? `${YELLOW}partial / stale${RESET}` : `${RED}not installed${RESET}`;
+  console.log(`
+Installation: ${BOLD}${label}${RESET}
+`);
+  console.log(`  ${pad("~/.claude.json", 30)}  ${tick(serverRegistered)} mcpServers.recall`);
+  console.log(`  ${pad("~/.claude/settings.json", 30)}  ${tick(ssRegistered)} SessionStart hook`);
+  console.log(`  ${pad("", 30)}  ${tick(ptuRegistered)} PostToolUse hook`);
+  console.log("");
+  console.log(`  ${pad("Build artifacts", 30)}`);
+  console.log(`  ${pad("  dist/server.js", 30)}  ${tick(serverExists)} ${DIM}${recallPaths.serverJs}${RESET}`);
+  console.log(`  ${pad("  dist/cli.js", 30)}  ${tick(cliExists)} ${DIM}${recallPaths.cliJs}${RESET}`);
+  if (!fullyInstalled) {
+    console.log("");
+    if (!serverExists || !cliExists) {
+      console.log(`  Run ${BOLD}bun run build${RESET} then ${BOLD}mcp-recall install${RESET}`);
+    } else {
+      console.log(`  Run ${BOLD}mcp-recall install${RESET}`);
+    }
+  }
+  console.log("");
+}
+
 // src/cli.ts
 var subcommand = process.argv[2];
 async function main() {
@@ -7985,6 +8252,19 @@ async function main() {
   }
   if (subcommand === "learn") {
     await handleLearnCommand(process.argv.slice(3));
+    process.exit(0);
+  }
+  if (subcommand === "install") {
+    const dryRun = process.argv.includes("--dry-run");
+    await installCommand({ dryRun });
+    process.exit(0);
+  }
+  if (subcommand === "uninstall") {
+    await uninstallCommand();
+    process.exit(0);
+  }
+  if (subcommand === "status") {
+    await statusCommand();
     process.exit(0);
   }
   const raw = await Bun.stdin.text();

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -10,6 +10,7 @@ import { handleSessionStart } from "./hooks/session-start";
 import { handlePostToolUse } from "./hooks/post-tool-use";
 import { handleProfilesCommand } from "./profiles/commands";
 import { handleLearnCommand } from "./learn/index";
+import { installCommand, uninstallCommand, statusCommand } from "./install/index";
 
 const subcommand = process.argv[2];
 
@@ -22,6 +23,22 @@ async function main(): Promise<void> {
 
   if (subcommand === "learn") {
     await handleLearnCommand(process.argv.slice(3));
+    process.exit(0);
+  }
+
+  if (subcommand === "install") {
+    const dryRun = process.argv.includes("--dry-run");
+    await installCommand({ dryRun });
+    process.exit(0);
+  }
+
+  if (subcommand === "uninstall") {
+    await uninstallCommand();
+    process.exit(0);
+  }
+
+  if (subcommand === "status") {
+    await statusCommand();
     process.exit(0);
   }
 

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -1,0 +1,364 @@
+/**
+ * src/install/index.ts
+ *
+ * Implements `mcp-recall install`, `mcp-recall uninstall`, and `mcp-recall status`.
+ *
+ * Writes the MCP server entry to ~/.claude.json and the two hook entries to
+ * ~/.claude/settings.json. All operations are non-destructive — existing entries
+ * from other tools are never touched. Writes are atomic (tmp → rename).
+ */
+
+import { existsSync } from "fs";
+import { mkdir, rename, readFile } from "fs/promises";
+import path from "path";
+import os from "os";
+
+// ── ANSI ─────────────────────────────────────────────────────────────────────
+
+const BOLD  = "\x1b[1m";
+const GREEN = "\x1b[32m";
+const YELLOW = "\x1b[33m";
+const RED   = "\x1b[31m";
+const DIM   = "\x1b[2m";
+const RESET = "\x1b[0m";
+
+// ── Default paths ─────────────────────────────────────────────────────────────
+
+export function defaultClaudeJsonPath(): string {
+  return path.join(os.homedir(), ".claude.json");
+}
+
+export function defaultSettingsPath(): string {
+  return path.join(os.homedir(), ".claude", "settings.json");
+}
+
+// ── Dist path detection ───────────────────────────────────────────────────────
+
+export interface RecallPaths {
+  serverJs: string;
+  cliJs: string;
+}
+
+export function detectPaths(): RecallPaths {
+  // import.meta.path is the absolute path of the currently executing file.
+  // Running from src/install/index.ts (dev): dist is ../../plugins/mcp-recall/dist/
+  // Running from dist/cli.js (built):        dist is import.meta.dir itself.
+  const isBuilt = import.meta.path.endsWith(".js");
+  const distDir = isBuilt
+    ? import.meta.dir
+    : path.resolve(import.meta.dir, "../../plugins/mcp-recall/dist");
+
+  return {
+    serverJs: path.join(distDir, "server.js"),
+    cliJs:    path.join(distDir, "cli.js"),
+  };
+}
+
+// ── JSON helpers ──────────────────────────────────────────────────────────────
+
+export async function readJsonFile(filePath: string): Promise<Record<string, unknown>> {
+  try {
+    const content = await readFile(filePath, "utf8");
+    return JSON.parse(content) as Record<string, unknown>;
+  } catch (e: any) {
+    if (e.code === "ENOENT") return {};
+    throw new Error(`Cannot parse ${filePath}: ${e.message}`);
+  }
+}
+
+export async function writeJsonFile(filePath: string, data: unknown): Promise<void> {
+  const dir = path.dirname(filePath);
+  await mkdir(dir, { recursive: true });
+  const content = JSON.stringify(data, null, 2) + "\n";
+  const tmp = filePath + ".tmp";
+  await Bun.write(tmp, content);
+  await rename(tmp, filePath);
+}
+
+// ── Hook builders ─────────────────────────────────────────────────────────────
+
+export const SESSION_START_MARKER = "session-start";
+export const POST_TOOL_USE_MARKER = "post-tool-use";
+export const POST_TOOL_USE_MATCHER = "(mcp__(?!recall__).*|Bash)";
+
+export function makeSessionStartEntry(cliJs: string) {
+  return {
+    hooks: [{ type: "command", command: `bun ${cliJs} session-start`, timeout: 10 }],
+  };
+}
+
+export function makePostToolUseEntry(cliJs: string) {
+  return {
+    matcher: POST_TOOL_USE_MATCHER,
+    hooks: [{ type: "command", command: `bun ${cliJs} post-tool-use`, timeout: 10 }],
+  };
+}
+
+// ── Hook detectors ────────────────────────────────────────────────────────────
+
+export function isOurSessionStartHook(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const hooks = (entry as Record<string, unknown>)["hooks"];
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => {
+    const cmd = (h as Record<string, unknown>)["command"];
+    return typeof cmd === "string"
+      && cmd.includes("recall")
+      && cmd.includes(SESSION_START_MARKER);
+  });
+}
+
+export function isOurPostToolUseHook(entry: unknown): boolean {
+  if (!entry || typeof entry !== "object") return false;
+  const e = entry as Record<string, unknown>;
+  if (e["matcher"] !== POST_TOOL_USE_MATCHER) return false;
+  const hooks = e["hooks"];
+  if (!Array.isArray(hooks)) return false;
+  return hooks.some((h) => {
+    const cmd = (h as Record<string, unknown>)["command"];
+    return typeof cmd === "string"
+      && cmd.includes("recall")
+      && cmd.includes(POST_TOOL_USE_MARKER);
+  });
+}
+
+// ── install ───────────────────────────────────────────────────────────────────
+
+export interface InstallOptions {
+  dryRun?: boolean;
+  claudeJsonPath?: string;
+  settingsPath?: string;
+}
+
+export async function installCommand(opts: InstallOptions = {}): Promise<void> {
+  const {
+    dryRun         = false,
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath   = defaultSettingsPath(),
+  } = opts;
+
+  const paths = detectPaths();
+
+  if (!existsSync(paths.serverJs) || !existsSync(paths.cliJs)) {
+    console.error(`${RED}✗ Build artifacts not found.${RESET}`);
+    console.error(`  Expected: ${DIM}${paths.serverJs}${RESET}`);
+    console.error(`  Run ${BOLD}bun run build${RESET} first.`);
+    process.exit(1);
+  }
+
+  if (dryRun) {
+    console.log(`${DIM}dry run — no files will be modified${RESET}\n`);
+  }
+
+  let anyChange = false;
+
+  // ── ~/.claude.json ──────────────────────────────────────────────────────────
+  const claudeJson = await readJsonFile(claudeJsonPath);
+  const mcpServers = (claudeJson["mcpServers"] as Record<string, unknown>) ?? {};
+  const newServer  = { type: "stdio", command: "bun", args: [paths.serverJs] };
+  const existing   = mcpServers["recall"] as Record<string, unknown> | undefined;
+  const currentServerPath = (existing?.["args"] as string[])?.[0];
+
+  if (!existing) {
+    if (!dryRun) {
+      claudeJson["mcpServers"] = { ...mcpServers, recall: newServer };
+      await writeJsonFile(claudeJsonPath, claudeJson);
+    }
+    console.log(`${GREEN}✓${RESET} MCP server registered     ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else if (currentServerPath !== paths.serverJs) {
+    if (!dryRun) {
+      claudeJson["mcpServers"] = { ...mcpServers, recall: newServer };
+      await writeJsonFile(claudeJsonPath, claudeJson);
+    }
+    console.log(`${YELLOW}↺${RESET} MCP server path updated    ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else {
+    console.log(`${DIM}ℹ MCP server already registered${RESET}`);
+  }
+
+  // ── ~/.claude/settings.json — read once, write once ─────────────────────────
+  const settings     = await readJsonFile(settingsPath);
+  const hooks        = (settings["hooks"] as Record<string, unknown[]>) ?? {};
+  let settingsChanged = false;
+
+  // SessionStart
+  const ssHooks  = (hooks["SessionStart"] as unknown[]) ?? [];
+  const ssIdx    = ssHooks.findIndex(isOurSessionStartHook);
+  const newSS    = makeSessionStartEntry(paths.cliJs);
+
+  if (ssIdx === -1) {
+    hooks["SessionStart"] = [...ssHooks, newSS];
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}✓${RESET} SessionStart hook added    ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    const currentCmd = ((ssHooks[ssIdx] as any)?.hooks?.[0]?.command as string | undefined);
+    if (currentCmd !== newSS.hooks[0].command) {
+      ssHooks[ssIdx] = newSS;
+      hooks["SessionStart"] = ssHooks;
+      settingsChanged = true;
+      anyChange = true;
+      console.log(`${YELLOW}↺${RESET} SessionStart hook updated   ${DIM}(${settingsPath})${RESET}`);
+    } else {
+      console.log(`${DIM}ℹ SessionStart hook already registered${RESET}`);
+    }
+  }
+
+  // PostToolUse
+  const ptuHooks = (hooks["PostToolUse"] as unknown[]) ?? [];
+  const ptuIdx   = ptuHooks.findIndex(isOurPostToolUseHook);
+  const newPTU   = makePostToolUseEntry(paths.cliJs);
+
+  if (ptuIdx === -1) {
+    hooks["PostToolUse"] = [...ptuHooks, newPTU];
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}✓${RESET} PostToolUse hook added     ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    const currentCmd = ((ptuHooks[ptuIdx] as any)?.hooks?.[0]?.command as string | undefined);
+    if (currentCmd !== newPTU.hooks[0].command) {
+      ptuHooks[ptuIdx] = newPTU;
+      hooks["PostToolUse"] = ptuHooks;
+      settingsChanged = true;
+      anyChange = true;
+      console.log(`${YELLOW}↺${RESET} PostToolUse hook updated    ${DIM}(${settingsPath})${RESET}`);
+    } else {
+      console.log(`${DIM}ℹ PostToolUse hook already registered${RESET}`);
+    }
+  }
+
+  if (settingsChanged && !dryRun) {
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+  }
+
+  if (anyChange && !dryRun) {
+    console.log(`\nRestart Claude Code to activate mcp-recall.`);
+  }
+}
+
+// ── uninstall ─────────────────────────────────────────────────────────────────
+
+export interface UninstallOptions {
+  claudeJsonPath?: string;
+  settingsPath?: string;
+}
+
+export async function uninstallCommand(opts: UninstallOptions = {}): Promise<void> {
+  const {
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath   = defaultSettingsPath(),
+  } = opts;
+
+  let anyChange = false;
+
+  // ~/.claude.json
+  const claudeJson = await readJsonFile(claudeJsonPath);
+  const mcpServers = claudeJson["mcpServers"] as Record<string, unknown> | undefined;
+  if (mcpServers?.["recall"]) {
+    delete mcpServers["recall"];
+    await writeJsonFile(claudeJsonPath, claudeJson);
+    console.log(`${GREEN}✓${RESET} Removed mcpServers.recall  ${DIM}(${claudeJsonPath})${RESET}`);
+    anyChange = true;
+  } else {
+    console.log(`${DIM}ℹ mcpServers.recall not present${RESET}`);
+  }
+
+  // ~/.claude/settings.json — read once, write once
+  const settings     = await readJsonFile(settingsPath);
+  const hooks        = (settings["hooks"] as Record<string, unknown[]>) ?? {};
+  let settingsChanged = false;
+
+  const ssHooks  = (hooks["SessionStart"] as unknown[]) ?? [];
+  const ssIdx    = ssHooks.findIndex(isOurSessionStartHook);
+  if (ssIdx !== -1) {
+    hooks["SessionStart"] = ssHooks.filter((_, i) => i !== ssIdx);
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}✓${RESET} Removed SessionStart hook   ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    console.log(`${DIM}ℹ SessionStart hook not present${RESET}`);
+  }
+
+  const ptuHooks = (hooks["PostToolUse"] as unknown[]) ?? [];
+  const ptuIdx   = ptuHooks.findIndex(isOurPostToolUseHook);
+  if (ptuIdx !== -1) {
+    hooks["PostToolUse"] = ptuHooks.filter((_, i) => i !== ptuIdx);
+    settingsChanged = true;
+    anyChange = true;
+    console.log(`${GREEN}✓${RESET} Removed PostToolUse hook    ${DIM}(${settingsPath})${RESET}`);
+  } else {
+    console.log(`${DIM}ℹ PostToolUse hook not present${RESET}`);
+  }
+
+  if (settingsChanged) {
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+  }
+
+  if (anyChange) {
+    console.log(`\nRestart Claude Code to deactivate mcp-recall.`);
+  }
+}
+
+// ── status ────────────────────────────────────────────────────────────────────
+
+export interface StatusOptions {
+  claudeJsonPath?: string;
+  settingsPath?: string;
+}
+
+export async function statusCommand(opts: StatusOptions = {}): Promise<void> {
+  const {
+    claudeJsonPath = defaultClaudeJsonPath(),
+    settingsPath   = defaultSettingsPath(),
+  } = opts;
+
+  const recallPaths = detectPaths();
+
+  function tick(ok: boolean) { return ok ? `${GREEN}✓${RESET}` : `${RED}✗${RESET}`; }
+  function pad(s: string, n: number) { return s + " ".repeat(Math.max(0, n - s.length)); }
+
+  // Config entries
+  const claudeJson   = await readJsonFile(claudeJsonPath);
+  const settings     = await readJsonFile(settingsPath);
+  const hooks        = (settings["hooks"] as Record<string, unknown[]>) ?? {};
+  const mcpServers   = claudeJson["mcpServers"] as Record<string, unknown> | undefined;
+
+  const serverRegistered = !!mcpServers?.["recall"];
+  const ssRegistered     = ((hooks["SessionStart"] as unknown[]) ?? []).some(isOurSessionStartHook);
+  const ptuRegistered    = ((hooks["PostToolUse"]  as unknown[]) ?? []).some(isOurPostToolUseHook);
+
+  // Build artifacts
+  const serverExists = existsSync(recallPaths.serverJs);
+  const cliExists    = existsSync(recallPaths.cliJs);
+
+  const fullyInstalled = serverRegistered && ssRegistered && ptuRegistered && serverExists && cliExists;
+  const label = fullyInstalled
+    ? `${GREEN}installed${RESET}`
+    : (serverRegistered || ssRegistered || ptuRegistered)
+      ? `${YELLOW}partial / stale${RESET}`
+      : `${RED}not installed${RESET}`;
+
+  console.log(`\nInstallation: ${BOLD}${label}${RESET}\n`);
+
+  console.log(`  ${pad("~/.claude.json", 30)}  ${tick(serverRegistered)} mcpServers.recall`);
+  console.log(`  ${pad("~/.claude/settings.json", 30)}  ${tick(ssRegistered)} SessionStart hook`);
+  console.log(`  ${pad("", 30)}  ${tick(ptuRegistered)} PostToolUse hook`);
+  console.log("");
+  console.log(`  ${pad("Build artifacts", 30)}`);
+  console.log(`  ${pad("  dist/server.js", 30)}  ${tick(serverExists)} ${DIM}${recallPaths.serverJs}${RESET}`);
+  console.log(`  ${pad("  dist/cli.js", 30)}  ${tick(cliExists)} ${DIM}${recallPaths.cliJs}${RESET}`);
+
+  if (!fullyInstalled) {
+    console.log("");
+    if (!serverExists || !cliExists) {
+      console.log(`  Run ${BOLD}bun run build${RESET} then ${BOLD}mcp-recall install${RESET}`);
+    } else {
+      console.log(`  Run ${BOLD}mcp-recall install${RESET}`);
+    }
+  }
+
+  console.log("");
+}

--- a/tests/install.test.ts
+++ b/tests/install.test.ts
@@ -1,0 +1,246 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { mkdtemp, rm } from "fs/promises";
+import { existsSync } from "fs";
+import path from "path";
+import os from "os";
+import {
+  installCommand,
+  uninstallCommand,
+  readJsonFile,
+  writeJsonFile,
+  isOurSessionStartHook,
+  isOurPostToolUseHook,
+  makeSessionStartEntry,
+  makePostToolUseEntry,
+  POST_TOOL_USE_MATCHER,
+} from "../src/install/index";
+
+const FAKE_CLI    = "/fake/mcp-recall/dist/cli.js";
+const FAKE_SERVER = "/fake/mcp-recall/dist/server.js";
+
+// Stub detectPaths so tests don't depend on the actual build artifacts existing.
+// We achieve this by passing explicit file paths to install/uninstall.
+
+let tmpDir: string;
+let claudeJsonPath: string;
+let settingsPath: string;
+
+beforeEach(async () => {
+  tmpDir = await mkdtemp(path.join(os.tmpdir(), "mcp-recall-install-test-"));
+  claudeJsonPath = path.join(tmpDir, ".claude.json");
+  settingsPath   = path.join(tmpDir, "settings.json");
+});
+
+afterEach(async () => {
+  await rm(tmpDir, { recursive: true, force: true });
+});
+
+// Helper: run install with fake paths injected so we bypass detectPaths
+async function install(opts: { dryRun?: boolean } = {}) {
+  // Patch detectPaths by pre-writing a minimal claude.json / settings.json
+  // and calling the exported functions directly.
+  // installCommand calls detectPaths() internally, but we test the JSON logic
+  // via the exported helpers to avoid needing real build artifacts.
+}
+
+// ── isOurSessionStartHook ─────────────────────────────────────────────────────
+
+describe("isOurSessionStartHook", () => {
+  it("recognises our hook", () => {
+    const entry = makeSessionStartEntry(FAKE_CLI);
+    expect(isOurSessionStartHook(entry)).toBe(true);
+  });
+
+  it("rejects a different tool's session-start hook", () => {
+    expect(isOurSessionStartHook({
+      hooks: [{ type: "command", command: "bun /other/tool/cli.js session-start" }],
+    })).toBe(false);
+  });
+
+  it("rejects null / non-object", () => {
+    expect(isOurSessionStartHook(null)).toBe(false);
+    expect(isOurSessionStartHook("string")).toBe(false);
+  });
+});
+
+// ── isOurPostToolUseHook ──────────────────────────────────────────────────────
+
+describe("isOurPostToolUseHook", () => {
+  it("recognises our hook", () => {
+    const entry = makePostToolUseEntry(FAKE_CLI);
+    expect(isOurPostToolUseHook(entry)).toBe(true);
+  });
+
+  it("rejects a hook with different matcher", () => {
+    expect(isOurPostToolUseHook({
+      matcher: "mcp__other__*",
+      hooks: [{ type: "command", command: `bun ${FAKE_CLI} post-tool-use` }],
+    })).toBe(false);
+  });
+
+  it("rejects a hook with our matcher but different command", () => {
+    expect(isOurPostToolUseHook({
+      matcher: POST_TOOL_USE_MATCHER,
+      hooks: [{ type: "command", command: "bun /other/tool/cli.js some-hook" }],
+    })).toBe(false);
+  });
+});
+
+// ── writeJsonFile / readJsonFile ──────────────────────────────────────────────
+
+describe("writeJsonFile / readJsonFile", () => {
+  it("round-trips JSON", async () => {
+    const filePath = path.join(tmpDir, "test.json");
+    await writeJsonFile(filePath, { foo: "bar", nested: { x: 1 } });
+    const result = await readJsonFile(filePath);
+    expect(result).toEqual({ foo: "bar", nested: { x: 1 } });
+  });
+
+  it("returns {} when file does not exist", async () => {
+    const result = await readJsonFile(path.join(tmpDir, "nonexistent.json"));
+    expect(result).toEqual({});
+  });
+
+  it("creates parent directories", async () => {
+    const nested = path.join(tmpDir, "a", "b", "c.json");
+    await writeJsonFile(nested, { ok: true });
+    expect(existsSync(nested)).toBe(true);
+  });
+});
+
+// ── JSON merge logic ─────────────────────────────────────────────────────────
+// Test the merge behaviour directly without needing real build artifacts by
+// pre-writing config files and calling helpers.
+
+describe("JSON merge — adds our entries non-destructively", () => {
+  it("preserves pre-existing hooks in settings.json", async () => {
+    const other = {
+      hooks: {
+        PostToolUse: [
+          {
+            matcher: "TaskCreate|TaskUpdate",
+            hooks: [{ type: "command", command: "/usr/local/bin/vikunja-sync" }],
+          },
+        ],
+      },
+    };
+    await writeJsonFile(settingsPath, other);
+
+    // Manually perform what installCommand does for PostToolUse
+    const settings = await readJsonFile(settingsPath);
+    const hooks = (settings["hooks"] as Record<string, unknown[]>);
+    const ptuHooks = hooks["PostToolUse"] as unknown[];
+    const newPTU = makePostToolUseEntry(FAKE_CLI);
+    hooks["PostToolUse"] = [...ptuHooks, newPTU];
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+
+    const result = await readJsonFile(settingsPath);
+    const ptu = (result["hooks"] as any)["PostToolUse"] as unknown[];
+    expect(ptu).toHaveLength(2);
+    expect((ptu[0] as any).matcher).toBe("TaskCreate|TaskUpdate");
+    expect((ptu[1] as any).matcher).toBe(POST_TOOL_USE_MATCHER);
+  });
+
+  it("does not duplicate SessionStart on second install", async () => {
+    const initial = makeSessionStartEntry(FAKE_CLI);
+    await writeJsonFile(settingsPath, {
+      hooks: { SessionStart: [initial] },
+    });
+
+    const settings = await readJsonFile(settingsPath);
+    const hooks = (settings["hooks"] as Record<string, unknown[]>);
+    const ssHooks = hooks["SessionStart"] as unknown[];
+    const ssIdx = ssHooks.findIndex(isOurSessionStartHook);
+    // Already installed — should not append
+    expect(ssIdx).toBe(0);
+    const newSS = makeSessionStartEntry(FAKE_CLI);
+    // Same command → no change
+    const currentCmd = (ssHooks[ssIdx] as any)?.hooks?.[0]?.command;
+    expect(currentCmd).toBe(newSS.hooks[0].command);
+  });
+
+  it("updates stale path on re-run", async () => {
+    const stale = makeSessionStartEntry("/old/mcp-recall/dist/cli.js");
+    await writeJsonFile(settingsPath, {
+      hooks: { SessionStart: [stale] },
+    });
+
+    const settings = await readJsonFile(settingsPath);
+    const hooks = (settings["hooks"] as Record<string, unknown[]>);
+    const ssHooks = hooks["SessionStart"] as unknown[];
+    const ssIdx = ssHooks.findIndex(isOurSessionStartHook);
+    expect(ssIdx).toBe(0);
+
+    const newSS = makeSessionStartEntry(FAKE_CLI);
+    ssHooks[ssIdx] = newSS;
+    hooks["SessionStart"] = ssHooks;
+    settings["hooks"] = hooks;
+    await writeJsonFile(settingsPath, settings);
+
+    const result = await readJsonFile(settingsPath);
+    const updated = (result["hooks"] as any)["SessionStart"][0];
+    expect(updated.hooks[0].command).toBe(`bun ${FAKE_CLI} session-start`);
+  });
+});
+
+// ── uninstall removes only our entries ───────────────────────────────────────
+
+describe("uninstall", () => {
+  it("removes our entries and leaves other hooks intact", async () => {
+    const otherHook = {
+      matcher: "TaskCreate|TaskUpdate",
+      hooks: [{ type: "command", command: "/usr/local/bin/vikunja-sync" }],
+    };
+    await writeJsonFile(settingsPath, {
+      hooks: {
+        SessionStart: [makeSessionStartEntry(FAKE_CLI)],
+        PostToolUse: [otherHook, makePostToolUseEntry(FAKE_CLI)],
+      },
+    });
+    await writeJsonFile(claudeJsonPath, {
+      mcpServers: { recall: { type: "stdio", command: "bun", args: [FAKE_SERVER] } },
+    });
+
+    await uninstallCommand({ claudeJsonPath, settingsPath });
+
+    const claude   = await readJsonFile(claudeJsonPath);
+    const settings = await readJsonFile(settingsPath);
+    const hooks    = (settings["hooks"] as Record<string, unknown[]>);
+
+    expect((claude["mcpServers"] as any)?.["recall"]).toBeUndefined();
+    expect((hooks["SessionStart"] ?? [])).toHaveLength(0);
+    expect((hooks["PostToolUse"] ?? [])).toHaveLength(1);
+    expect((hooks["PostToolUse"] as any)[0].matcher).toBe("TaskCreate|TaskUpdate");
+  });
+
+  it("is a no-op when nothing is installed", async () => {
+    // Should not throw
+    await uninstallCommand({ claudeJsonPath, settingsPath });
+  });
+});
+
+// ── mcpServers merge ─────────────────────────────────────────────────────────
+
+describe("mcpServers merge", () => {
+  it("preserves other MCP servers when adding recall", async () => {
+    await writeJsonFile(claudeJsonPath, {
+      mcpServers: {
+        github: { type: "stdio", command: "bun", args: ["/other/github.js"] },
+      },
+    });
+
+    const claudeJson = await readJsonFile(claudeJsonPath);
+    const mcpServers = (claudeJson["mcpServers"] as Record<string, unknown>) ?? {};
+    claudeJson["mcpServers"] = {
+      ...mcpServers,
+      recall: { type: "stdio", command: "bun", args: [FAKE_SERVER] },
+    };
+    await writeJsonFile(claudeJsonPath, claudeJson);
+
+    const result = await readJsonFile(claudeJsonPath);
+    const servers = result["mcpServers"] as Record<string, unknown>;
+    expect(servers["github"]).toBeDefined();
+    expect(servers["recall"]).toBeDefined();
+  });
+});


### PR DESCRIPTION
## Summary

- `mcp-recall install [--dry-run]` — writes `mcpServers.recall` to `~/.claude.json` and both hooks to `~/.claude/settings.json`. Idempotent: safe to re-run after a rebuild; updates stale paths in place rather than appending duplicates. Validates build artifacts exist before touching any files.
- `mcp-recall uninstall` — removes our entries from both files, leaves all other hooks intact
- `mcp-recall status` — checks config entries are present and build artifacts exist on disk; reports stale installs where config is there but dist was deleted or moved

Writes are atomic (write to `.tmp`, then `rename`). Existing hooks from other tools are never touched.

## Test plan

- [ ] `mcp-recall status` shows `installed` on a correctly configured machine
- [ ] `mcp-recall install --dry-run` prints changes without modifying files
- [ ] `mcp-recall install` is idempotent (second run shows "already registered")
- [ ] `mcp-recall uninstall` removes our entries, preserves other hooks
- [ ] 15 new unit tests passing (491 total)
- [ ] Typecheck clean