### PR TITLE
chore: update GitHub Actions to Node.js 24-compatible versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -11,9 +11,9 @@ jobs:
     name: Test & typecheck
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: latest
 
@@ -30,9 +30,9 @@ jobs:
     name: Bundle freshness
     runs-on: ubuntu-latest
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: latest
 

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -12,15 +12,15 @@ jobs:
       contents: read
       id-token: write
     steps:
-      - uses: actions/checkout@v4
+      - uses: actions/checkout@v6
 
-      - uses: oven-sh/setup-bun@v2
+      - uses: oven-sh/setup-bun@v2.1.3
         with:
           bun-version: latest
 
-      - uses: actions/setup-node@v4
+      - uses: actions/setup-node@v6
         with:
-          node-version: "20"
+          node-version: "24"
           registry-url: "https://registry.npmjs.org"
 
       - name: Install dependencies


### PR DESCRIPTION
## Summary

- `actions/checkout@v4` → `@v6` (released Nov 2025, uses Node.js 24 runtime)
- `oven-sh/setup-bun@v2` → `@v2.1.3` (latest v2 release, March 2026)
- `actions/setup-node@v4` → `@v6` + `node-version: "24"` (publish.yml only)

Addresses the Node.js 20 deprecation warnings that appeared in CI after #123. GitHub is forcing Node.js 24 as the default for action runners on June 2nd, 2026.

Note: if `oven-sh/setup-bun@v2.1.3` still emits the warning after this lands, we'll need to wait for a v3 release from that action — nothing more to do on our end.

## Test plan

- [ ] CI passes on this PR (both Test & typecheck and Bundle freshness jobs)
- [ ] No Node.js 20 deprecation warnings in the annotations