### PR TITLE
feat: improve profile seeding discoverability

### DIFF
--- a/README.md
+++ b/README.md
@@ -160,8 +160,43 @@ git clone https://github.com/sakebomb/mcp-recall
 cd mcp-recall
 bun install
 bun run build
-mcp-recall install
+./bin/recall install
 ```
+
+The `mcp-recall` binary is not on PATH for source installs. Add an alias so the CLI works everywhere:
+
+```bash
+echo 'alias mcp-recall="bun /path/to/mcp-recall/plugins/mcp-recall/dist/cli.js"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+Or symlink it:
+
+```bash
+ln -sf /path/to/mcp-recall/plugins/mcp-recall/dist/cli.js ~/.local/bin/mcp-recall
+```
+
+---
+
+## Profiles
+
+Profiles teach mcp-recall how to compress output from specific MCPs. **[18 community profiles](https://github.com/sakebomb/mcp-recall-profiles)** cover Jira, Stripe, Grafana, Shopify, Notion, and more.
+
+```bash
+# Install profiles for all your connected MCPs
+mcp-recall profiles seed
+
+# Or install the full community catalog at once
+mcp-recall profiles seed --all
+
+# See what's installed
+mcp-recall profiles list
+
+# Keep profiles up to date
+mcp-recall profiles update
+```
+
+→ [Profiles quickstart](docs/profiles-quickstart.md) · [Profile schema](docs/profile-schema.md) · [Community catalog](https://github.com/sakebomb/mcp-recall-profiles)
 
 ---
 
@@ -343,7 +378,7 @@ mcp-recall profiles test <tool>     # apply a profile and show compression resul
 mcp-recall profiles list            # show all installed profiles
 ```
 
-→ [Profile schema](docs/profile-schema.md) · [retrain guide](docs/retrain.md) · [AI profile guide](docs/ai-profile-guide.md) · [Contributing a profile](CONTRIBUTING.md#contributing-a-profile)
+→ [Profiles quickstart](docs/profiles-quickstart.md) · [Profile schema](docs/profile-schema.md) · [retrain guide](docs/retrain.md) · [AI profile guide](docs/ai-profile-guide.md) · [Contributing a profile](CONTRIBUTING.md#contributing-a-profile)
 
 ---
 

--- a/docs/profiles-quickstart.md
+++ b/docs/profiles-quickstart.md
@@ -1,0 +1,116 @@
+# Profiles quickstart
+
+Profiles tell mcp-recall how to compress output from specific MCPs — which fields to keep, how many items to show, and how to summarise responses. Without a profile, mcp-recall falls back to a generic text truncator that works but isn't as smart.
+
+The [community profiles repo](https://github.com/sakebomb/mcp-recall-profiles) has 18+ ready-made profiles. This guide walks through getting them installed for each install method.
+
+---
+
+## npm / bun global install
+
+The `mcp-recall` CLI is already on PATH. Just seed:
+
+```bash
+# Install profiles for your currently connected MCPs
+mcp-recall profiles seed
+
+# Or install the entire community catalog at once
+mcp-recall profiles seed --all
+
+# Verify
+mcp-recall profiles list
+
+# Keep profiles current
+mcp-recall profiles update
+```
+
+---
+
+## Claude Code plugin marketplace
+
+The CLI is bundled with the plugin. Use it the same way:
+
+```bash
+mcp-recall profiles seed
+mcp-recall profiles list
+```
+
+If `mcp-recall` isn't found, verify the plugin installed correctly:
+
+```bash
+claude --debug
+```
+
+---
+
+## From source
+
+The `bin/recall` script runs the CLI using your local Bun installation. After running `bun run build`, make it available on PATH so you can use the full `mcp-recall` command:
+
+**Option 1 — alias (quick)**
+
+```bash
+echo 'alias mcp-recall="bun /path/to/mcp-recall/plugins/mcp-recall/dist/cli.js"' >> ~/.zshrc
+source ~/.zshrc
+```
+
+**Option 2 — symlink (permanent)**
+
+```bash
+ln -sf /path/to/mcp-recall/plugins/mcp-recall/dist/cli.js ~/.local/bin/mcp-recall
+# make sure ~/.local/bin is in your PATH
+```
+
+Then seed profiles normally:
+
+```bash
+mcp-recall profiles seed
+mcp-recall profiles list
+```
+
+---
+
+## Keeping community profiles updated
+
+Community profiles live in `~/.local/share/mcp-recall/profiles/community/`. They are never overwritten by local customisations.
+
+```bash
+# Update all community profiles to latest versions
+mcp-recall profiles update
+
+# Check for pattern conflicts between installed profiles
+mcp-recall profiles check
+```
+
+---
+
+## Local customisations
+
+Local profiles live in `~/.config/mcp-recall/profiles/` and always take precedence over community profiles. Edit freely — `mcp-recall profiles update` will never touch them.
+
+```bash
+# See which tier each profile comes from (user / community / bundled)
+mcp-recall profiles list
+
+# Test a profile against real stored output
+mcp-recall profiles test mcp__grafana__search_dashboards
+
+# Suggest field improvements using your stored data
+mcp-recall profiles retrain
+```
+
+---
+
+## Contributing a profile
+
+If you use an MCP that isn't covered, the easiest path is:
+
+```bash
+# Generate a profile suggestion from your session data
+mcp-recall learn
+
+# Contribute it to the community repo
+mcp-recall profiles feed path/to/your/profile.toml
+```
+
+→ Full guide: [AI profile guide](ai-profile-guide.md) · [Profile schema](profile-schema.md)

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -8734,6 +8734,19 @@ Installation: ${BOLD}${label}${RESET}
     }
   }
   console.log("");
+  const profiles = loadProfiles();
+  if (profiles.length === 0) {
+    console.log(`  ${RED}\u2717${RESET} Profiles: none installed`);
+    console.log(`    \u2192 Run: ${BOLD}mcp-recall profiles seed${RESET}`);
+  } else {
+    const counts = profiles.reduce((acc, p) => {
+      acc[p.tier] = (acc[p.tier] ?? 0) + 1;
+      return acc;
+    }, {});
+    const summary = Object.entries(counts).map(([t, n]) => `${n} ${t}`).join(", ");
+    console.log(`  ${GREEN}\u2713${RESET} Profiles: ${profiles.length} installed (${summary})`);
+  }
+  console.log("");
 }
 
 // src/cli.ts

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -12,6 +12,7 @@ import { existsSync } from "fs";
 import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
+import { loadProfiles } from "../profiles/loader";
 
 // ── ANSI ─────────────────────────────────────────────────────────────────────
 
@@ -365,6 +366,21 @@ export async function statusCommand(opts: StatusOptions = {}): Promise<void> {
     } else {
       console.log(`  Run ${BOLD}mcp-recall install${RESET}`);
     }
+  }
+
+  // Profiles
+  console.log("");
+  const profiles = loadProfiles();
+  if (profiles.length === 0) {
+    console.log(`  ${RED}✗${RESET} Profiles: none installed`);
+    console.log(`    → Run: ${BOLD}mcp-recall profiles seed${RESET}`);
+  } else {
+    const counts = profiles.reduce<Record<string, number>>((acc, p) => {
+      acc[p.tier] = (acc[p.tier] ?? 0) + 1;
+      return acc;
+    }, {});
+    const summary = Object.entries(counts).map(([t, n]) => `${n} ${t}`).join(", ");
+    console.log(`  ${GREEN}✓${RESET} Profiles: ${profiles.length} installed (${summary})`);
   }
 
   console.log("");


### PR DESCRIPTION
## Summary

- `mcp-recall status` now shows profile count with a `→ Run: mcp-recall profiles seed` nudge when none are installed
- README: new **Profiles** section right after Install with `seed`, `seed --all`, `list`, and `update` commands
- README: Option C (from source) now explains how to put the CLI on PATH (alias or symlink)
- `docs/profiles-quickstart.md`: step-by-step for npm, plugin marketplace, and source installs — covers local customisations and contributing

Closes #118.

## Test plan

- [x] `bun test` — 528 passing, 0 failures
- [x] `bun run typecheck` — clean
- [x] `mcp-recall status` output manually reviewed — shows profile count section at the bottom
- [ ] Verify README renders correctly on GitHub (Profiles section visible after Install)