### PR TITLE
feat: add --all flag to profiles seed

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -7843,7 +7843,35 @@ function cmdRemove(args) {
   clearProfileCache();
   console.log(`\u2713 Removed ${id}`);
 }
-async function cmdSeed() {
+async function cmdSeed(args) {
+  const all = args.includes("--all");
+  process.stdout.write("Fetching manifest\u2026 ");
+  const entries = await fetchManifest();
+  console.log(`done
+`);
+  const installed = installedCommunityMap();
+  let installCount = 0;
+  let alreadyCount = 0;
+  if (all) {
+    for (const entry of entries) {
+      if (installed.has(entry.id)) {
+        console.log(`    ${entry.id}: already installed`);
+        alreadyCount++;
+        continue;
+      }
+      assertSafeId(entry.id);
+      assertSafeFile(entry.file);
+      const content = await fetchProfileContent(entry.file);
+      verifyHash(content, entry.sha256, entry.id);
+      saveToCommunitDir(entry.id, content);
+      console.log(`  \u2713 ${entry.id} installed`);
+      installCount++;
+    }
+    clearProfileCache();
+    console.log(`
+${installCount} profile(s) installed (${alreadyCount} already installed, ${entries.length} total available)`);
+    return;
+  }
   let serverKeys = [];
   try {
     const raw = JSON.parse(readFileSync4(join4(homedir4(), ".claude.json"), "utf8"));
@@ -7858,12 +7886,6 @@ async function cmdSeed() {
     return;
   }
   console.log(`Detected MCPs: ${serverKeys.join(", ")}`);
-  process.stdout.write("Fetching manifest\u2026 ");
-  const entries = await fetchManifest();
-  console.log(`done
-`);
-  const installed = installedCommunityMap();
-  let count = 0;
   for (const key of serverKeys) {
     const prefix = `mcp__${key.replace(/-/g, "_")}__`;
     const matches = entries.filter((e) => {
@@ -7880,6 +7902,7 @@ async function cmdSeed() {
     for (const entry of matches) {
       if (installed.has(entry.id)) {
         console.log(`  ${entry.id}: already installed`);
+        alreadyCount++;
         continue;
       }
       assertSafeId(entry.id);
@@ -7888,12 +7911,12 @@ async function cmdSeed() {
       verifyHash(content, entry.sha256, entry.id);
       saveToCommunitDir(entry.id, content);
       console.log(`  \u2713 ${entry.id} installed (matched ${key})`);
-      count++;
+      installCount++;
     }
   }
   clearProfileCache();
   console.log(`
-${count} profile(s) installed.`);
+${installCount} profile(s) installed.`);
 }
 function cmdFeed(args) {
   const profilePath = args[0];
@@ -8113,7 +8136,7 @@ async function handleProfilesCommand(args) {
       cmdRemove(rest);
       break;
     case "seed":
-      await cmdSeed();
+      await cmdSeed(rest);
       break;
     case "feed":
       cmdFeed(rest);
@@ -8137,7 +8160,7 @@ async function handleProfilesCommand(args) {
       console.error("  install <id>      Install a community profile by ID");
       console.error("  update            Update all installed community profiles");
       console.error("  remove <id>       Remove a community profile");
-      console.error("  seed              Install profiles for all detected MCPs");
+      console.error("  seed [--all]      Install profiles for all detected MCPs (--all for entire catalog)");
       console.error("  feed [path]       Contribute a local profile to the community");
       console.error("  check             Detect pattern conflicts");
       console.error("  retrain [--apply] [--depth N] [filter]  Suggest profile improvements from stored corpus");

--- a/src/profiles/commands.ts
+++ b/src/profiles/commands.ts
@@ -298,7 +298,37 @@ function cmdRemove(args: string[]): void {
 
 // ── seed ──────────────────────────────────────────────────────────────────────
 
-async function cmdSeed(): Promise<void> {
+export async function cmdSeed(args: string[]): Promise<void> {
+  const all = args.includes("--all");
+
+  process.stdout.write("Fetching manifest… ");
+  const entries = await fetchManifest();
+  console.log("done\n");
+
+  const installed = installedCommunityMap();
+  let installCount = 0;
+  let alreadyCount = 0;
+
+  if (all) {
+    for (const entry of entries) {
+      if (installed.has(entry.id)) {
+        console.log(`    ${entry.id}: already installed`);
+        alreadyCount++;
+        continue;
+      }
+      assertSafeId(entry.id);
+      assertSafeFile(entry.file);
+      const content = await fetchProfileContent(entry.file);
+      verifyHash(content, entry.sha256, entry.id);
+      saveToCommunitDir(entry.id, content);
+      console.log(`  ✓ ${entry.id} installed`);
+      installCount++;
+    }
+    clearProfileCache();
+    console.log(`\n${installCount} profile(s) installed (${alreadyCount} already installed, ${entries.length} total available)`);
+    return;
+  }
+
   let serverKeys: string[] = [];
   try {
     const raw = JSON.parse(
@@ -317,12 +347,6 @@ async function cmdSeed(): Promise<void> {
   }
 
   console.log(`Detected MCPs: ${serverKeys.join(", ")}`);
-  process.stdout.write("Fetching manifest… ");
-  const entries = await fetchManifest();
-  console.log("done\n");
-
-  const installed = installedCommunityMap();
-  let count = 0;
 
   for (const key of serverKeys) {
     const prefix = `mcp__${key.replace(/-/g, "_")}__`;
@@ -342,6 +366,7 @@ async function cmdSeed(): Promise<void> {
     for (const entry of matches) {
       if (installed.has(entry.id)) {
         console.log(`  ${entry.id}: already installed`);
+        alreadyCount++;
         continue;
       }
       assertSafeId(entry.id);
@@ -350,12 +375,12 @@ async function cmdSeed(): Promise<void> {
       verifyHash(content, entry.sha256, entry.id);
       saveToCommunitDir(entry.id, content);
       console.log(`  ✓ ${entry.id} installed (matched ${key})`);
-      count++;
+      installCount++;
     }
   }
 
   clearProfileCache();
-  console.log(`\n${count} profile(s) installed.`);
+  console.log(`\n${installCount} profile(s) installed.`);
 }
 
 // ── feed ──────────────────────────────────────────────────────────────────────
@@ -621,7 +646,7 @@ export async function handleProfilesCommand(args: string[]): Promise<void> {
       cmdRemove(rest);
       break;
     case "seed":
-      await cmdSeed();
+      await cmdSeed(rest);
       break;
     case "feed":
       cmdFeed(rest);
@@ -643,7 +668,7 @@ export async function handleProfilesCommand(args: string[]): Promise<void> {
       console.error("  install <id>      Install a community profile by ID");
       console.error("  update            Update all installed community profiles");
       console.error("  remove <id>       Remove a community profile");
-      console.error("  seed              Install profiles for all detected MCPs");
+      console.error("  seed [--all]      Install profiles for all detected MCPs (--all for entire catalog)");
       console.error("  feed [path]       Contribute a local profile to the community");
       console.error("  check             Detect pattern conflicts");
       console.error("  retrain [--apply] [--depth N] [filter]  Suggest profile improvements from stored corpus");

--- a/tests/profiles-commands.test.ts
+++ b/tests/profiles-commands.test.ts
@@ -297,3 +297,129 @@ type = "text_truncate"`
     expect(lines.join("").trim()).toBe("");
   });
 });
+
+// ── cmdSeed --all ─────────────────────────────────────────────────────────────
+
+describe("cmdSeed --all", () => {
+  let communityDir: string;
+  let originalFetch: typeof globalThis.fetch;
+
+  const fakeManifest = {
+    profiles: [
+      {
+        id: "mcp__grafana",
+        version: "1.0.0",
+        description: "Grafana",
+        mcp_pattern: "mcp__grafana__*",
+        file: "profiles/mcp__grafana/default.toml",
+        sha256: undefined,
+      },
+      {
+        id: "mcp__jira",
+        version: "1.0.0",
+        description: "Jira",
+        mcp_pattern: "mcp__jira__*",
+        file: "profiles/mcp__jira/default.toml",
+        sha256: undefined,
+      },
+    ],
+  };
+
+  const fakeToml = (id: string) => `[profile]
+id = "${id}"
+version = "1.0.0"
+description = "Test"
+mcp_pattern = "${id}__*"
+[strategy]
+type = "text_truncate"`;
+
+  beforeEach(() => {
+    communityDir = mkdtempSync(join(tmpdir(), "recall-seed-"));
+    clearProfileCache();
+    process.env.RECALL_COMMUNITY_PROFILES_PATH = communityDir;
+    originalFetch = globalThis.fetch;
+    globalThis.fetch = (async (url: string | URL | Request) => {
+      const u = url.toString();
+      if (u.includes("manifest.json")) {
+        return new Response(JSON.stringify(fakeManifest), { status: 200 });
+      }
+      if (u.includes("mcp__grafana")) {
+        return new Response(fakeToml("mcp__grafana"), { status: 200 });
+      }
+      if (u.includes("mcp__jira")) {
+        return new Response(fakeToml("mcp__jira"), { status: 200 });
+      }
+      return new Response("not found", { status: 404 });
+    }) as typeof globalThis.fetch;
+  });
+
+  afterEach(() => {
+    rmSync(communityDir, { recursive: true, force: true });
+    delete process.env.RECALL_COMMUNITY_PROFILES_PATH;
+    clearProfileCache();
+    globalThis.fetch = originalFetch;
+  });
+
+  test("installs all profiles from manifest when --all is passed", async () => {
+    const { cmdSeed } = require("../src/profiles/commands");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(" "));
+    try {
+      await cmdSeed(["--all"]);
+    } finally {
+      console.log = orig;
+    }
+    const output = lines.join("\n");
+    expect(output).toContain("mcp__grafana installed");
+    expect(output).toContain("mcp__jira installed");
+    expect(output).toContain("2 profile(s) installed");
+    expect(output).toContain("0 already installed");
+    expect(output).toContain("2 total available");
+
+    // Files should exist on disk
+    const { existsSync } = require("fs");
+    expect(existsSync(join(communityDir, "mcp__grafana", "default.toml"))).toBe(true);
+    expect(existsSync(join(communityDir, "mcp__jira", "default.toml"))).toBe(true);
+  });
+
+  test("skips already-installed profiles and reports them in summary", async () => {
+    // Pre-install grafana
+    mkdirSync(join(communityDir, "mcp__grafana"), { recursive: true });
+    writeFileSync(join(communityDir, "mcp__grafana", "default.toml"), fakeToml("mcp__grafana"));
+
+    const { cmdSeed } = require("../src/profiles/commands");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(" "));
+    try {
+      clearProfileCache();
+      await cmdSeed(["--all"]);
+    } finally {
+      console.log = orig;
+    }
+    const output = lines.join("\n");
+    expect(output).toContain("mcp__grafana: already installed");
+    expect(output).toContain("mcp__jira installed");
+    expect(output).toContain("1 profile(s) installed");
+    expect(output).toContain("1 already installed");
+  });
+
+  test("--all installs profiles without reading claude.json (no Detected MCPs line)", async () => {
+    const { cmdSeed } = require("../src/profiles/commands");
+    const lines: string[] = [];
+    const orig = console.log;
+    console.log = (...args: unknown[]) => lines.push(args.join(" "));
+    try {
+      clearProfileCache();
+      await cmdSeed(["--all"]);
+    } finally {
+      console.log = orig;
+    }
+    const output = lines.join("\n");
+    // --all skips MCP detection entirely
+    expect(output).not.toContain("Detected MCPs");
+    // Both profiles installed
+    expect(output).toContain("2 profile(s) installed");
+  });
+});


### PR DESCRIPTION
## Summary

- `mcp-recall profiles seed --all` installs every profile in the community catalog, skipping MCP detection
- Idempotent — already-installed profiles are skipped and counted in the summary
- Default behavior (`mcp-recall profiles seed` with no flag) is unchanged
- Summary line shows installed / already installed / total available counts

Closes #121.

## Test plan

- [x] `bun test` — 531 passing, 0 failures
- [x] `bun run typecheck` — clean
- [x] 3 new tests: installs all, skips already-installed, skips MCP detection line with --all