### PR TITLE
chore: housekeeping for v1.5.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,28 @@ All notable changes to mcp-recall are documented here.
 
 ---
 
+## v1.5.0 — 2026-03-03
+
+### `mcp-recall install` / `uninstall` / `status`
+
+Removes the biggest install friction — no more manually editing `~/.claude.json` and `~/.claude/settings.json`.
+
+```bash
+mcp-recall install [--dry-run]   # write MCP server + hooks, idempotent
+mcp-recall uninstall             # remove all entries, leave other hooks intact
+mcp-recall status                # verify config entries + build artifacts exist
+```
+
+Writes are atomic (temp file → rename). Existing hooks from other tools are never touched. Re-running after a `bun run build` updates stale paths in place.
+
+### Stripe compression handler
+
+New TypeScript handler for all `mcp__stripe__*` tools. Formats amounts correctly — Stripe stores values in the smallest currency unit (`250000` = **$2,500.00**, not `250000`). Zero-decimal currencies (JPY, KRW, etc.) handled separately.
+
+Per-tool routing: customers, invoices, payment intents, subscriptions, products, prices, disputes, payment links, balance, account info. Mixed `search_stripe_resources` results routed per item by `object` field. Handles both Stripe list responses (`{ object: "list", data: [...] }`) and single-object responses from create/update/cancel tools.
+
+---
+
 ## v1.4.0 — 2026-03-03
 
 ### Three new TypeScript compression handlers

--- a/README.md
+++ b/README.md
@@ -116,6 +116,25 @@ claude plugin update mcp-recall@mcp-recall
 claude plugin uninstall mcp-recall@mcp-recall
 ```
 
+### Manual install / from source
+
+If you prefer to run from a local clone, or if the plugin system isn't available:
+
+```bash
+git clone https://github.com/sakebomb/mcp-recall
+cd mcp-recall
+bun install
+bun run build
+mcp-recall install
+```
+
+`mcp-recall install` writes the MCP server entry and both hooks directly to `~/.claude.json` and `~/.claude/settings.json`. It's idempotent — safe to re-run after pulling updates.
+
+```bash
+mcp-recall status      # verify installation
+mcp-recall uninstall   # remove all entries
+```
+
 ---
 
 ## Configuration

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -16,9 +16,6 @@ _nothing scheduled — see backlog below_
 
 | # | Title | Priority | Notes |
 |---|-------|----------|-------|
-| #51 | Database results handler | P2 | Good first issue |
-| #52 | Sentry handler | P2 | Good first issue |
-| #53 | GitLab handler | P2 | Good first issue |
 | Claude Code | Runtime config via `/mcp` | — | On hold |
 | OpenCode | `tool.execute.after` output mod | — | On hold, v2.0 |
 | Layer 2 | `recall__register_profile` MCP tool | — | On hold, v2.0 — when MCPs self-describe |


### PR DESCRIPTION
## Summary

- `tasks/todo.md` — clear shipped install command from Up Next
- `README.md` — add Manual install / from source section with `mcp-recall install/status/uninstall`
- `CHANGELOG.md` — add v1.5.0 entry covering install commands and Stripe handler

## Test plan

- [ ] README install section reads correctly
- [ ] CHANGELOG v1.5.0 entry is accurate
- [ ] todo.md Up Next is clean