### PR TITLE
chore: bump package.json to v1.5.0, fix PR template

### DIFF
--- a/.github/PULL_REQUEST_TEMPLATE.md
+++ b/.github/PULL_REQUEST_TEMPLATE.md
@@ -6,7 +6,7 @@
 
 ## Test plan
 
-- [ ] `bun test` passes (276 tests)
+- [ ] `bun test` passes
 - [ ] `bun run typecheck` passes
 - [ ] `bun run build` run (if any `src/` files changed — pre-commit hook does this automatically)
 - [ ] New tests added for new behaviour

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.1.0",
+  "version": "1.5.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",


### PR DESCRIPTION
## Summary

- `package.json` version was stale at `1.1.0` — bumped to `1.5.0`
- PR template had hardcoded `(276 tests)` — removed count so it never goes stale again

## Test plan

- [ ] `bun test` passes