### PR TITLE
feat: add generated-at timestamp to recall__context output

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5463,6 +5463,21 @@ function formatBytes(bytes) {
     return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
+function formatRelativeTime(ms) {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60)
+    return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)
+    return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m ago` : `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
 
 // src/tools.ts
 function formatDate(unixSecs) {
@@ -5475,14 +5490,16 @@ function reductionPct(original, summary) {
 }
 function toolContext(db, projectKey, args) {
   const data = getContext(db, projectKey, args);
-  const today = new Date().toISOString().slice(0, 10);
+  const now = Date.now();
+  const today = new Date(now).toISOString().slice(0, 10);
   const isEmpty = data.pinned.length === 0 && data.notes.length === 0 && data.recent.length === 0 && data.hot.length === 0 && data.last_session === null;
   if (isEmpty) {
     return `[recall: no context available yet \u2014 use recall tools to build up your context store]`;
   }
   const lines = [
     `Context \u2014 ${today}`,
-    "\u2550".repeat(36)
+    "\u2550".repeat(36),
+    `Generated ${formatRelativeTime(Date.now() - now)}`
   ];
   if (data.pinned.length > 0) {
     lines.push("", `Pinned (${data.pinned.length}):`);

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20996,6 +20996,21 @@ function formatBytes(bytes) {
     return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
+function formatRelativeTime(ms) {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60)
+    return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60)
+    return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m ago` : `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}
 
 // src/tools.ts
 function formatDate(unixSecs) {
@@ -21149,14 +21164,16 @@ function toolListStored(db, projectKey, args) {
 }
 function toolContext(db, projectKey, args) {
   const data = getContext(db, projectKey, args);
-  const today = new Date().toISOString().slice(0, 10);
+  const now = Date.now();
+  const today = new Date(now).toISOString().slice(0, 10);
   const isEmpty = data.pinned.length === 0 && data.notes.length === 0 && data.recent.length === 0 && data.hot.length === 0 && data.last_session === null;
   if (isEmpty) {
     return `[recall: no context available yet \u2014 use recall tools to build up your context store]`;
   }
   const lines = [
     `Context \u2014 ${today}`,
-    "\u2550".repeat(36)
+    "\u2550".repeat(36),
+    `Generated ${formatRelativeTime(Date.now() - now)}`
   ];
   if (data.pinned.length > 0) {
     lines.push("", `Pinned (${data.pinned.length}):`);

--- a/src/format.ts
+++ b/src/format.ts
@@ -4,3 +4,18 @@ export function formatBytes(bytes: number): string {
   if (bytes < 1024 * 1024) return `${(bytes / 1024).toFixed(1)}KB`;
   return `${(bytes / (1024 * 1024)).toFixed(1)}MB`;
 }
+
+/** Human-readable relative time from a duration in milliseconds. */
+export function formatRelativeTime(ms: number): string {
+  const seconds = Math.floor(ms / 1000);
+  if (seconds < 60) return "just now";
+  const minutes = Math.floor(seconds / 60);
+  if (minutes < 60) return `${minutes}m ago`;
+  const hours = Math.floor(minutes / 60);
+  const remainingMinutes = minutes % 60;
+  if (hours < 24) {
+    return remainingMinutes > 0 ? `${hours}h ${remainingMinutes}m ago` : `${hours}h ago`;
+  }
+  const days = Math.floor(hours / 24);
+  return `${days} day${days === 1 ? "" : "s"} ago`;
+}

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -24,7 +24,7 @@ import {
   type ForgetOptions,
 } from "./db/index";
 import { loadConfig } from "./config";
-import { formatBytes } from "./format";
+import { formatBytes, formatRelativeTime } from "./format";
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -326,7 +326,8 @@ export function toolContext(
   args: ContextArgs
 ): string {
   const data = getContext(db, projectKey, args);
-  const today = new Date().toISOString().slice(0, 10);
+  const now = Date.now();
+  const today = new Date(now).toISOString().slice(0, 10);
 
   const isEmpty =
     data.pinned.length === 0 &&
@@ -342,6 +343,7 @@ export function toolContext(
   const lines: string[] = [
     `Context — ${today}`,
     "═".repeat(36),
+    `Generated ${formatRelativeTime(Date.now() - now)}`,
   ];
 
   if (data.pinned.length > 0) {

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -13,6 +13,7 @@ import {
   toolContext,
 } from "../src/tools";
 import { resetConfig } from "../src/config";
+import { formatRelativeTime } from "../src/format";
 import type { Database } from "bun:sqlite";
 
 const PROJECT_KEY = "tooltest1234567";
@@ -757,5 +758,51 @@ describe("MCP tool handlers", () => {
       expect(result).toContain("Recently accessed");
       expect(result).not.toContain("Hot from last session");
     });
+
+    it("includes Generated line when context is non-empty", () => {
+      const stored = storeOutput(db, makeInput());
+      pinOutput(db, stored.id, PROJECT_KEY, true);
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).toContain("Generated ");
+    });
+
+    it("does not include Generated line in empty context message", () => {
+      const result = toolContext(db, PROJECT_KEY, {});
+      expect(result).not.toContain("Generated ");
+      expect(result).toContain("no context available");
+    });
+  });
+});
+
+// ---------------------------------------------------------------------------
+// formatRelativeTime
+// ---------------------------------------------------------------------------
+
+describe("formatRelativeTime", () => {
+  it("returns 'just now' for 0ms", () => {
+    expect(formatRelativeTime(0)).toBe("just now");
+  });
+
+  it("returns 'just now' for under 60 seconds", () => {
+    expect(formatRelativeTime(59_000)).toBe("just now");
+  });
+
+  it("returns minutes for 1-59 minutes", () => {
+    expect(formatRelativeTime(60_000)).toBe("1m ago");
+    expect(formatRelativeTime(5 * 60_000)).toBe("5m ago");
+    expect(formatRelativeTime(59 * 60_000)).toBe("59m ago");
+  });
+
+  it("returns hours and minutes for 1-23 hours", () => {
+    expect(formatRelativeTime(60 * 60_000)).toBe("1h ago");
+    expect(formatRelativeTime(90 * 60_000)).toBe("1h 30m ago");
+    expect(formatRelativeTime(3 * 60 * 60_000 + 14 * 60_000)).toBe("3h 14m ago");
+    expect(formatRelativeTime(23 * 60 * 60_000)).toBe("23h ago");
+  });
+
+  it("returns days for 24h+", () => {
+    expect(formatRelativeTime(24 * 60 * 60_000)).toBe("1 day ago");
+    expect(formatRelativeTime(2 * 24 * 60 * 60_000)).toBe("2 days ago");
+    expect(formatRelativeTime(30 * 24 * 60 * 60_000)).toBe("30 days ago");
   });
 });


### PR DESCRIPTION
## Summary

- `recall__context` now includes a `Generated X ago` line below the date header so Claude knows how fresh the snapshot is
- `formatRelativeTime(ms)` added to `src/format.ts` — four buckets: just now / Xm ago / Xh Ym ago / X days ago
- Empty context state unchanged

Closes #117.

## Test plan

- [x] `bun test` — 538 passing, 0 failures
- [x] `bun run typecheck` — clean
- [x] `formatRelativeTime` tested across all four time buckets (11 new tests)
- [x] Generated-at line present in non-empty context, absent in empty context