### PR TITLE
chore: bump to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,20 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+---
+
+## [1.6.0] — 2026-03-10
+
+### Security
+
+- Profile install now validates `id` and `file` fields from manifest against strict patterns — prevents path traversal and URL injection (#111)
+- `profiles test` now checks denylist before processing — denylist-protected tools can no longer be passed to `getHandler` (#111)
+- TOML strategy numeric fields (`max_depth`, `max_items`, `max_array_items`, `max_chars`, `max_chars_per_field`, `fallback_chars`) now enforce upper bounds at load time — prevents stack overflow or heap exhaustion via crafted profiles (#111)
+- Terminal output in `profiles list` now strips ANSI escape sequences and control characters — prevents escape injection via malicious profile metadata (#111)
+- Downloaded profile content verified against SHA256 hashes in manifest before writing to disk (#111)
+
 ### Fixed
+
 - AWS secret regex used PCRE `(?i:...)` syntax that silently never matched in JavaScript — now uses `/i` flag (#103)
 - MCP server tool handlers now catch errors and return text instead of crashing (#103)
 - FTS5 queries sanitized to prevent syntax errors from user input (#103)
@@ -14,6 +27,10 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 - MCP server version synced with package.json (was hardcoded 1.0.0) (#103)
 
 ### Changed
+
+- README: new tagline — "Your context window is finite. MCP tool outputs aren't. mcp-recall bridges the gap." (#110)
+- README: new "The full context stack" section positions mcp-recall in the broader MCP ecosystem (#110)
+- README: simplified *How it works* diagram — 4-node overview with detailed pipeline in collapsible section (#110)
 - Denylist regex patterns cached — eliminated ~17 compilations per hook call (#103)
 - `getProjectKey` result cached — eliminated `spawnSync` per hook call (#103)
 - Store + chunk inserts wrapped in a transaction for atomicity and write perf (#103)
@@ -211,7 +228,8 @@ Ten `recall__*` tools available in every Claude session:
 
 ---
 
-[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.5.0...HEAD
+[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.6.0...HEAD
+[1.6.0]: https://github.com/sakebomb/mcp-recall/compare/v1.5.0...v1.6.0
 [1.5.0]: https://github.com/sakebomb/mcp-recall/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/sakebomb/mcp-recall/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/sakebomb/mcp-recall/compare/v1.2.0...v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.5.0",
+  "version": "1.6.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.5.0",
+    version: "1.6.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -12,6 +12,44 @@ _nothing scheduled — see backlog below_
 
 ---
 
+## Security: Manifest signing (sigstore — Phase 2)
+
+**Recommended approach: GitHub Artifact Attestations**
+Uses `actions/attest-build-provenance` — sigstore keyless under the hood, no key management, identity is the GitHub Actions OIDC token. Attestations stored in GitHub's store + Rekor transparency log. Client verifies with `gh attestation verify`.
+
+**Protects against:** CDN poisoning, partial repo compromise, tampered manifests.
+**Does not protect against:** Full `sakebomb` account compromise (attacker could trigger a new signed workflow run). Mitigate with pinned action SHAs.
+
+### Tasks
+
+**In `sakebomb/mcp-recall-profiles` (new workflow `sign-manifest.yml`):**
+1. Add `permissions: id-token: write, attestations: write` to manifest-regen job
+2. Add `actions/attest-build-provenance@v2` step after manifest generation, subject: `manifest.json`
+3. Pin all action versions to full commit SHAs
+4. Trigger: `workflow_dispatch` + push to `profiles/**` or `manifest.json`
+
+**In `mcp-recall` client (`src/profiles/commands.ts`):**
+5. Add `verifyManifest(path)` — shells out to `gh attestation verify <path> --repo sakebomb/mcp-recall-profiles`
+6. Add `profiles.verify_signature` config flag: `"warn"` (default) | `"error"` | `"skip"`
+   - `"warn"`: continue with warning if `gh` absent or verification fails
+   - `"error"`: abort on failure
+   - `"skip"`: bypass (air-gapped envs)
+7. Add `--skip-verify` flag to `install`, `update`, `seed` subcommands
+8. Degrade gracefully if `gh` not in PATH
+
+**Config (`src/config.ts`):**
+9. Add `profiles.verify_signature` to Zod schema, default `"warn"`
+
+**Tests:**
+10. Mock `Bun.spawnSync` for `verifyManifest` — assert warn/error/skip behavior
+11. Test `gh` not found → no throw
+
+**No new npm dependencies** — `gh` CLI already expected.
+
+**Scope: M** (1–3 days)
+
+---
+
 ## Open Issues (paused / backlog)
 
 | # | Title | Priority | Notes |


### PR DESCRIPTION
## Summary
- Bumps `package.json` version to 1.6.0
- Promotes `[Unreleased]` to `[1.6.0] — 2026-03-10` in CHANGELOG with Security, Fixed, and Changed sections
- Rebuilds dist with updated version
- Adds sigstore Phase 2 plan to `tasks/todo.md`

## What's in v1.6.0
- **Security**: path traversal + URL injection fix, denylist bypass fix, numeric bounds, ANSI escape sanitization, SHA256 hash verification (#111)
- **Fixed**: AWS regex, MCP error handling, FTS sanitization, PRAGMA optimize, version sync (#103)
- **Changed**: README tagline, ecosystem section, simplified diagram (#110); perf/cleanup (#103)

## Test plan
- [x] `bun test` — 516 pass
- [x] `bun run build` — clean
- [ ] Verify CHANGELOG renders correctly on GitHub