### PR TITLE
feat: add Stripe compression handler with proper currency formatting

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -6426,6 +6426,292 @@ var sentryHandler = (_toolName, output) => {
   return { summary: String(parsed), originalSize };
 };
 
+// src/handlers/stripe.ts
+var ZERO_DECIMAL = new Set([
+  "bif",
+  "clp",
+  "gnf",
+  "isk",
+  "jpy",
+  "kmf",
+  "krw",
+  "mga",
+  "pyg",
+  "rwf",
+  "ugx",
+  "vnd",
+  "xaf",
+  "xof",
+  "xpf"
+]);
+function formatAmount(amount, currency) {
+  if (typeof amount !== "number")
+    return "";
+  const curr = typeof currency === "string" ? currency.toLowerCase() : "usd";
+  const value = ZERO_DECIMAL.has(curr) ? amount : amount / 100;
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: curr.toUpperCase(),
+      minimumFractionDigits: ZERO_DECIMAL.has(curr) ? 0 : 2
+    }).format(value);
+  } catch {
+    return `${curr.toUpperCase()} ${value.toFixed(ZERO_DECIMAL.has(curr) ? 0 : 2)}`;
+  }
+}
+function summariseCustomer(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  if (typeof item["name"] === "string" && item["name"])
+    parts.push(`"${item["name"]}"`);
+  if (typeof item["email"] === "string")
+    parts.push(item["email"]);
+  if (typeof item["phone"] === "string" && item["phone"])
+    parts.push(item["phone"]);
+  if (item["delinquent"] === true)
+    parts.push("[delinquent]");
+  return parts.join(" \xB7 ");
+}
+function summariseInvoice(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  if (typeof item["status"] === "string")
+    parts.push(`[${item["status"]}]`);
+  const amountDue = item["amount_due"];
+  const amountPaid = item["amount_paid"];
+  const curr = item["currency"];
+  if (typeof amountDue === "number")
+    parts.push(`due: ${formatAmount(amountDue, curr)}`);
+  if (typeof amountPaid === "number" && amountPaid > 0)
+    parts.push(`paid: ${formatAmount(amountPaid, curr)}`);
+  const name = item["customer_name"] ?? item["customer_email"];
+  if (typeof name === "string" && name)
+    parts.push(name);
+  if (typeof item["billing_reason"] === "string")
+    parts.push(`reason: ${item["billing_reason"]}`);
+  return parts.join(" \xB7 ");
+}
+function summarisePaymentIntent(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  parts.push(formatAmount(item["amount"], item["currency"]));
+  if (typeof item["status"] === "string")
+    parts.push(`[${item["status"]}]`);
+  if (typeof item["customer"] === "string" && item["customer"])
+    parts.push(`customer: ${item["customer"]}`);
+  if (typeof item["description"] === "string" && item["description"]) {
+    parts.push(item["description"].slice(0, 100));
+  }
+  return parts.filter(Boolean).join(" \xB7 ");
+}
+function summariseSubscription(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  if (typeof item["status"] === "string")
+    parts.push(`[${item["status"]}]`);
+  const plan = item["plan"];
+  if (plan) {
+    if (typeof plan["id"] === "string")
+      parts.push(`plan: ${plan["id"]}`);
+    const planAmount = formatAmount(plan["amount"], plan["currency"] ?? item["currency"]);
+    if (planAmount)
+      parts.push(planAmount);
+  }
+  if (typeof item["customer"] === "string")
+    parts.push(`customer: ${item["customer"]}`);
+  if (item["cancel_at_period_end"] === true)
+    parts.push("cancels at period end");
+  return parts.join(" \xB7 ");
+}
+function summariseProduct(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  if (typeof item["name"] === "string")
+    parts.push(`"${item["name"]}"`);
+  if (item["active"] === false)
+    parts.push("[inactive]");
+  if (typeof item["description"] === "string" && item["description"]) {
+    parts.push(item["description"].slice(0, 100));
+  }
+  return parts.join(" \xB7 ");
+}
+function summarisePrice(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  const amount = formatAmount(item["unit_amount"], item["currency"]);
+  if (amount)
+    parts.push(amount);
+  const recurring = item["recurring"];
+  if (recurring) {
+    const count = recurring["interval_count"];
+    const interval = recurring["interval"];
+    parts.push(count && count !== 1 ? `every ${count} ${interval}s` : `per ${interval}`);
+  }
+  if (typeof item["product"] === "string")
+    parts.push(`product: ${item["product"]}`);
+  return parts.join(" \xB7 ");
+}
+function summariseDispute(item) {
+  const parts = [];
+  if (typeof item["id"] === "string")
+    parts.push(item["id"]);
+  const amount = formatAmount(item["amount"], item["currency"]);
+  if (amount)
+    parts.push(amount);
+  if (typeof item["status"] === "string")
+    parts.push(`[${item["status"]}]`);
+  if (typeof item["reason"] === "string")
+    parts.push(`reason: ${item["reason"]}`);
+  if (typeof item["charge"] === "string")
+    parts.push(`charge: ${item["charge"]}`);
+  return parts.join(" \xB7 ");
+}
+function summariseBalance(obj) {
+  const lines = [];
+  const available = obj["available"];
+  const pending = obj["pending"];
+  for (const b of available ?? [])
+    lines.push(`available: ${formatAmount(b.amount, b.currency)}`);
+  for (const b of pending ?? []) {
+    if (b.amount !== 0)
+      lines.push(`pending: ${formatAmount(b.amount, b.currency)}`);
+  }
+  return lines.join(" \xB7 ") || "Balance: $0.00";
+}
+function summariseAccount(obj) {
+  const parts = [];
+  if (typeof obj["id"] === "string")
+    parts.push(obj["id"]);
+  if (typeof obj["display_name"] === "string")
+    parts.push(`"${obj["display_name"]}"`);
+  if (typeof obj["email"] === "string")
+    parts.push(obj["email"]);
+  if (typeof obj["country"] === "string")
+    parts.push(obj["country"]);
+  return parts.join(" \xB7 ");
+}
+function summarisePaymentLink(obj) {
+  const parts = [];
+  if (typeof obj["id"] === "string")
+    parts.push(obj["id"]);
+  if (typeof obj["url"] === "string")
+    parts.push(obj["url"]);
+  if (obj["active"] === false)
+    parts.push("[inactive]");
+  return parts.join(" \xB7 ");
+}
+function summariseByObjectType(item) {
+  switch (item["object"]) {
+    case "customer":
+      return summariseCustomer(item);
+    case "invoice":
+      return summariseInvoice(item);
+    case "payment_intent":
+      return summarisePaymentIntent(item);
+    case "subscription":
+      return summariseSubscription(item);
+    case "product":
+      return summariseProduct(item);
+    case "price":
+      return summarisePrice(item);
+    case "dispute":
+      return summariseDispute(item);
+    case "payment_link":
+      return summarisePaymentLink(item);
+    default: {
+      const parts = [];
+      if (typeof item["id"] === "string")
+        parts.push(item["id"]);
+      if (typeof item["object"] === "string")
+        parts.push(`[${item["object"]}]`);
+      if (typeof item["status"] === "string")
+        parts.push(`[${item["status"]}]`);
+      return parts.join(" \xB7 ");
+    }
+  }
+}
+function pickSummariser(suffix) {
+  if (suffix.includes("customer"))
+    return summariseCustomer;
+  if (suffix.includes("invoice"))
+    return summariseInvoice;
+  if (suffix.includes("payment_intent"))
+    return summarisePaymentIntent;
+  if (suffix.includes("subscription"))
+    return summariseSubscription;
+  if (suffix.includes("product"))
+    return summariseProduct;
+  if (suffix.includes("price"))
+    return summarisePrice;
+  if (suffix.includes("dispute"))
+    return summariseDispute;
+  if (suffix.includes("payment_link"))
+    return summarisePaymentLink;
+  return summariseByObjectType;
+}
+var MAX_ITEMS = 10;
+function summariseList(items, summarise) {
+  const lines = items.slice(0, MAX_ITEMS).map((item) => typeof item === "object" && item !== null ? summarise(item) : String(item));
+  const overflow = items.length > MAX_ITEMS ? `
+\u2026and ${items.length - MAX_ITEMS} more` : "";
+  return lines.join(`
+`) + overflow;
+}
+var stripeHandler = (toolName, output) => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+  const suffix = toolName.split("__").pop() ?? "";
+  if (suffix === "retrieve_balance") {
+    let parsed2;
+    try {
+      parsed2 = JSON.parse(raw);
+    } catch {
+      return { summary: raw.slice(0, 500), originalSize };
+    }
+    return { summary: summariseBalance(parsed2), originalSize };
+  }
+  if (suffix === "get_stripe_account_info") {
+    let parsed2;
+    try {
+      parsed2 = JSON.parse(raw);
+    } catch {
+      return { summary: raw.slice(0, 500), originalSize };
+    }
+    return { summary: summariseAccount(parsed2), originalSize };
+  }
+  if (suffix === "search_stripe_documentation") {
+    return { summary: raw.slice(0, 500).trimEnd(), originalSize };
+  }
+  let parsed;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { summary: raw.slice(0, 500).trimEnd(), originalSize };
+  }
+  const summarise = pickSummariser(suffix);
+  if (typeof parsed === "object" && parsed !== null && Array.isArray(parsed["data"])) {
+    const items = parsed["data"];
+    if (items.length === 0)
+      return { summary: "No items.", originalSize };
+    return { summary: summariseList(items, summarise), originalSize };
+  }
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0)
+      return { summary: "No items.", originalSize };
+    return { summary: summariseList(parsed, summarise), originalSize };
+  }
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summarise(parsed), originalSize };
+  }
+  return { summary: String(parsed), originalSize };
+};
+
 // src/handlers/csv.ts
 var MAX_PREVIEW_ROWS2 = 5;
 function splitCsvRow(row) {
@@ -6847,6 +7133,9 @@ function getHandler(toolName, output, input) {
   }
   if (toolName.startsWith("mcp__gitlab__")) {
     return gitlabHandler;
+  }
+  if (toolName.startsWith("mcp__stripe__")) {
+    return stripeHandler;
   }
   if (toolName.startsWith("mcp__filesystem__") || toolName.includes("read_file") || toolName.includes("get_file")) {
     return filesystemHandler;

--- a/src/handlers/index.ts
+++ b/src/handlers/index.ts
@@ -10,6 +10,7 @@ import { slackHandler } from "./slack";
 import { tavilyHandler } from "./tavily";
 import { databaseHandler } from "./database";
 import { sentryHandler } from "./sentry";
+import { stripeHandler } from "./stripe";
 import { csvHandler, looksLikeCsv } from "./csv";
 import { jsonHandler } from "./json";
 import { genericHandler } from "./generic";
@@ -28,18 +29,19 @@ export { extractText } from "./types";
  *   3. Playwright browser_snapshot          → playwright handler
  *   4. GitHub tools                         → github handler
  *   5. GitLab tools                         → gitlab handler
- *   6. Filesystem tools                     → filesystem handler
- *   7. Shell/bash/remote-exec               → shell handler
- *   8. Linear tools                         → linear handler
- *   9. Slack tools                          → slack handler
- *  10. Tavily search/research               → tavily handler
- *  11. Database query tools                 → database handler
- *  12. Sentry tools                         → sentry handler
- *  13. CSV tools (name-based)               → csv handler
- *  14. Bundled profile match                → profile handler
- *  15. Unmatched with JSON output           → json handler
- *  16. CSV content-based fallback           → csv handler
- *  17. Everything else                      → generic handler
+ *   6. Stripe tools                         → stripe handler
+ *   7. Filesystem tools                     → filesystem handler
+ *   8. Shell/bash/remote-exec               → shell handler
+ *   9. Linear tools                         → linear handler
+ *  10. Slack tools                          → slack handler
+ *  11. Tavily search/research               → tavily handler
+ *  12. Database query tools                 → database handler
+ *  13. Sentry tools                         → sentry handler
+ *  14. CSV tools (name-based)               → csv handler
+ *  15. Bundled profile match                → profile handler
+ *  16. Unmatched with JSON output           → json handler
+ *  17. CSV content-based fallback           → csv handler
+ *  18. Everything else                      → generic handler
  *
  * `input` (tool_input) is used for the Bash tool to route on the command string.
  */
@@ -63,6 +65,10 @@ export function getHandler(toolName: string, output: unknown, input?: unknown): 
 
   if (toolName.startsWith("mcp__gitlab__")) {
     return gitlabHandler;
+  }
+
+  if (toolName.startsWith("mcp__stripe__")) {
+    return stripeHandler;
   }
 
   if (

--- a/src/handlers/stripe.ts
+++ b/src/handlers/stripe.ts
@@ -1,0 +1,257 @@
+/**
+ * Stripe handler — formats Stripe API responses with proper currency formatting,
+ * per-object-type field selection, and both list ({data:[...]}) and single-object support.
+ */
+import type { CompressionResult, Handler } from "./types";
+import { extractText } from "./types";
+
+type JsonObject = Record<string, unknown>;
+
+// ── Currency formatting ───────────────────────────────────────────────────────
+
+// Stripe stores amounts in the smallest currency unit (cents for USD).
+// Zero-decimal currencies use the whole unit directly.
+const ZERO_DECIMAL = new Set([
+  "bif", "clp", "gnf", "isk", "jpy", "kmf", "krw", "mga", "pyg",
+  "rwf", "ugx", "vnd", "xaf", "xof", "xpf",
+]);
+
+function formatAmount(amount: unknown, currency: unknown): string {
+  if (typeof amount !== "number") return "";
+  const curr = typeof currency === "string" ? currency.toLowerCase() : "usd";
+  const value = ZERO_DECIMAL.has(curr) ? amount : amount / 100;
+  try {
+    return new Intl.NumberFormat("en-US", {
+      style: "currency",
+      currency: curr.toUpperCase(),
+      minimumFractionDigits: ZERO_DECIMAL.has(curr) ? 0 : 2,
+    }).format(value);
+  } catch {
+    return `${curr.toUpperCase()} ${value.toFixed(ZERO_DECIMAL.has(curr) ? 0 : 2)}`;
+  }
+}
+
+// ── Per-object summarisers ────────────────────────────────────────────────────
+
+function summariseCustomer(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  if (typeof item["name"] === "string" && item["name"]) parts.push(`"${item["name"]}"`);
+  if (typeof item["email"] === "string") parts.push(item["email"]);
+  if (typeof item["phone"] === "string" && item["phone"]) parts.push(item["phone"]);
+  if (item["delinquent"] === true) parts.push("[delinquent]");
+  return parts.join(" · ");
+}
+
+function summariseInvoice(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  if (typeof item["status"] === "string") parts.push(`[${item["status"]}]`);
+  const amountDue = item["amount_due"];
+  const amountPaid = item["amount_paid"];
+  const curr = item["currency"];
+  if (typeof amountDue === "number") parts.push(`due: ${formatAmount(amountDue, curr)}`);
+  if (typeof amountPaid === "number" && amountPaid > 0) parts.push(`paid: ${formatAmount(amountPaid, curr)}`);
+  const name = item["customer_name"] ?? item["customer_email"];
+  if (typeof name === "string" && name) parts.push(name);
+  if (typeof item["billing_reason"] === "string") parts.push(`reason: ${item["billing_reason"]}`);
+  return parts.join(" · ");
+}
+
+function summarisePaymentIntent(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  parts.push(formatAmount(item["amount"], item["currency"]));
+  if (typeof item["status"] === "string") parts.push(`[${item["status"]}]`);
+  if (typeof item["customer"] === "string" && item["customer"]) parts.push(`customer: ${item["customer"]}`);
+  if (typeof item["description"] === "string" && item["description"]) {
+    parts.push(item["description"].slice(0, 100));
+  }
+  return parts.filter(Boolean).join(" · ");
+}
+
+function summariseSubscription(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  if (typeof item["status"] === "string") parts.push(`[${item["status"]}]`);
+  const plan = item["plan"] as JsonObject | null | undefined;
+  if (plan) {
+    if (typeof plan["id"] === "string") parts.push(`plan: ${plan["id"]}`);
+    const planAmount = formatAmount(plan["amount"], plan["currency"] ?? item["currency"]);
+    if (planAmount) parts.push(planAmount);
+  }
+  if (typeof item["customer"] === "string") parts.push(`customer: ${item["customer"]}`);
+  if (item["cancel_at_period_end"] === true) parts.push("cancels at period end");
+  return parts.join(" · ");
+}
+
+function summariseProduct(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  if (typeof item["name"] === "string") parts.push(`"${item["name"]}"`);
+  if (item["active"] === false) parts.push("[inactive]");
+  if (typeof item["description"] === "string" && item["description"]) {
+    parts.push(item["description"].slice(0, 100));
+  }
+  return parts.join(" · ");
+}
+
+function summarisePrice(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  const amount = formatAmount(item["unit_amount"], item["currency"]);
+  if (amount) parts.push(amount);
+  const recurring = item["recurring"] as JsonObject | null | undefined;
+  if (recurring) {
+    const count = recurring["interval_count"];
+    const interval = recurring["interval"];
+    parts.push(count && count !== 1 ? `every ${count} ${interval}s` : `per ${interval}`);
+  }
+  if (typeof item["product"] === "string") parts.push(`product: ${item["product"]}`);
+  return parts.join(" · ");
+}
+
+function summariseDispute(item: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof item["id"] === "string") parts.push(item["id"]);
+  const amount = formatAmount(item["amount"], item["currency"]);
+  if (amount) parts.push(amount);
+  if (typeof item["status"] === "string") parts.push(`[${item["status"]}]`);
+  if (typeof item["reason"] === "string") parts.push(`reason: ${item["reason"]}`);
+  if (typeof item["charge"] === "string") parts.push(`charge: ${item["charge"]}`);
+  return parts.join(" · ");
+}
+
+function summariseBalance(obj: JsonObject): string {
+  const lines: string[] = [];
+  const available = obj["available"] as Array<{ amount: number; currency: string }> | undefined;
+  const pending   = obj["pending"]   as Array<{ amount: number; currency: string }> | undefined;
+  for (const b of available ?? []) lines.push(`available: ${formatAmount(b.amount, b.currency)}`);
+  for (const b of pending   ?? []) {
+    if (b.amount !== 0) lines.push(`pending: ${formatAmount(b.amount, b.currency)}`);
+  }
+  return lines.join(" · ") || "Balance: $0.00";
+}
+
+function summariseAccount(obj: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof obj["id"] === "string") parts.push(obj["id"]);
+  if (typeof obj["display_name"] === "string") parts.push(`"${obj["display_name"]}"`);
+  if (typeof obj["email"] === "string") parts.push(obj["email"]);
+  if (typeof obj["country"] === "string") parts.push(obj["country"]);
+  return parts.join(" · ");
+}
+
+function summarisePaymentLink(obj: JsonObject): string {
+  const parts: string[] = [];
+  if (typeof obj["id"] === "string") parts.push(obj["id"]);
+  if (typeof obj["url"] === "string") parts.push(obj["url"]);
+  if (obj["active"] === false) parts.push("[inactive]");
+  return parts.join(" · ");
+}
+
+// ── Route by tool suffix or item object type ──────────────────────────────────
+
+function summariseByObjectType(item: JsonObject): string {
+  switch (item["object"]) {
+    case "customer":       return summariseCustomer(item);
+    case "invoice":        return summariseInvoice(item);
+    case "payment_intent": return summarisePaymentIntent(item);
+    case "subscription":   return summariseSubscription(item);
+    case "product":        return summariseProduct(item);
+    case "price":          return summarisePrice(item);
+    case "dispute":        return summariseDispute(item);
+    case "payment_link":   return summarisePaymentLink(item);
+    default: {
+      // Fallback: id + a few key fields
+      const parts: string[] = [];
+      if (typeof item["id"] === "string") parts.push(item["id"]);
+      if (typeof item["object"] === "string") parts.push(`[${item["object"]}]`);
+      if (typeof item["status"] === "string") parts.push(`[${item["status"]}]`);
+      return parts.join(" · ");
+    }
+  }
+}
+
+function pickSummariser(suffix: string): (item: JsonObject) => string {
+  if (suffix.includes("customer"))       return summariseCustomer;
+  if (suffix.includes("invoice"))        return summariseInvoice;
+  if (suffix.includes("payment_intent")) return summarisePaymentIntent;
+  if (suffix.includes("subscription"))   return summariseSubscription;
+  if (suffix.includes("product"))        return summariseProduct;
+  if (suffix.includes("price"))          return summarisePrice;
+  if (suffix.includes("dispute"))        return summariseDispute;
+  if (suffix.includes("payment_link"))   return summarisePaymentLink;
+  // search_stripe_resources / fetch_stripe_resources — route per item by object type
+  return summariseByObjectType;
+}
+
+// ── List extraction ───────────────────────────────────────────────────────────
+
+const MAX_ITEMS = 10;
+
+function summariseList(items: unknown[], summarise: (item: JsonObject) => string): string {
+  const lines = items.slice(0, MAX_ITEMS).map((item) =>
+    typeof item === "object" && item !== null ? summarise(item as JsonObject) : String(item)
+  );
+  const overflow = items.length > MAX_ITEMS ? `\n…and ${items.length - MAX_ITEMS} more` : "";
+  return lines.join("\n") + overflow;
+}
+
+// ── Handler ───────────────────────────────────────────────────────────────────
+
+export const stripeHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const raw = extractText(output);
+  const originalSize = Buffer.byteLength(raw, "utf8");
+
+  // Special cases that return non-standard shapes
+  const suffix = toolName.split("__").pop() ?? "";
+  if (suffix === "retrieve_balance") {
+    let parsed: unknown;
+    try { parsed = JSON.parse(raw); } catch { return { summary: raw.slice(0, 500), originalSize }; }
+    return { summary: summariseBalance(parsed as JsonObject), originalSize };
+  }
+  if (suffix === "get_stripe_account_info") {
+    let parsed: unknown;
+    try { parsed = JSON.parse(raw); } catch { return { summary: raw.slice(0, 500), originalSize }; }
+    return { summary: summariseAccount(parsed as JsonObject), originalSize };
+  }
+  if (suffix === "search_stripe_documentation") {
+    return { summary: raw.slice(0, 500).trimEnd(), originalSize };
+  }
+
+  let parsed: unknown;
+  try {
+    parsed = JSON.parse(raw);
+  } catch {
+    return { summary: raw.slice(0, 500).trimEnd(), originalSize };
+  }
+
+  const summarise = pickSummariser(suffix);
+
+  // Stripe list response: { object: "list", data: [...] }
+  if (
+    typeof parsed === "object" && parsed !== null &&
+    Array.isArray((parsed as JsonObject)["data"])
+  ) {
+    const items = (parsed as JsonObject)["data"] as unknown[];
+    if (items.length === 0) return { summary: "No items.", originalSize };
+    return { summary: summariseList(items, summarise), originalSize };
+  }
+
+  // Bare array
+  if (Array.isArray(parsed)) {
+    if (parsed.length === 0) return { summary: "No items.", originalSize };
+    return { summary: summariseList(parsed, summarise), originalSize };
+  }
+
+  // Single object (create_*, finalize_*, cancel_*, update_*)
+  if (typeof parsed === "object" && parsed !== null) {
+    return { summary: summarise(parsed as JsonObject), originalSize };
+  }
+
+  return { summary: String(parsed), originalSize };
+};

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -14,6 +14,7 @@ import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler } f
 import { tavilyHandler } from "../src/handlers/tavily";
 import { databaseHandler } from "../src/handlers/database";
 import { sentryHandler } from "../src/handlers/sentry";
