### PR TITLE
fix: harden security, robustness, and performance

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5018,20 +5018,23 @@ function loadConfig() {
 // src/project-key.ts
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
+var pathCache = new Map;
 function getProjectKey(cwd) {
   const resolved = resolveProjectPath(cwd);
   return hashPath(resolved);
 }
 function resolveProjectPath(cwd) {
+  const cached2 = pathCache.get(cwd);
+  if (cached2 !== undefined)
+    return cached2;
   const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
     cwd,
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  if (result.status === 0 && result.stdout) {
-    return result.stdout.trim();
-  }
-  return cwd;
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : cwd;
+  pathCache.set(cwd, resolved);
+  return resolved;
 }
 function hashPath(path) {
   return createHash("sha256").update(path).digest("hex").slice(0, 16);
@@ -5121,7 +5124,6 @@ function getDb(path) {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
-  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;
@@ -5155,13 +5157,16 @@ function storeOutput(db, input) {
   const summary_size = Buffer.byteLength(input.summary, "utf8");
   const created_at = Math.floor(Date.now() / 1000);
   const input_hash = input.input_hash ?? null;
-  db.prepare(`
-    INSERT INTO stored_outputs
-      (id, project_key, session_id, tool_name, summary, full_content,
-       original_size, summary_size, created_at, input_hash)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, input.full_content, input.original_size, summary_size, created_at, input_hash);
-  storeChunks(db, id, input.full_content);
+  const insertAndChunk = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO stored_outputs
+        (id, project_key, session_id, tool_name, summary, full_content,
+         original_size, summary_size, created_at, input_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, input.full_content, input.original_size, summary_size, created_at, input_hash);
+    storeChunks(db, id, input.full_content);
+  });
+  insertAndChunk();
   return {
     id,
     ...input,
@@ -5354,7 +5359,7 @@ function getSessionDays(db) {
   return db.prepare(`SELECT date FROM sessions ORDER BY date DESC`).all().map((r) => r.date);
 }
 
-// src/tools.ts
+// src/format.ts
 function formatBytes(bytes) {
   if (bytes < 1024)
     return `${bytes}B`;
@@ -5362,6 +5367,8 @@ function formatBytes(bytes) {
     return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
+
+// src/tools.ts
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -5491,9 +5498,15 @@ function isDenied(toolName, config) {
   const patterns = [...base, ...config.denylist.additional];
   return patterns.some((p) => matchesPattern(toolName, p));
 }
+var regexCache = new Map;
 function matchesPattern(toolName, pattern) {
-  const escaped = pattern.split("*").map((s) => s.replace(/[.+^${}()|[\]\\]/g, "\\$&")).join(".*");
-  return new RegExp(`^${escaped}$`).test(toolName);
+  let re = regexCache.get(pattern);
+  if (!re) {
+    const escaped = pattern.split("*").map((s) => s.replace(/[.+^${}()|[\]\\]/g, "\\$&")).join(".*");
+    re = new RegExp(`^${escaped}$`);
+    regexCache.set(pattern, re);
+  }
+  return re.test(toolName);
 }
 
 // src/secrets.ts
@@ -5524,7 +5537,7 @@ var SECRET_PATTERNS = [
   },
   {
     name: "AWS secret access key",
-    pattern: /(?i:aws.{0,20}secret.{0,20})[A-Za-z0-9/+=]{40}/
+    pattern: /aws.{0,20}secret.{0,20}[A-Za-z0-9/+=]{40}/i
   },
   {
     name: "Anthropic API key",
@@ -5539,9 +5552,6 @@ var SECRET_PATTERNS = [
     pattern: /-----BEGIN OPENSSH PRIVATE KEY-----/
   }
 ];
-function containsSecret(content) {
-  return SECRET_PATTERNS.some(({ pattern }) => pattern.test(content));
-}
 function findSecrets(content) {
   return SECRET_PATTERNS.filter(({ pattern }) => pattern.test(content)).map(({ name }) => name);
 }
@@ -7176,13 +7186,6 @@ function getHandler(toolName, output, input) {
 }
 
 // src/hooks/post-tool-use.ts
-function formatBytes2(bytes) {
-  if (bytes < 1024)
-    return `${bytes}B`;
-  if (bytes < 1024 * 1024)
-    return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
 function handlePostToolUse(raw) {
   const input = JSON.parse(raw);
   const { tool_name, tool_input, tool_response, cwd, session_id } = input;
@@ -7192,10 +7195,10 @@ function handlePostToolUse(raw) {
     return {};
   }
   const fullContent = extractText(tool_response);
-  dbg(`intercepted ${tool_name} \xB7 ${formatBytes2(Buffer.byteLength(fullContent, "utf8"))}`);
-  if (containsSecret(fullContent)) {
-    const names = findSecrets(fullContent);
-    process.stderr.write(`[recall] skipped ${tool_name}: detected ${names.join(", ")}
+  dbg(`intercepted ${tool_name} \xB7 ${formatBytes(Buffer.byteLength(fullContent, "utf8"))}`);
+  const secretNames = findSecrets(fullContent);
+  if (secretNames.length > 0) {
+    process.stderr.write(`[recall] skipped ${tool_name}: detected ${secretNames.join(", ")}
 `);
     return {};
   }
@@ -7220,7 +7223,7 @@ ${cached2.summary}`,
   const { summary, originalSize } = handler(tool_name, tool_response);
   const summarySize = Buffer.byteLength(summary, "utf8");
   if (summarySize >= originalSize) {
-    dbg(`SKIP no-compression \xB7 ${tool_name} \xB7 ${formatBytes2(summarySize)} \u2265 ${formatBytes2(originalSize)}`);
+    dbg(`SKIP no-compression \xB7 ${tool_name} \xB7 ${formatBytes(summarySize)} \u2265 ${formatBytes(originalSize)}`);
     return {};
   }
   const stored = storeOutput(db, {
@@ -7234,8 +7237,8 @@ ${cached2.summary}`,
   });
   evictIfNeeded(db, projectKey, config.store.max_size_mb);
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
-  dbg(`STORED \xB7 ${tool_name} \xB7 id=${stored.id} \xB7 ${formatBytes2(originalSize)}\u2192${formatBytes2(summarySize)} (${reduction}% reduction)`);
-  const header = `[recall:${stored.id} \xB7 ${formatBytes2(originalSize)}\u2192${formatBytes2(summarySize)} (${reduction}% reduction)]`;
+  dbg(`STORED \xB7 ${tool_name} \xB7 id=${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)`);
+  const header = `[recall:${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)]`;
   return {
     updatedMCPToolOutput: `${header}
 ${summary}`,
@@ -7836,7 +7839,7 @@ ${conflicts.length} conflict(s):
 `);
   }
 }
-function formatBytes3(bytes) {
+function formatBytes2(bytes) {
   if (bytes < 1024)
     return `${bytes} B`;
   if (bytes < 1024 * 1024)
@@ -7917,11 +7920,11 @@ To add a profile:`);
     console.log(`  https://github.com/sakebomb/mcp-recall/blob/main/docs/profile-schema.md`);
   }
   console.log(`
-Input:  ${formatBytes3(result.inputBytes)}  (${contentSource})`);
+Input:  ${formatBytes2(result.inputBytes)}  (${contentSource})`);
   console.log("\u2500".repeat(60));
   console.log(result.summary);
   console.log("\u2500".repeat(60));
-  console.log(`Output: ${formatBytes3(result.outputBytes)}  (${result.reductionPct}% reduction)
+  console.log(`Output: ${formatBytes2(result.outputBytes)}  (${result.reductionPct}% reduction)
 `);
 }
 async function handleProfilesCommand(args) {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6516,6 +6516,51 @@ var require_dist = __commonJS((exports, module) => {
   exports.default = formatsPlugin;
 });
 
+// package.json
+var require_package = __commonJS((exports, module) => {
+  module.exports = {
+    name: "mcp-recall",
+    version: "1.5.0",
+    description: "Context compression and persistent retrieval for Claude Code",
+    author: {
+      name: "sakebomb",
+      url: "https://github.com/sakebomb"
+    },
+    license: "MIT",
+    homepage: "https://github.com/sakebomb/mcp-recall#readme",
+    repository: {
+      type: "git",
+      url: "https://github.com/sakebomb/mcp-recall"
+    },
+    bugs: {
+      url: "https://github.com/sakebomb/mcp-recall/issues"
+    },
+    keywords: ["mcp", "claude", "claude-code", "context", "compression", "memory", "sqlite", "plugin"],
+    engines: {
+      bun: ">=1.1.0"
+    },
+    module: "src/server.ts",
+    type: "module",
+    scripts: {
+      start: "bun run src/server.ts",
+      test: "bun test",
+      dev: "bun --watch src/server.ts",
+      typecheck: "tsc --noEmit",
+      build: "bun build src/server.ts --target bun --outfile plugins/mcp-recall/dist/server.js && bun build src/cli.ts --target bun --outfile plugins/mcp-recall/dist/cli.js && cp hooks/hooks.json plugins/mcp-recall/hooks/hooks.json && rm -rf plugins/mcp-recall/profiles && cp -r profiles plugins/mcp-recall/profiles",
+      prepare: "git config core.hooksPath .githooks"
+    },
+    dependencies: {
+      "@modelcontextprotocol/sdk": "^1.27.1",
+      "smol-toml": "^1.6.0",
+      zod: "^3.24.0"
+    },
+    devDependencies: {
+      "@types/bun": "latest",
+      typescript: "^5.7.0"
+    }
+  };
+});
+
 // node_modules/zod/v3/external.js
 var exports_external = {};
 __export(exports_external, {
@@ -19475,20 +19520,23 @@ class StdioServerTransport {
 // src/project-key.ts
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
+var pathCache = new Map;
 function getProjectKey(cwd) {
   const resolved = resolveProjectPath(cwd);
   return hashPath(resolved);
 }
 function resolveProjectPath(cwd) {
+  const cached2 = pathCache.get(cwd);
+  if (cached2 !== undefined)
+    return cached2;
   const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
     cwd,
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  if (result.status === 0 && result.stdout) {
-    return result.stdout.trim();
-  }
-  return cwd;
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : cwd;
+  pathCache.set(cwd, resolved);
+  return resolved;
 }
 function hashPath(path) {
   return createHash("sha256").update(path).digest("hex").slice(0, 16);
@@ -19578,7 +19626,6 @@ function getDb(path) {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
-  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;
@@ -19604,6 +19651,12 @@ function storeChunks(db, id, full_content) {
     stmt.run(id, i, chunks[i]);
   }
 }
+function sanitizeFtsQuery(query) {
+  const trimmed = query.trim();
+  if (trimmed.length === 0)
+    return '""';
+  return trimmed.split(/\s+/).map((term) => `"${term.replace(/"/g, '""')}"`).join(" ");
+}
 function generateId() {
   return `recall_${randomBytes(4).toString("hex")}`;
 }
@@ -19612,13 +19665,16 @@ function storeOutput(db, input) {
   const summary_size = Buffer.byteLength(input.summary, "utf8");
   const created_at = Math.floor(Date.now() / 1000);
   const input_hash = input.input_hash ?? null;
-  db.prepare(`
-    INSERT INTO stored_outputs
-      (id, project_key, session_id, tool_name, summary, full_content,
-       original_size, summary_size, created_at, input_hash)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, input.full_content, input.original_size, summary_size, created_at, input_hash);
-  storeChunks(db, id, input.full_content);
+  const insertAndChunk = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO stored_outputs
+        (id, project_key, session_id, tool_name, summary, full_content,
+         original_size, summary_size, created_at, input_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, input.full_content, input.original_size, summary_size, created_at, input_hash);
+    storeChunks(db, id, input.full_content);
+  });
+  insertAndChunk();
   return {
     id,
     ...input,
@@ -19651,24 +19707,32 @@ function retrieveSnippet(db, id, query) {
   const row = db.prepare(`SELECT rowid FROM stored_outputs WHERE id = ?`).get(id);
   if (!row)
     return null;
-  const chunkRow = db.prepare(`
-    SELECT content FROM content_chunks
-    WHERE content_chunks MATCH ? AND output_id = ?
-    ORDER BY rank
-    LIMIT 1
-  `).get(query, id);
-  if (chunkRow)
-    return chunkRow.content;
-  const snippetRow = db.prepare(`
-    SELECT snippet(outputs_fts, 3, '', '', ' [...] ', 64) as excerpt
-    FROM outputs_fts
-    WHERE outputs_fts MATCH ?
-    AND rowid = ?
-  `).get(query, row.rowid);
-  return snippetRow?.excerpt ?? null;
+  const safeQuery = sanitizeFtsQuery(query);
+  try {
+    const chunkRow = db.prepare(`
+      SELECT content FROM content_chunks
+      WHERE content_chunks MATCH ? AND output_id = ?
+      ORDER BY rank
+      LIMIT 1
+    `).get(safeQuery, id);
+    if (chunkRow)
+      return chunkRow.content;
+  } catch {}
+  try {
+    const snippetRow = db.prepare(`
+      SELECT snippet(outputs_fts, 3, '', '', ' [...] ', 64) as excerpt
+      FROM outputs_fts
+      WHERE outputs_fts MATCH ?
+      AND rowid = ?
+    `).get(safeQuery, row.rowid);
+    return snippetRow?.excerpt ?? null;
+  } catch {
+    return null;
+  }
 }
 function searchOutputs(db, query, options) {
   const limit = options.limit ?? 10;
+  const safeQuery = sanitizeFtsQuery(query);
   const sql = `
     SELECT s.* FROM outputs_fts f
     JOIN stored_outputs s ON s.rowid = f.rowid
@@ -19678,11 +19742,15 @@ function searchOutputs(db, query, options) {
     ORDER BY rank
     LIMIT ?
   `;
-  const params = [query, options.project_key];
+  const params = [safeQuery, options.project_key];
   if (options.tool)
     params.push(options.tool);
   params.push(limit);
-  return db.prepare(sql).all(...params);
+  try {
+    return db.prepare(sql).all(...params);
+  } catch {
+    return [];
+  }
 }
 function countAndDelete(db, where, params) {
   const count = db.prepare(`SELECT COUNT(*) as n FROM stored_outputs WHERE ${where}`).get(...params).n;
@@ -20899,7 +20967,7 @@ function loadConfig() {
   return cached2;
 }
 
-// src/tools.ts
+// src/format.ts
 function formatBytes(bytes) {
   if (bytes < 1024)
     return `${bytes}B`;
@@ -20907,6 +20975,8 @@ function formatBytes(bytes) {
     return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
+
+// src/tools.ts
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -21219,39 +21289,50 @@ function toolStats(db, projectKey, args = {}) {
 // src/server.ts
 var projectKey = getProjectKey(process.cwd());
 var db = getDb(defaultDbPath(projectKey));
+function safeTool(fn) {
+  return async (args) => {
+    try {
+      return fn(args);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text", text: `[recall: error] ${msg}` }] };
+    }
+  };
+}
+var { version: version2 } = await Promise.resolve().then(() => __toESM(require_package(), 1));
 var server = new McpServer({
   name: "recall",
-  version: "1.0.0"
+  version: version2
 });
 server.tool("recall__retrieve", "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.", {
   id: exports_external.string().describe("8-char or full item ID"),
   query: exports_external.string().optional().describe("FTS query to return a focused excerpt"),
   max_bytes: exports_external.number().optional().describe("Override default 8KB cap on returned bytes (used when FTS returns no match)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolRetrieve(db, args) }]
-}));
+})));
 server.tool("recall__search", "Search across all stored tool outputs by content. Use when you don't have an ID but know what you're looking for. Returns matching items with IDs for retrieval.", {
   query: exports_external.string().describe("FTS search query"),
   tool: exports_external.string().optional().describe("Filter by tool name (substring match)"),
   limit: exports_external.number().optional().describe("Max results to return (default 5)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolSearch(db, projectKey, args) }]
-}));
+})));
 server.tool("recall__pin", "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin.", {
   id: exports_external.string().describe("Item ID to pin or unpin"),
   pinned: exports_external.boolean().optional().describe("true to pin (default), false to unpin")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolPin(db, projectKey, args) }]
-}));
+})));
 server.tool("recall__note", "Store arbitrary text as a recall note \u2014 conclusions, findings, context that should survive context resets. Use for project memory.", {
   text: exports_external.string().describe("Note content to store"),
   title: exports_external.string().optional().describe("Short title for the note (shown in list/search)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolNote(db, projectKey, args) }]
-}));
-server.tool("recall__export", "Export all stored items for this project as JSON. Use before a full clear to preserve data.", {}, async () => ({
+})));
+server.tool("recall__export", "Export all stored items for this project as JSON. Use before a full clear to preserve data.", {}, safeTool(() => ({
   content: [{ type: "text", text: toolExport(db, projectKey) }]
-}));
+})));
 server.tool("recall__forget", "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true.", {
   id: exports_external.string().optional().describe("Delete a single item by ID"),
   tool: exports_external.string().optional().describe("Delete all items matching tool name substring"),
@@ -21260,18 +21341,18 @@ server.tool("recall__forget", "Delete stored items by ID, tool pattern, session,
   all: exports_external.boolean().optional().describe("Clear entire store (requires confirmed: true)"),
   confirmed: exports_external.boolean().optional().describe("Required to execute all: true"),
   force: exports_external.boolean().optional().describe("Override pin protection and delete pinned items too")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolForget(db, projectKey, args) }]
-}));
+})));
 server.tool("recall__list_stored", "Browse stored items by recency, access frequency, or size. Use to find a specific item to retrieve or forget.", {
   limit: exports_external.number().optional().describe("Items per page (default 10)"),
   offset: exports_external.number().optional().describe("Pagination offset"),
   tool: exports_external.string().optional().describe("Filter by tool name substring"),
   sort: exports_external.enum(["recent", "accessed", "size"]).optional().describe("Sort order: recent (default), accessed (most-used first), size (largest first)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolListStored(db, projectKey, args) }]
-}));
-server.tool("recall__stats", "Aggregate session efficiency stats \u2014 total savings, compression ratio, token savings, session days. Use to understand the big picture.", {}, async () => {
+})));
+server.tool("recall__stats", "Aggregate session efficiency stats \u2014 total savings, compression ratio, token savings, session days. Use to understand the big picture.", {}, safeTool(() => {
   const config2 = loadConfig();
   return {
     content: [{ type: "text", text: toolStats(db, projectKey, {
@@ -21279,18 +21360,18 @@ server.tool("recall__stats", "Aggregate session efficiency stats \u2014 total sa
       stale_days: config2.store.stale_item_days
     }) }]
   };
-});
+}));
 server.tool("recall__session_summary", "Digest of a single session's activity \u2014 tools called, compression savings, most-accessed items, pinned items, notes. Defaults to today. Use at session start for orientation or handoff.", {
   session_id: exports_external.string().optional().describe("Filter by specific Claude session ID (exact match)"),
   date: exports_external.string().optional().describe("Filter by date in YYYY-MM-DD format (defaults to today)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolSessionSummary(db, projectKey, args) }]
-}));
+})));
 server.tool("recall__context", "Session orientation: pinned items, recent notes, recently accessed items, and last session headline. Call at the start of a session to quickly re-orient to prior work.", {
   days: exports_external.number().optional().describe("Lookback window for recently accessed items in days (default 7)"),
   limit: exports_external.number().optional().describe("Max recently accessed items to show (default 5)")
-}, async (args) => ({
+}, safeTool((args) => ({
   content: [{ type: "text", text: toolContext(db, projectKey, args) }]
-}));
+})));
 var transport = new StdioServerTransport;
 await server.connect(transport);

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -216,7 +216,6 @@ export function getDb(path: string): Database {
   instance = new Database(path);
   instance.run("PRAGMA journal_mode=WAL");
   instance.run("PRAGMA foreign_keys=ON");
-  instance.run("PRAGMA optimize");
   instance.run(SCHEMA);
   applyMigrations(instance);
   return instance;
@@ -224,7 +223,10 @@ export function getDb(path: string): Database {
 
 /** Closes the singleton database connection and resets the instance. Call in tests after each case. */
 export function closeDb(): void {
-  instance?.close();
+  if (instance) {
+    instance.run("PRAGMA optimize");
+    instance.close();
+  }
   instance = null;
 }
 
@@ -261,6 +263,24 @@ function storeChunks(db: Database, id: string, full_content: string): void {
 }
 
 // ---------------------------------------------------------------------------
+// FTS helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Escapes an FTS5 query to prevent syntax errors from user input.
+ * Wraps each whitespace-separated term in double-quotes so FTS5
+ * treats special characters (AND, OR, NOT, NEAR, brackets) as literals.
+ */
+export function sanitizeFtsQuery(query: string): string {
+  const trimmed = query.trim();
+  if (trimmed.length === 0) return '""';
+  return trimmed
+    .split(/\s+/)
+    .map((term) => `"${term.replace(/"/g, '""')}"`)
+    .join(" ");
+}
+
+// ---------------------------------------------------------------------------
 // Operations
 // ---------------------------------------------------------------------------
 
@@ -278,18 +298,22 @@ export function storeOutput(db: Database, input: StoreInput): StoredOutput {
   const created_at = Math.floor(Date.now() / 1000);
   const input_hash = input.input_hash ?? null;
 
-  db.prepare(`
-    INSERT INTO stored_outputs
-      (id, project_key, session_id, tool_name, summary, full_content,
-       original_size, summary_size, created_at, input_hash)
-    VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-  `).run(
-    id, input.project_key, input.session_id, input.tool_name,
-    input.summary, input.full_content, input.original_size,
-    summary_size, created_at, input_hash
-  );
+  const insertAndChunk = db.transaction(() => {
+    db.prepare(`
+      INSERT INTO stored_outputs
+        (id, project_key, session_id, tool_name, summary, full_content,
+         original_size, summary_size, created_at, input_hash)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(
+      id, input.project_key, input.session_id, input.tool_name,
+      input.summary, input.full_content, input.original_size,
+      summary_size, created_at, input_hash
+    );
 
-  storeChunks(db, id, input.full_content);
+    storeChunks(db, id, input.full_content);
+  });
+
+  insertAndChunk();
 
   return {
     id, ...input, summary_size, created_at,
@@ -402,25 +426,37 @@ export function retrieveSnippet(
 
   if (!row) return null;
 
-  // 1. Chunk-based retrieval: returns the best matching chunk verbatim
-  const chunkRow = db.prepare(`
-    SELECT content FROM content_chunks
-    WHERE content_chunks MATCH ? AND output_id = ?
-    ORDER BY rank
-    LIMIT 1
-  `).get(query, id) as { content: string } | null;
+  // FTS5 MATCH has its own query syntax — malformed queries throw.
+  // Wrap in double-quotes to treat as a phrase, falling back on error.
+  const safeQuery = sanitizeFtsQuery(query);
 
-  if (chunkRow) return chunkRow.content;
+  // 1. Chunk-based retrieval: returns the best matching chunk verbatim
+  try {
+    const chunkRow = db.prepare(`
+      SELECT content FROM content_chunks
+      WHERE content_chunks MATCH ? AND output_id = ?
+      ORDER BY rank
+      LIMIT 1
+    `).get(safeQuery, id) as { content: string } | null;
+
+    if (chunkRow) return chunkRow.content;
+  } catch {
+    // FTS parse error — fall through to legacy
+  }
 
   // 2. Legacy fallback: FTS snippet on full document (items stored pre-chunking)
-  const snippetRow = db.prepare(`
-    SELECT snippet(outputs_fts, 3, '', '', ' [...] ', 64) as excerpt
-    FROM outputs_fts
-    WHERE outputs_fts MATCH ?
-    AND rowid = ?
-  `).get(query, row.rowid) as { excerpt: string } | null;
+  try {
+    const snippetRow = db.prepare(`
+      SELECT snippet(outputs_fts, 3, '', '', ' [...] ', 64) as excerpt
+      FROM outputs_fts
+      WHERE outputs_fts MATCH ?
+      AND rowid = ?
+    `).get(safeQuery, row.rowid) as { excerpt: string } | null;
 
-  return snippetRow?.excerpt ?? null;
+    return snippetRow?.excerpt ?? null;
+  } catch {
+    return null;
+  }
 }
 
 /**
@@ -433,6 +469,7 @@ export function searchOutputs(
   options: SearchOptions
 ): StoredOutput[] {
   const limit = options.limit ?? 10;
+  const safeQuery = sanitizeFtsQuery(query);
   const sql = `
     SELECT s.* FROM outputs_fts f
     JOIN stored_outputs s ON s.rowid = f.rowid
@@ -442,10 +479,14 @@ export function searchOutputs(
     ORDER BY rank
     LIMIT ?
   `;
-  const params: SQLQueryBindings[] = [query, options.project_key];
+  const params: SQLQueryBindings[] = [safeQuery, options.project_key];
   if (options.tool) params.push(options.tool);
   params.push(limit);
-  return db.prepare(sql).all(...params) as StoredOutput[];
+  try {
+    return db.prepare(sql).all(...params) as StoredOutput[];
+  } catch {
+    return [];
+  }
 }
 
 /** Returns a paginated list of stored outputs, optionally filtered by tool name. */

--- a/src/denylist.ts
+++ b/src/denylist.ts
@@ -48,12 +48,19 @@ export function isDenied(toolName: string, config: RecallConfig): boolean {
 /**
  * Matches a tool name against a glob pattern.
  * Supports * as a wildcard matching any sequence of characters.
- * Matching is case-sensitive.
+ * Matching is case-sensitive. Compiled regexes are cached.
  */
+const regexCache = new Map<string, RegExp>();
+
 export function matchesPattern(toolName: string, pattern: string): boolean {
-  const escaped = pattern
-    .split("*")
-    .map((s) => s.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
-    .join(".*");
-  return new RegExp(`^${escaped}$`).test(toolName);
+  let re = regexCache.get(pattern);
+  if (!re) {
+    const escaped = pattern
+      .split("*")
+      .map((s) => s.replace(/[.+^${}()|[\]\\]/g, "\\$&"))
+      .join(".*");
+    re = new RegExp(`^${escaped}$`);
+    regexCache.set(pattern, re);
+  }
+  return re.test(toolName);
 }

--- a/src/format.ts
+++ b/src/format.ts
@@ -1,0 +1,6 @@
+/** Shared byte-size formatting. */
+export function formatBytes(bytes: number): string {
+  if (bytes < 1024) return `${bytes}B`;
+  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
+  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
+}

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -2,9 +2,10 @@ import { createHash } from "crypto";
 import { loadConfig } from "../config";
 import { getProjectKey } from "../project-key";
 import { isDenied } from "../denylist";
-import { containsSecret, findSecrets } from "../secrets";
+import { findSecrets } from "../secrets";
 import { getHandler, extractText } from "../handlers/index";
 import { getDb, defaultDbPath, storeOutput, checkDedup, evictIfNeeded } from "../db/index";
+import { formatBytes } from "../format";
 import { dbg } from "../debug";
 
 interface PostToolUseInput {
@@ -21,12 +22,6 @@ export interface HookOutput {
   suppressOutput?: boolean;
 }
 
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
-
 export function handlePostToolUse(raw: string): HookOutput {
   const input = JSON.parse(raw) as PostToolUseInput;
   const { tool_name, tool_input, tool_response, cwd, session_id } = input;
@@ -41,9 +36,9 @@ export function handlePostToolUse(raw: string): HookOutput {
   // 2. Extract text and check for secrets
   const fullContent = extractText(tool_response);
   dbg(`intercepted ${tool_name} · ${formatBytes(Buffer.byteLength(fullContent, "utf8"))}`);
-  if (containsSecret(fullContent)) {
-    const names = findSecrets(fullContent);
-    process.stderr.write(`[recall] skipped ${tool_name}: detected ${names.join(", ")}\n`);
+  const secretNames = findSecrets(fullContent);
+  if (secretNames.length > 0) {
+    process.stderr.write(`[recall] skipped ${tool_name}: detected ${secretNames.join(", ")}\n`);
     return {};
   }
 

--- a/src/project-key.ts
+++ b/src/project-key.ts
@@ -1,11 +1,14 @@
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
 
+const pathCache = new Map<string, string>();
+
 /**
  * Resolves a stable project key for the given working directory.
  * Prefers git root for stability across launch locations.
  * Falls back to cwd if not inside a git repo.
  * Returns a 16-char hex hash of the resolved path.
+ * Results are cached — git root won't change within a process.
  */
 export function getProjectKey(cwd: string): string {
   const resolved = resolveProjectPath(cwd);
@@ -21,17 +24,21 @@ export function getProjectPath(cwd: string): string {
 }
 
 function resolveProjectPath(cwd: string): string {
+  const cached = pathCache.get(cwd);
+  if (cached !== undefined) return cached;
+
   const result = spawnSync("git", ["rev-parse", "--show-toplevel"], {
     cwd,
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"],
   });
 
-  if (result.status === 0 && result.stdout) {
-    return result.stdout.trim();
-  }
+  const resolved = result.status === 0 && result.stdout
+    ? result.stdout.trim()
+    : cwd;
 
-  return cwd;
+  pathCache.set(cwd, resolved);
+  return resolved;
 }
 
 function hashPath(path: string): string {

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -34,7 +34,7 @@ export const SECRET_PATTERNS: SecretPattern[] = [
   },
   {
     name: "AWS secret access key",
-    pattern: /(?i:aws.{0,20}secret.{0,20})[A-Za-z0-9/+=]{40}/,
+    pattern: /aws.{0,20}secret.{0,20}[A-Za-z0-9/+=]{40}/i,
   },
   {
     name: "Anthropic API key",

--- a/src/server.ts
+++ b/src/server.ts
@@ -35,9 +35,23 @@ import {
 const projectKey = getProjectKey(process.cwd());
 const db = getDb(defaultDbPath(projectKey));
 
+/** Wraps a tool callback so errors return a text error instead of crashing. */
+function safeTool<T>(fn: (args: T) => { content: Array<{ type: "text"; text: string }> }) {
+  return async (args: T) => {
+    try {
+      return fn(args);
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      return { content: [{ type: "text" as const, text: `[recall: error] ${msg}` }] };
+    }
+  };
+}
+
+const { version } = await import("../package.json");
+
 const server = new McpServer({
   name: "recall",
-  version: "1.0.0",
+  version,
 });
 
 server.tool(
@@ -51,9 +65,9 @@ server.tool(
       .optional()
       .describe("Override default 8KB cap on returned bytes (used when FTS returns no match)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolRetrieve(db, args) }],
-  })
+  }))
 );
 
 server.tool(
@@ -64,9 +78,9 @@ server.tool(
     tool: z.string().optional().describe("Filter by tool name (substring match)"),
     limit: z.number().optional().describe("Max results to return (default 5)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolSearch(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
@@ -76,9 +90,9 @@ server.tool(
     id: z.string().describe("Item ID to pin or unpin"),
     pinned: z.boolean().optional().describe("true to pin (default), false to unpin"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolPin(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
@@ -88,18 +102,18 @@ server.tool(
     text: z.string().describe("Note content to store"),
     title: z.string().optional().describe("Short title for the note (shown in list/search)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolNote(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
   "recall__export",
   "Export all stored items for this project as JSON. Use before a full clear to preserve data.",
   {},
-  async () => ({
+  safeTool(() => ({
     content: [{ type: "text", text: toolExport(db, projectKey) }],
-  })
+  }))
 );
 
 server.tool(
@@ -117,9 +131,9 @@ server.tool(
     confirmed: z.boolean().optional().describe("Required to execute all: true"),
     force: z.boolean().optional().describe("Override pin protection and delete pinned items too"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolForget(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
@@ -134,16 +148,16 @@ server.tool(
       .optional()
       .describe("Sort order: recent (default), accessed (most-used first), size (largest first)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolListStored(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
   "recall__stats",
   "Aggregate session efficiency stats — total savings, compression ratio, token savings, session days. Use to understand the big picture.",
   {},
-  async () => {
+  safeTool(() => {
     const config = loadConfig();
     return {
       content: [{ type: "text", text: toolStats(db, projectKey, {
@@ -151,7 +165,7 @@ server.tool(
         stale_days: config.store.stale_item_days,
       }) }],
     };
-  }
+  })
 );
 
 server.tool(
@@ -167,9 +181,9 @@ server.tool(
       .optional()
       .describe("Filter by date in YYYY-MM-DD format (defaults to today)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolSessionSummary(db, projectKey, args) }],
-  })
+  }))
 );
 
 server.tool(
@@ -185,9 +199,9 @@ server.tool(
       .optional()
       .describe("Max recently accessed items to show (default 5)"),
   },
-  async (args) => ({
+  safeTool((args) => ({
     content: [{ type: "text", text: toolContext(db, projectKey, args) }],
-  })
+  }))
 );
 
 const transport = new StdioServerTransport();

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -24,16 +24,11 @@ import {
   type ForgetOptions,
 } from "./db/index";
 import { loadConfig } from "./config";
+import { formatBytes } from "./format";
 
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
-
-function formatBytes(bytes: number): string {
-  if (bytes < 1024) return `${bytes}B`;
-  if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
-  return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
-}
 
 function formatDate(unixSecs: number): string {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -20,6 +20,7 @@ import {
   chunkText,
   CHUNK_SIZE,
   CHUNK_OVERLAP,
+  sanitizeFtsQuery,
   type StoreInput,
 } from "../src/db/index";
 import type { Database } from "bun:sqlite";
@@ -147,6 +148,36 @@ describe("db", () => {
       storeOutput(db, makeInput({ project_key: "otherproject567", summary: "secret stuff" }));
       const results = searchOutputs(db, "secret", { project_key: PROJECT_KEY });
       expect(results.length).toBe(0);
+    });
+
+    it("returns empty array for malformed FTS query instead of throwing", () => {
+      storeOutput(db, makeInput());
+      const results = searchOutputs(db, "NOT *", { project_key: PROJECT_KEY });
+      expect(Array.isArray(results)).toBe(true);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // sanitizeFtsQuery
+  // -------------------------------------------------------------------------
+
+  describe("sanitizeFtsQuery", () => {
+    it("wraps simple terms in double-quotes", () => {
+      expect(sanitizeFtsQuery("hello world")).toBe('"hello" "world"');
+    });
+
+    it("escapes embedded double-quotes", () => {
+      expect(sanitizeFtsQuery('say "hi"')).toBe('"say" """hi"""');
+    });
+
+    it("handles empty and whitespace-only input", () => {
+      expect(sanitizeFtsQuery("")).toBe('""');
+      expect(sanitizeFtsQuery("   ")).toBe('""');
+    });
+
+    it("neutralises FTS operators", () => {
+      expect(sanitizeFtsQuery("NOT something")).toBe('"NOT" "something"');
+      expect(sanitizeFtsQuery("a OR b")).toBe('"a" "OR" "b"');
     });
   });
 


### PR DESCRIPTION
## Summary

- **Security**: Fix AWS secret regex that used PCRE `(?i:...)` syntax — silently never matched in JavaScript. Now uses `/i` flag correctly.
- **Robustness**: Wrap all 10 MCP server tool handlers with try/catch (errors return text instead of crashing). Sanitize FTS5 queries to prevent syntax errors from user input. Wrap store + chunk inserts in a transaction for atomicity.
- **Performance**: Cache denylist regex compilations (~17 RegExp per hook call → 0). Cache `getProjectKey` result (`spawnSync` per hook call → 0). Move `PRAGMA optimize` from DB open to close (no-op at open).
- **Cleanup**: Sync MCP server version with package.json (was hardcoded 1.0.0). Extract shared `formatBytes` to `src/format.ts`. Consolidate double secret scan into single pass.

## Test plan

- [x] `bun test` — 507 pass (5 new tests for FTS sanitization + malformed query handling)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — bundles fresh
- [x] Existing FTS search/snippet tests still pass with sanitized queries
- [x] Denylist tests unchanged (caching is transparent)