### PR TITLE
chore: bump to v1.5.1

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ---
 
-## [1.6.0] — 2026-03-10
+## [1.5.1] — 2026-03-10
 
 ### Security
 
@@ -228,8 +228,8 @@ Ten `recall__*` tools available in every Claude session:
 
 ---
 
-[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.6.0...HEAD
-[1.6.0]: https://github.com/sakebomb/mcp-recall/compare/v1.5.0...v1.6.0
+[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.5.1...HEAD
+[1.5.1]: https://github.com/sakebomb/mcp-recall/compare/v1.5.0...v1.5.1
 [1.5.0]: https://github.com/sakebomb/mcp-recall/compare/v1.4.0...v1.5.0
 [1.4.0]: https://github.com/sakebomb/mcp-recall/compare/v1.3.0...v1.4.0
 [1.3.0]: https://github.com/sakebomb/mcp-recall/compare/v1.2.0...v1.3.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.6.0",
+  "version": "1.5.1",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.6.0",
+    version: "1.5.1",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary
Corrects v1.6.0 (incorrectly bumped) to v1.5.1 — this release contains only bug fixes and security patches, no new features, so PATCH is the right increment per semver.

- `package.json` 1.6.0 → 1.5.1
- CHANGELOG `[1.6.0]` → `[1.5.1]`, comparison links updated
- Dist rebuilt