+import { stripeHandler } from "../src/handlers/stripe";
 
 // ---------------------------------------------------------------------------
 // extractText
@@ -1314,5 +1315,130 @@ describe("sentryHandler", () => {
   it("routes sentry tools to sentry handler", () => {
     expect(getHandler("mcp__sentry__get_issue", "{}")).toBe(sentryHandler);
     expect(getHandler("mcp__sentry__list_issues", "{}")).toBe(sentryHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// stripeHandler
+// ---------------------------------------------------------------------------
+
+const STRIPE_CUSTOMERS = JSON.stringify({
+  object: "list",
+  data: [
+    { id: "cus_JW2RJx1dRFf8kZ", name: "Daniel Sheena", email: "daniel@sabanahome.com", phone: "+15168847383" },
+    { id: "cus_JJXYpwnDxyf1QS", name: "Mazak Optonics", email: "dcreekmur@mazaklaser.com", phone: null },
+  ],
+});
+
+const STRIPE_INVOICES = JSON.stringify({
+  object: "list",
+  data: [
+    {
+      id: "in_1It0i5Gvh8VjBGyd8Z04Lk55",
+      status: "open",
+      amount_due: 250000,
+      amount_paid: 0,
+      currency: "usd",
+      customer_name: "Daniel Sheena",
+      billing_reason: "manual",
+    },
+    {
+      id: "in_1It0MrGvh8VjBGydGmuXRvFS",
+      status: "draft",
+      amount_due: 0,
+      amount_paid: 0,
+      currency: "usd",
+      customer_name: "Daniel Sheena",
+      billing_reason: "manual",
+    },
+  ],
+});
+
+const STRIPE_PAYMENT_INTENTS = JSON.stringify({
+  object: "list",
+  data: [
+    { id: "pi_1It0j3Gvh8VjBGydhyPkvVKe", amount: 250000, currency: "usd", status: "requires_payment_method", customer: "cus_JW2RJx1dRFf8kZ" },
+    { id: "pi_1IQGk6Gvh8VjBGydTy5c9A4O", amount: 40000,  currency: "usd", status: "succeeded", customer: null },
+  ],
+});
+
+const STRIPE_BALANCE = JSON.stringify({
+  object: "balance",
+  available: [{ amount: 50000, currency: "usd" }],
+  pending:   [{ amount: 10000, currency: "usd" }],
+});
+
+describe("stripeHandler", () => {
+  it("formats customer list with name and email", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_customers", STRIPE_CUSTOMERS);
+    expect(summary).toContain("cus_JW2RJx1dRFf8kZ");
+    expect(summary).toContain("Daniel Sheena");
+    expect(summary).toContain("daniel@sabanahome.com");
+  });
+
+  it("formats invoice amounts as dollars, not cents", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_invoices", STRIPE_INVOICES);
+    expect(summary).toContain("$2,500.00");
+    expect(summary).not.toContain("250000");
+  });
+
+  it("formats payment intent amounts as dollars", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_payment_intents", STRIPE_PAYMENT_INTENTS);
+    expect(summary).toContain("$2,500.00");
+    expect(summary).toContain("$400.00");
+    expect(summary).not.toContain("250000");
+  });
+
+  it("shows invoice status and billing reason", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_invoices", STRIPE_INVOICES);
+    expect(summary).toContain("[open]");
+    expect(summary).toContain("due: $2,500.00");
+  });
+
+  it("formats balance with dollar amounts", () => {
+    const { summary } = stripeHandler("mcp__stripe__retrieve_balance", STRIPE_BALANCE);
+    expect(summary).toContain("available: $500.00");
+    expect(summary).toContain("pending: $100.00");
+  });
+
+  it("handles empty list gracefully", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_subscriptions", JSON.stringify({ object: "list", data: [] }));
+    expect(summary).toBe("No items.");
+  });
+
+  it("handles bare empty array", () => {
+    const { summary } = stripeHandler("mcp__stripe__list_subscriptions", "[]");
+    expect(summary).toBe("No items.");
+  });
+
+  it("handles single object (create_customer response)", () => {
+    const single = JSON.stringify({ id: "cus_new123", name: "New User", email: "new@example.com" });
+    const { summary } = stripeHandler("mcp__stripe__create_customer", single);
+    expect(summary).toContain("cus_new123");
+    expect(summary).toContain("New User");
+  });
+
+  it("formats JPY amounts without decimal (zero-decimal currency)", () => {
+    const jpy = JSON.stringify({
+      object: "list",
+      data: [{ id: "pi_jpy", amount: 1500, currency: "jpy", status: "succeeded" }],
+    });
+    const { summary } = stripeHandler("mcp__stripe__list_payment_intents", jpy);
+    expect(summary).toContain("¥1,500");
+    expect(summary).not.toContain("¥15.00");
+  });
+
+  it("returns overflow count for more than 10 items", () => {
+    const items = Array.from({ length: 13 }, (_, i) => ({
+      id: `cus_${i}`, name: `Customer ${i}`, email: `c${i}@example.com`,
+    }));
+    const { summary } = stripeHandler("mcp__stripe__list_customers", JSON.stringify({ object: "list", data: items }));
+    expect(summary).toContain("…and 3 more");
+  });
+
+  it("routes mcp__stripe__* to stripeHandler", () => {
+    expect(getHandler("mcp__stripe__list_customers", "{}")).toBe(stripeHandler);
+    expect(getHandler("mcp__stripe__list_invoices", "{}")).toBe(stripeHandler);
+    expect(getHandler("mcp__stripe__retrieve_balance", "{}")).toBe(stripeHandler);
   });
 });


### PR DESCRIPTION
## Summary

- New `src/handlers/stripe.ts` — routes all `mcp__stripe__*` tools with per-object-type summarisers and proper currency formatting
- Amounts converted from cents to dollars: `250000` → `$2,500.00` (and zero-decimal currencies like JPY handled correctly: `1500` → `¥1,500`)
- Per-tool routing: customers, invoices, payment intents, subscriptions, products, prices, disputes, payment links, balance, account info, search results
- Handles both Stripe list objects (`{ object: "list", data: [...] }`) and single-object responses (create/update/cancel tools)
- Mixed search results (`search_stripe_resources`) routed per item by `object` field
- 11 new tests, 502 total

## Test plan

- [ ] `list_customers` shows id, name, email
- [ ] `list_invoices` shows `$2,500.00` not `250000`
- [ ] `list_payment_intents` shows formatted amounts and status
- [ ] `retrieve_balance` shows available/pending in dollars
- [ ] JPY amounts not divided by 100
- [ ] Empty list returns "No items."
- [ ] 13-item list shows "…and 3 more"
- [ ] `mcp__stripe__*` dispatch routes to stripeHandler