### PR TITLE
docs: add full context stack section and simplify How it works diagram

### DIFF
--- a/README.md
+++ b/README.md
@@ -5,7 +5,7 @@
 ![Runtime: Bun](https://img.shields.io/badge/runtime-Bun-f472b6.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-orange.svg)
 
-**Context compression and persistent retrieval for Claude Code.**
+**Your context window is finite. MCP tool outputs aren't. mcp-recall bridges the gap.**
 
 MCP tool outputs — Playwright snapshots, GitHub issues, file reads — can consume tens of kilobytes of context per call. A 200K token context window fills up in ~30 minutes of active MCP use. mcp-recall intercepts those outputs, stores them in full locally, and delivers compressed summaries to Claude instead. When Claude needs more detail, it retrieves exactly what it needs via FTS search — without re-running the tool.
 


### PR DESCRIPTION
## Summary
- Adds **The full context stack** section immediately after the intro — positions mcp-recall within the broader MCP context management ecosystem across all four pressure layers
- Simple 4-node mermaid diagram replaces the 15-node pipeline as the default view in **How it works**; original detailed pipeline preserved in a `<details>` collapsible block
- Links to Claude Code Tool Search docs, Cloudflare Code Mode, and FastMCP 3.1 for complementary tools at layers ① and ②

## Test plan
- [ ] Verify mermaid diagrams render correctly on GitHub (both the new 4-layer ecosystem flowchart and the simplified How it works diagram)
- [ ] Verify `<details>` collapsible works on GitHub for the detailed pipeline
- [ ] Confirm all external links resolve (Claude Code docs, Cloudflare blog, FastMCP post)
- [ ] Read through the full README top-to-bottom for flow and tone consistency