### PR TITLE
test: recall__forget older_than_days coverage + guard + bump expiry default to 30 days

### DIFF
--- a/README.md
+++ b/README.md
@@ -210,7 +210,7 @@ mcp-recall works out of the box. To customize, create `~/.config/mcp-recall/conf
 # Vacations and context switches to other projects don't count —
 # only days you actively used Claude Code on this project.
 # See "Session days" below.
-expire_after_session_days = 7
+expire_after_session_days = 30
 
 # How to identify a project.
 # "git_root" is recommended — stable regardless of launch directory.

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5051,7 +5051,7 @@ var RecallConfigSchema = exports_external.object({
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
 var DEFAULTS = {
   store: {
-    expire_after_session_days: 7,
+    expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
     pin_recommendation_threshold: 5,

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20928,7 +20928,7 @@ var RecallConfigSchema = exports_external.object({
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
 var DEFAULTS = {
   store: {
-    expire_after_session_days: 7,
+    expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
@@ -21100,6 +21100,9 @@ function toolExport(db, projectKey) {
 function toolForget(db, projectKey, args) {
   if (args.all && !args.confirmed) {
     return `[recall: clearing all stored items requires confirmed: true]`;
+  }
+  if (args.older_than_days !== undefined && args.older_than_days < 1) {
+    return `[recall: older_than_days must be at least 1 \u2014 use all: true with confirmed: true to delete everything]`;
   }
   const options = {
     id: args.id,

--- a/src/config.ts
+++ b/src/config.ts
@@ -31,7 +31,7 @@ export type RecallConfig = z.infer<typeof RecallConfigSchema>;
 
 const DEFAULTS: RecallConfig = {
   store: {
-    expire_after_session_days: 7,
+    expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
     pin_recommendation_threshold: 5,

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -233,6 +233,10 @@ export function toolForget(
     return `[recall: clearing all stored items requires confirmed: true]`;
   }
 
+  if (args.older_than_days !== undefined && args.older_than_days < 1) {
+    return `[recall: older_than_days must be at least 1 — use all: true with confirmed: true to delete everything]`;
+  }
+
   const options: ForgetOptions = {
     id: args.id,
     tool: args.tool,

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -22,7 +22,7 @@ describe("loadConfig", () => {
 
   it("returns defaults when no config file exists", () => {
     const config = loadConfig();
-    expect(config.store.expire_after_session_days).toBe(7);
+    expect(config.store.expire_after_session_days).toBe(30);
     expect(config.store.key).toBe("git_root");
     expect(config.store.max_size_mb).toBe(500);
     expect(config.store.pin_recommendation_threshold).toBe(5);
@@ -49,7 +49,7 @@ describe("loadConfig", () => {
     writeFileSync(TEST_CONFIG_PATH, "[store]\nmax_size_mb = 1024\n");
     const config = loadConfig();
     expect(config.store.max_size_mb).toBe(1024);
-    expect(config.store.expire_after_session_days).toBe(7);
+    expect(config.store.expire_after_session_days).toBe(30);
     expect(config.store.key).toBe("git_root");
     expect(config.retrieve.default_max_bytes).toBe(8192);
   });
@@ -63,7 +63,7 @@ describe("loadConfig", () => {
   it("falls back to defaults on malformed TOML", () => {
     writeFileSync(TEST_CONFIG_PATH, "this is not @@## valid toml");
     const config = loadConfig();
-    expect(config.store.expire_after_session_days).toBe(7);
+    expect(config.store.expire_after_session_days).toBe(30);
   });
 
   it("strips unknown keys from TOML", () => {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -188,6 +188,53 @@ describe("MCP tool handlers", () => {
       const result = toolForget(db, PROJECT_KEY, { id: "recall_00000000" });
       expect(result).toContain("nothing deleted");
     });
+
+    it("rejects older_than_days: 0 with a guard error", () => {
+      const result = toolForget(db, PROJECT_KEY, { older_than_days: 0 });
+      expect(result).toContain("older_than_days must be at least 1");
+    });
+
+    it("rejects negative older_than_days", () => {
+      const result = toolForget(db, PROJECT_KEY, { older_than_days: -5 });
+      expect(result).toContain("older_than_days must be at least 1");
+    });
+
+    it("deletes items older than the cutoff, retains newer ones", () => {
+      const old = storeOutput(db, makeInput({ summary: "old item" }));
+      const fresh = storeOutput(db, makeInput({ summary: "fresh item" }));
+
+      // Back-date the old item to 10 days ago
+      const tenDaysAgo = Math.floor(Date.now() / 1000) - 10 * 86400;
+      db.prepare("UPDATE stored_outputs SET created_at = ? WHERE id = ?").run(tenDaysAgo, old.id);
+
+      const result = toolForget(db, PROJECT_KEY, { older_than_days: 7 });
+      expect(result).toContain("deleted 1 item");
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(old.id)).toBeNull();
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(fresh.id)).not.toBeNull();
+    });
+
+    it("returns nothing-deleted when no items are old enough", () => {
+      storeOutput(db, makeInput({ summary: "fresh item" }));
+      const result = toolForget(db, PROJECT_KEY, { older_than_days: 30 });
+      expect(result).toContain("nothing deleted");
+    });
+
+    it("does not delete pinned items when using older_than_days", () => {
+      const pinned = storeOutput(db, makeInput({ summary: "pinned old item" }));
+      const unpinned = storeOutput(db, makeInput({ summary: "unpinned old item" }));
+
+      // Back-date both to 10 days ago
+      const tenDaysAgo = Math.floor(Date.now() / 1000) - 10 * 86400;
+      db.prepare("UPDATE stored_outputs SET created_at = ? WHERE id = ?").run(tenDaysAgo, pinned.id);
+      db.prepare("UPDATE stored_outputs SET created_at = ? WHERE id = ?").run(tenDaysAgo, unpinned.id);
+
+      pinOutput(db, pinned.id, PROJECT_KEY, true);
+
+      const result = toolForget(db, PROJECT_KEY, { older_than_days: 7 });
+      expect(result).toContain("deleted 1 item");
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(pinned.id)).not.toBeNull();
+      expect(db.prepare("SELECT id FROM stored_outputs WHERE id = ?").get(unpinned.id)).toBeNull();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Guard: `older_than_days < 1` returns a clear error directing users to `all: true + confirmed: true` instead of silently deleting everything
- Default `expire_after_session_days` bumped **7 → 30** — more realistic for ongoing projects with vacations and context switches (session days, not calendar days)
- 5 new tests covering all scenarios from #116: guard (0 and negative), age deletion with retention of newer items, nothing-deleted when no match, and pin protection under age-based deletion

Closes #116.

## Test plan

- [x] `bun test` — 536 passing, 0 failures
- [x] `bun run typecheck` — clean
- [x] Config tests updated to expect new default of 30