### PR TITLE
feat: add 5 new bash handlers (git status, package install, test runners, docker ps, make/just)

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5981,6 +5981,8 @@ ${fmt.body}`,
 // src/handlers/bash.ts
 var MAX_LOG_COMMITS = 20;
 var MAX_TERRAFORM_RESOURCES = 10;
+var MAX_DOCKER_CONTAINERS = 20;
+var MAX_BUILD_ERRORS = 20;
 function extractStdout(output) {
   if (output !== null && typeof output === "object") {
     const obj = output;
@@ -5990,6 +5992,14 @@ function extractStdout(output) {
       return stripSshNoise(stripAnsi(obj.output));
   }
   return stripSshNoise(stripAnsi(extractText(output)));
+}
+function extractStderr(output) {
+  if (output !== null && typeof output === "object") {
+    const obj = output;
+    if (typeof obj.stderr === "string")
+      return stripAnsi(obj.stderr);
+  }
+  return "";
 }
 function extractCommand(input) {
   if (input !== null && typeof input === "object") {
@@ -6092,6 +6102,74 @@ var gitLogHandler = (_toolName, output) => {
     originalSize
   };
 };
+var gitStatusHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  if (!stdout.trim()) {
+    return { summary: "[git status \u2014 clean working tree]", originalSize };
+  }
+  const staged = [];
+  const unstaged = [];
+  const untracked = [];
+  const conflicts = [];
+  let section = null;
+  for (const line of stdout.split(`
+`)) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("Changes to be committed")) {
+      section = "staged";
+      continue;
+    }
+    if (trimmed.startsWith("Changes not staged")) {
+      section = "unstaged";
+      continue;
+    }
+    if (trimmed.startsWith("Untracked files")) {
+      section = "untracked";
+      continue;
+    }
+    if (trimmed.startsWith("both modified") || trimmed.startsWith("both added")) {
+      conflicts.push(trimmed);
+      continue;
+    }
+    if (!trimmed || trimmed.startsWith("(") || trimmed.startsWith("no changes"))
+      continue;
+    if (trimmed.startsWith("On branch") || trimmed.startsWith("HEAD") || trimmed.startsWith("Your branch") || trimmed.startsWith("nothing"))
+      continue;
+    const porcelain = line.match(/^([MADRCU?!]{1,2})\s+(.+)$/);
+    if (porcelain) {
+      const [, code, file] = porcelain;
+      if (code.startsWith("?"))
+        untracked.push(file);
+      else if (code[0] !== " " && code[0] !== "?")
+        staged.push(`${code[0]} ${file}`);
+      if (code[1] && code[1] !== " " && code[1] !== "?")
+        unstaged.push(`${code[1]} ${file}`);
+      continue;
+    }
+    if (section === "staged" && trimmed.match(/^(modified|new file|deleted|renamed):/)) {
+      staged.push(trimmed);
+    } else if (section === "unstaged" && trimmed.match(/^(modified|deleted):/)) {
+      unstaged.push(trimmed);
+    } else if (section === "untracked" && trimmed && !trimmed.startsWith("(")) {
+      untracked.push(trimmed);
+    }
+  }
+  if (staged.length === 0 && unstaged.length === 0 && untracked.length === 0 && conflicts.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const lines = ["git status"];
+  if (conflicts.length > 0)
+    lines.push(`  conflicts (${conflicts.length}): ${conflicts.slice(0, 5).join(", ")}`);
+  if (staged.length > 0)
+    lines.push(`  staged (${staged.length}): ${staged.slice(0, 5).map((f) => f.replace(/^(modified|new file|deleted|renamed):\s*/, "")).join(", ")}${staged.length > 5 ? ` +${staged.length - 5} more` : ""}`);
+  if (unstaged.length > 0)
+    lines.push(`  unstaged (${unstaged.length}): ${unstaged.slice(0, 5).map((f) => f.replace(/^(modified|deleted):\s*/, "")).join(", ")}${unstaged.length > 5 ? ` +${unstaged.length - 5} more` : ""}`);
+  if (untracked.length > 0)
+    lines.push(`  untracked (${untracked.length}): ${untracked.slice(0, 5).join(", ")}${untracked.length > 5 ? ` +${untracked.length - 5} more` : ""}`);
+  return { summary: lines.join(`
+`), originalSize };
+};
 var TERRAFORM_RESOURCE_RE = /^\s+#\s+(.+?)\s+will\s+be\s+(created|destroyed|updated in-place|replaced)/;
 var TERRAFORM_PLAN_SUMMARY_RE = /^Plan:\s+.+$/m;
 var TERRAFORM_SYMBOL = {
@@ -6128,6 +6206,232 @@ var terraformPlanHandler = (toolName, output) => {
   return { summary: lines.join(`
 `), originalSize };
 };
+var packageInstallHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}
+${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const warnings = [];
+  const errors2 = [];
+  for (const line of combined.split(`
+`)) {
+    const t = line.trim();
+    if (!t)
+      continue;
+    if (/^(npm warn|warn |warning )/i.test(t))
+      warnings.push(t.slice(0, 100));
+    else if (/^(npm error|error |err )/i.test(t))
+      errors2.push(t.slice(0, 100));
+  }
+  let countLine = null;
+  const bunMatch = combined.match(/(\d+)\s+packages?\s+installed/i);
+  if (bunMatch)
+    countLine = `${bunMatch[1]} packages installed`;
+  if (!countLine) {
+    const npmMatch = combined.match(/added\s+(\d+)[^,\n]*/i);
+    if (npmMatch)
+      countLine = npmMatch[0].trim().slice(0, 60);
+  }
+  if (!countLine) {
+    const pipMatch = combined.match(/Successfully installed (.+)/);
+    if (pipMatch) {
+      const pkgs = pipMatch[1].trim().split(/\s+/);
+      countLine = `pip: ${pkgs.length} package${pkgs.length === 1 ? "" : "s"} installed`;
+    }
+  }
+  if (!countLine) {
+    const yarnMatch = combined.match(/success Saved (\d+) new dependenc/i);
+    if (yarnMatch)
+      countLine = `yarn: ${yarnMatch[1]} new dependencies saved`;
+  }
+  if (!countLine && errors2.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const lines = [countLine ?? "package install"];
+  if (warnings.length > 0)
+    lines.push(`  ${warnings.length} warning${warnings.length === 1 ? "" : "s"}${warnings.length <= 3 ? ": " + warnings.join("; ") : ""}`);
+  if (errors2.length > 0)
+    lines.push(...errors2.slice(0, 5).map((e) => `  error: ${e}`));
+  return { summary: lines.join(`
+`), originalSize };
+};
+var testRunnerHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}
+${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const failureLines = [];
+  for (const line of combined.split(`
+`)) {
+    const t = line.trim();
+    if (!t)
+      continue;
+    if (/^(FAILED|FAIL)\s+/.test(t) || /^[\u2715\u2717\u00D7\u25CF]\s/.test(t) || /^\(fail\)\s/.test(t) || /^--- FAIL:/.test(t)) {
+      failureLines.push(t.slice(0, 120));
+    }
+  }
+  let passed = 0, failed = 0, skipped = 0;
+  let foundSummary = false;
+  for (const line of combined.split(`
+`)) {
+    const t = line.trim();
+    const bunPass = t.match(/^(\d+)\s+pass$/);
+    const bunFail = t.match(/^(\d+)\s+fail$/);
+    if (bunPass) {
+      passed = parseInt(bunPass[1]);
+      foundSummary = true;
+    }
+    if (bunFail) {
+      failed = parseInt(bunFail[1]);
+      foundSummary = true;
+    }
+    const pytestMatch = t.match(/(\d+)\s+passed(?:,\s+(\d+)\s+failed)?(?:,\s+(\d+)\s+(?:skipped|warning))?/);
+    if (pytestMatch) {
+      passed = parseInt(pytestMatch[1]);
+      if (pytestMatch[2])
+        failed = parseInt(pytestMatch[2]);
+      if (pytestMatch[3])
+        skipped = parseInt(pytestMatch[3]);
+      foundSummary = true;
+    }
+    const jestMatch = t.match(/Tests:\s+(?:(\d+)\s+failed,\s+)?(\d+)\s+passed(?:,\s+(\d+)\s+skipped)?/);
+    if (jestMatch) {
+      if (jestMatch[1])
+        failed = parseInt(jestMatch[1]);
+      passed = parseInt(jestMatch[2]);
+      if (jestMatch[3])
+        skipped = parseInt(jestMatch[3]);
+      foundSummary = true;
+    }
+    const goOk = t.match(/^ok\s+\S+/);
+    const goFail = t.match(/^FAIL\s+\S+/);
+    if (goOk) {
+      passed++;
+      foundSummary = true;
+    }
+    if (goFail) {
+      failed++;
+      foundSummary = true;
+    }
+  }
+  if (!foundSummary && failureLines.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const total = passed + failed + skipped;
+  const status = failed > 0 ? "FAIL" : "pass";
+  const parts = [];
+  if (passed > 0)
+    parts.push(`${passed} passed`);
+  if (failed > 0)
+    parts.push(`${failed} failed`);
+  if (skipped > 0)
+    parts.push(`${skipped} skipped`);
+  const summaryStr = parts.length > 0 ? parts.join(", ") : "no results";
+  const lines = [`test runner \u2014 ${status}: ${summaryStr}${total > 0 ? ` (${total} total)` : ""}`];
+  if (failureLines.length > 0) {
+    lines.push(`  failures:`);
+    lines.push(...failureLines.slice(0, MAX_BUILD_ERRORS).map((l) => `    ${l}`));
+    if (failureLines.length > MAX_BUILD_ERRORS) {
+      lines.push(`    \u2026 (+${failureLines.length - MAX_BUILD_ERRORS} more)`);
+    }
+  }
+  return { summary: lines.join(`
+`), originalSize };
+};
+var dockerPsHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const lines = stdout.trim().split(`
+`).filter((l) => l.trim());
+  if (lines.length === 0) {
+    return { summary: "[docker ps \u2014 no containers]", originalSize };
+  }
+  const dataLines = lines[0]?.toUpperCase().includes("CONTAINER") ? lines.slice(1) : lines;
+  if (dataLines.length === 0) {
+    return { summary: "[docker ps \u2014 no containers running]", originalSize };
+  }
+  const containers = [];
+  for (const line of dataLines) {
+    const parts = line.trim().split(/\s{2,}/);
+    if (parts.length < 2)
+      continue;
+    const name = parts[parts.length - 1] ?? "";
+    const statusPart = parts.find((p) => /^(Up|Exited|Restarting|Created|Paused|Dead)/i.test(p)) ?? "";
+    const portsPart = parts.find((p) => p.includes("->") || p.includes("0.0.0.0:")) ?? "";
+    if (!name)
+      continue;
+    const statusShort = statusPart.slice(0, 20);
+    const portsShort = portsPart.slice(0, 40);
+    containers.push({ name, status: statusShort, ports: portsShort });
+  }
+  if (containers.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const shown = containers.slice(0, MAX_DOCKER_CONTAINERS);
+  const overflow = containers.length > MAX_DOCKER_CONTAINERS ? `
+  \u2026 (+${containers.length - MAX_DOCKER_CONTAINERS} more)` : "";
+  const rows = shown.map((c) => {
+    const name = c.name.padEnd(30);
+    const status = c.status.padEnd(22);
+    return `  ${name}  ${status}  ${c.ports}`;
+  });
+  const header = `docker ps \u2014 ${containers.length} container${containers.length === 1 ? "" : "s"}`;
+  return {
+    summary: [header, ...rows].join(`
+`) + overflow,
+    originalSize
+  };
+};
+var buildToolHandler = (toolName, output) => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}
+${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+  const errorLines = [];
+  const targetLines = [];
+  for (const line of combined.split(`
+`)) {
+    const t = line.trim();
+    if (!t)
+      continue;
+    if (/^make(\[\d+\])?:\s/.test(t)) {
+      if (t.includes("Error") || t.includes("***"))
+        errorLines.push(t.slice(0, 120));
+      else if (t.includes("Leaving directory") || t.includes("Entering directory"))
+        continue;
+      else
+        targetLines.push(t.slice(0, 80));
+      continue;
+    }
+    if (/^(error:|justfile|warning:)\s/i.test(t)) {
+      errorLines.push(t.slice(0, 120));
+      continue;
+    }
+    if (/^[^\s]+:\d+:\d*:?\s*(error|fatal error):/i.test(t) || /^error\[/.test(t) || /^\s*\^\s*$/.test(t)) {
+      errorLines.push(t.slice(0, 120));
+    }
+  }
+  if (errorLines.length === 0 && targetLines.length === 0) {
+    return shellHandler(toolName, output);
+  }
+  const exitCode = output?.exit_code;
+  const status = exitCode === 0 ? "\u2713" : exitCode !== undefined ? "\u2717" : "";
+  const lines = [`${status ? status + " " : ""}build`];
+  if (errorLines.length > 0) {
+    lines.push(`  errors (${errorLines.length}):`);
+    lines.push(...errorLines.slice(0, MAX_BUILD_ERRORS).map((e) => `    ${e}`));
+    if (errorLines.length > MAX_BUILD_ERRORS) {
+      lines.push(`    \u2026 (+${errorLines.length - MAX_BUILD_ERRORS} more)`);
+    }
+  } else {
+    lines.push(`  completed successfully`);
+  }
+  return { summary: lines.join(`
+`), originalSize };
+};
 function getBashHandler(input) {
   const command = extractCommand(input);
   if (!command)
@@ -6136,8 +6440,18 @@ function getBashHandler(input) {
     return gitDiffHandler;
   if (/^git\s+log(\s|$)/.test(command))
     return gitLogHandler;
+  if (/^git\s+status(\s|$)/.test(command))
+    return gitStatusHandler;
   if (/^terraform\s+plan(\s|$)/.test(command))
     return terraformPlanHandler;
+  if (/^(npm|bun|yarn|pnpm)\s+install(\s|$)/.test(command) || /^pip\d*\s+install(\s|$)/.test(command))
+    return packageInstallHandler;
+  if (/^(pytest|python\s+-m\s+pytest)(\s|$)/.test(command) || /^(jest|npx\s+jest|bun\s+test|vitest|npx\s+vitest)(\s|$)/.test(command) || /^go\s+test(\s|$)/.test(command))
+    return testRunnerHandler;
+  if (/^docker(-compose)?\s+(ps|compose\s+ps)(\s|$)/.test(command) || /^docker\s+compose\s+ps(\s|$)/.test(command))
+    return dockerPsHandler;
+  if (/^(make|just)(\s|$)/.test(command))
+    return buildToolHandler;
   return shellHandler;
 }
 

--- a/src/handlers/bash.ts
+++ b/src/handlers/bash.ts
@@ -9,6 +9,8 @@ import { shellHandler, stripAnsi, stripSshNoise } from "./shell";
 
 const MAX_LOG_COMMITS = 20;
 const MAX_TERRAFORM_RESOURCES = 10;
+const MAX_DOCKER_CONTAINERS = 20;
+const MAX_BUILD_ERRORS = 20;
 
 // ---------------------------------------------------------------------------
 // Helpers
@@ -25,6 +27,14 @@ function extractStdout(output: unknown): string {
     if (typeof obj.output === "string") return stripSshNoise(stripAnsi(obj.output));
   }
   return stripSshNoise(stripAnsi(extractText(output)));
+}
+
+function extractStderr(output: unknown): string {
+  if (output !== null && typeof output === "object") {
+    const obj = output as Record<string, unknown>;
+    if (typeof obj.stderr === "string") return stripAnsi(obj.stderr);
+  }
+  return "";
 }
 
 function extractCommand(input: unknown): string | null {
@@ -163,6 +173,76 @@ export const gitLogHandler: Handler = (
 };
 
 // ---------------------------------------------------------------------------
+// git status
+// ---------------------------------------------------------------------------
+
+export const gitStatusHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  if (!stdout.trim()) {
+    return { summary: "[git status — clean working tree]", originalSize };
+  }
+
+  const staged: string[] = [];
+  const unstaged: string[] = [];
+  const untracked: string[] = [];
+  const conflicts: string[] = [];
+
+  let section: "staged" | "unstaged" | "untracked" | null = null;
+
+  for (const line of stdout.split("\n")) {
+    const trimmed = line.trim();
+    if (trimmed.startsWith("Changes to be committed")) { section = "staged"; continue; }
+    if (trimmed.startsWith("Changes not staged")) { section = "unstaged"; continue; }
+    if (trimmed.startsWith("Untracked files")) { section = "untracked"; continue; }
+    if (trimmed.startsWith("both modified") || trimmed.startsWith("both added")) {
+      conflicts.push(trimmed);
+      continue;
+    }
+    if (!trimmed || trimmed.startsWith("(") || trimmed.startsWith("no changes")) continue;
+
+    // Skip header lines and hints
+    if (trimmed.startsWith("On branch") || trimmed.startsWith("HEAD") ||
+        trimmed.startsWith("Your branch") || trimmed.startsWith("nothing")) continue;
+
+    // Porcelain-style (git status --short or similar)
+    const porcelain = line.match(/^([MADRCU?!]{1,2})\s+(.+)$/);
+    if (porcelain) {
+      const [, code, file] = porcelain as [string, string, string];
+      if (code.startsWith("?")) untracked.push(file);
+      else if (code[0] !== " " && code[0] !== "?") staged.push(`${code[0]} ${file}`);
+      if (code[1] && code[1] !== " " && code[1] !== "?") unstaged.push(`${code[1]} ${file}`);
+      continue;
+    }
+
+    if (section === "staged" && trimmed.match(/^(modified|new file|deleted|renamed):/)) {
+      staged.push(trimmed);
+    } else if (section === "unstaged" && trimmed.match(/^(modified|deleted):/)) {
+      unstaged.push(trimmed);
+    } else if (section === "untracked" && trimmed && !trimmed.startsWith("(")) {
+      untracked.push(trimmed);
+    }
+  }
+
+  if (staged.length === 0 && unstaged.length === 0 && untracked.length === 0 && conflicts.length === 0) {
+    // Couldn't parse — fall back to shell
+    return shellHandler(toolName, output);
+  }
+
+  const lines = ["git status"];
+  if (conflicts.length > 0) lines.push(`  conflicts (${conflicts.length}): ${conflicts.slice(0, 5).join(", ")}`);
+  if (staged.length > 0) lines.push(`  staged (${staged.length}): ${staged.slice(0, 5).map(f => f.replace(/^(modified|new file|deleted|renamed):\s*/, "")).join(", ")}${staged.length > 5 ? ` +${staged.length - 5} more` : ""}`);
+  if (unstaged.length > 0) lines.push(`  unstaged (${unstaged.length}): ${unstaged.slice(0, 5).map(f => f.replace(/^(modified|deleted):\s*/, "")).join(", ")}${unstaged.length > 5 ? ` +${unstaged.length - 5} more` : ""}`);
+  if (untracked.length > 0) lines.push(`  untracked (${untracked.length}): ${untracked.slice(0, 5).join(", ")}${untracked.length > 5 ? ` +${untracked.length - 5} more` : ""}`);
+
+  return { summary: lines.join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
 // terraform plan
 // ---------------------------------------------------------------------------
 
@@ -212,6 +292,292 @@ export const terraformPlanHandler: Handler = (
 };
 
 // ---------------------------------------------------------------------------
+// Package installers: npm install, bun install, pip install, yarn
+// ---------------------------------------------------------------------------
+
+export const packageInstallHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}\n${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  const warnings: string[] = [];
+  const errors: string[] = [];
+
+  // Collect warnings and errors
+  for (const line of combined.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    if (/^(npm warn|warn |warning )/i.test(t)) warnings.push(t.slice(0, 100));
+    else if (/^(npm error|error |err )/i.test(t)) errors.push(t.slice(0, 100));
+  }
+
+  // Try to extract package counts from common output patterns
+  let countLine: string | null = null;
+
+  // bun: "120 packages installed [1.23s]"
+  const bunMatch = combined.match(/(\d+)\s+packages?\s+installed/i);
+  if (bunMatch) countLine = `${bunMatch[1]} packages installed`;
+
+  // npm: "added 42 packages"  /  "added 5, removed 2"
+  if (!countLine) {
+    const npmMatch = combined.match(/added\s+(\d+)[^,\n]*/i);
+    if (npmMatch) countLine = npmMatch[0].trim().slice(0, 60);
+  }
+
+  // pip: "Successfully installed foo-1.0 bar-2.0"
+  if (!countLine) {
+    const pipMatch = combined.match(/Successfully installed (.+)/);
+    if (pipMatch) {
+      const pkgs = pipMatch[1]!.trim().split(/\s+/);
+      countLine = `pip: ${pkgs.length} package${pkgs.length === 1 ? "" : "s"} installed`;
+    }
+  }
+
+  // yarn: "✨ Done in 3.14s."  — not much info, try "success Saved X new dependencies"
+  if (!countLine) {
+    const yarnMatch = combined.match(/success Saved (\d+) new dependenc/i);
+    if (yarnMatch) countLine = `yarn: ${yarnMatch[1]} new dependencies saved`;
+  }
+
+  if (!countLine && errors.length === 0) {
+    // Can't parse — fall back
+    return shellHandler(toolName, output);
+  }
+
+  const lines: string[] = [countLine ?? "package install"];
+  if (warnings.length > 0) lines.push(`  ${warnings.length} warning${warnings.length === 1 ? "" : "s"}${warnings.length <= 3 ? ": " + warnings.join("; ") : ""}`);
+  if (errors.length > 0) lines.push(...errors.slice(0, 5).map(e => `  error: ${e}`));
+
+  return { summary: lines.join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
+// Test runners: pytest, jest, bun test, vitest, go test
+// Detected by output pattern rather than command name.
+// ---------------------------------------------------------------------------
+
+export const testRunnerHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}\n${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  // Collect failure blocks — lines that look like test failures/errors
+  const failureLines: string[] = [];
+  for (const line of combined.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+    // pytest: FAILED src/test.py::test_name
+    // jest/vitest: ✕ / ✗ / × test name  or  ● test name
+    // bun: (fail) suite > test name
+    if (/^(FAILED|FAIL)\s+/.test(t) ||
+        /^[✕✗×●]\s/.test(t) ||
+        /^\(fail\)\s/.test(t) ||
+        /^--- FAIL:/.test(t)) {
+      failureLines.push(t.slice(0, 120));
+    }
+  }
+
+  // Try to find a summary line
+  let passed = 0, failed = 0, skipped = 0;
+  let foundSummary = false;
+
+  for (const line of combined.split("\n")) {
+    const t = line.trim();
+
+    // bun: "X pass\nY fail"
+    const bunPass = t.match(/^(\d+)\s+pass$/);
+    const bunFail = t.match(/^(\d+)\s+fail$/);
+    if (bunPass) { passed = parseInt(bunPass[1]!); foundSummary = true; }
+    if (bunFail) { failed = parseInt(bunFail[1]!); foundSummary = true; }
+
+    // pytest: "5 passed, 2 failed, 1 warning in 1.23s"
+    const pytestMatch = t.match(/(\d+)\s+passed(?:,\s+(\d+)\s+failed)?(?:,\s+(\d+)\s+(?:skipped|warning))?/);
+    if (pytestMatch) {
+      passed = parseInt(pytestMatch[1]!);
+      if (pytestMatch[2]) failed = parseInt(pytestMatch[2]);
+      if (pytestMatch[3]) skipped = parseInt(pytestMatch[3]);
+      foundSummary = true;
+    }
+
+    // jest/vitest: "Tests: 5 passed, 2 failed, 7 total"
+    const jestMatch = t.match(/Tests:\s+(?:(\d+)\s+failed,\s+)?(\d+)\s+passed(?:,\s+(\d+)\s+skipped)?/);
+    if (jestMatch) {
+      if (jestMatch[1]) failed = parseInt(jestMatch[1]);
+      passed = parseInt(jestMatch[2]!);
+      if (jestMatch[3]) skipped = parseInt(jestMatch[3]);
+      foundSummary = true;
+    }
+
+    // go test: "ok  \tpackage\t0.123s" / "FAIL\tpackage\t0.123s"
+    const goOk = t.match(/^ok\s+\S+/);
+    const goFail = t.match(/^FAIL\s+\S+/);
+    if (goOk) { passed++; foundSummary = true; }
+    if (goFail) { failed++; foundSummary = true; }
+  }
+
+  if (!foundSummary && failureLines.length === 0) {
+    return shellHandler(toolName, output);
+  }
+
+  const total = passed + failed + skipped;
+  const status = failed > 0 ? "FAIL" : "pass";
+  const parts: string[] = [];
+  if (passed > 0) parts.push(`${passed} passed`);
+  if (failed > 0) parts.push(`${failed} failed`);
+  if (skipped > 0) parts.push(`${skipped} skipped`);
+  const summaryStr = parts.length > 0 ? parts.join(", ") : "no results";
+
+  const lines = [`test runner — ${status}: ${summaryStr}${total > 0 ? ` (${total} total)` : ""}`];
+  if (failureLines.length > 0) {
+    lines.push(`  failures:`);
+    lines.push(...failureLines.slice(0, MAX_BUILD_ERRORS).map(l => `    ${l}`));
+    if (failureLines.length > MAX_BUILD_ERRORS) {
+      lines.push(`    … (+${failureLines.length - MAX_BUILD_ERRORS} more)`);
+    }
+  }
+
+  return { summary: lines.join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
+// docker ps / docker compose ps
+// ---------------------------------------------------------------------------
+
+export const dockerPsHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  const lines = stdout.trim().split("\n").filter(l => l.trim());
+  if (lines.length === 0) {
+    return { summary: "[docker ps — no containers]", originalSize };
+  }
+
+  // First line is the header row
+  const dataLines = lines[0]?.toUpperCase().includes("CONTAINER") ? lines.slice(1) : lines;
+
+  if (dataLines.length === 0) {
+    return { summary: "[docker ps — no containers running]", originalSize };
+  }
+
+  interface Container { name: string; status: string; ports: string; }
+  const containers: Container[] = [];
+
+  for (const line of dataLines) {
+    // docker ps columns: CONTAINER ID | IMAGE | COMMAND | CREATED | STATUS | PORTS | NAMES
+    const parts = line.trim().split(/\s{2,}/);
+    if (parts.length < 2) continue;
+
+    // NAMES is last column, STATUS is typically 4th (index 3 or 4)
+    const name = parts[parts.length - 1] ?? "";
+    // Find STATUS column — contains "Up", "Exited", "Restarting", etc.
+    const statusPart = parts.find(p => /^(Up|Exited|Restarting|Created|Paused|Dead)/i.test(p)) ?? "";
+    // PORTS column — contains "0.0.0.0:" or "->"
+    const portsPart = parts.find(p => p.includes("->") || p.includes("0.0.0.0:")) ?? "";
+
+    if (!name) continue;
+    const statusShort = statusPart.slice(0, 20);
+    const portsShort = portsPart.slice(0, 40);
+    containers.push({ name, status: statusShort, ports: portsShort });
+  }
+
+  if (containers.length === 0) {
+    return shellHandler(toolName, output);
+  }
+
+  const shown = containers.slice(0, MAX_DOCKER_CONTAINERS);
+  const overflow = containers.length > MAX_DOCKER_CONTAINERS
+    ? `\n  … (+${containers.length - MAX_DOCKER_CONTAINERS} more)`
+    : "";
+
+  const rows = shown.map(c => {
+    const name = c.name.padEnd(30);
+    const status = c.status.padEnd(22);
+    return `  ${name}  ${status}  ${c.ports}`;
+  });
+
+  const header = `docker ps — ${containers.length} container${containers.length === 1 ? "" : "s"}`;
+  return {
+    summary: [header, ...rows].join("\n") + overflow,
+    originalSize,
+  };
+};
+
+// ---------------------------------------------------------------------------
+// make / just build output
+// ---------------------------------------------------------------------------
+
+export const buildToolHandler: Handler = (
+  toolName: string,
+  output: unknown
+): CompressionResult => {
+  const stdout = extractStdout(output);
+  const stderr = extractStderr(output);
+  const combined = `${stdout}\n${stderr}`.trim();
+  const originalSize = Buffer.byteLength(extractText(output), "utf8");
+
+  const errorLines: string[] = [];
+  const targetLines: string[] = [];
+
+  for (const line of combined.split("\n")) {
+    const t = line.trim();
+    if (!t) continue;
+
+    // make targets: "make[1]: Entering directory" / "make: *** [target] Error 1"
+    if (/^make(\[\d+\])?:\s/.test(t)) {
+      if (t.includes("Error") || t.includes("***")) errorLines.push(t.slice(0, 120));
+      else if (t.includes("Leaving directory") || t.includes("Entering directory")) continue;
+      else targetLines.push(t.slice(0, 80));
+      continue;
+    }
+
+    // just: "error: recipe `target` failed"  or  "===> Running recipe `target`"
+    if (/^(error:|justfile|warning:)\s/i.test(t)) {
+      errorLines.push(t.slice(0, 120));
+      continue;
+    }
+
+    // Compiler/linker errors: "src/foo.c:42: error:" or "error[E0001]:"
+    if (/^[^\s]+:\d+:\d*:?\s*(error|fatal error):/i.test(t) ||
+        /^error\[/.test(t) ||
+        /^\s*\^\s*$/.test(t)) {
+      errorLines.push(t.slice(0, 120));
+    }
+  }
+
+  if (errorLines.length === 0 && targetLines.length === 0) {
+    return shellHandler(toolName, output);
+  }
+
+  // Determine overall result from exit code if available
+  const exitCode = (output as Record<string, unknown>)?.exit_code;
+  const status = exitCode === 0 ? "✓" : exitCode !== undefined ? "✗" : "";
+
+  const lines: string[] = [`${status ? status + " " : ""}build`];
+  if (errorLines.length > 0) {
+    lines.push(`  errors (${errorLines.length}):`);
+    lines.push(...errorLines.slice(0, MAX_BUILD_ERRORS).map(e => `    ${e}`));
+    if (errorLines.length > MAX_BUILD_ERRORS) {
+      lines.push(`    … (+${errorLines.length - MAX_BUILD_ERRORS} more)`);
+    }
+  } else {
+    lines.push(`  completed successfully`);
+  }
+
+  return { summary: lines.join("\n"), originalSize };
+};
+
+// ---------------------------------------------------------------------------
 // Dispatcher
 // ---------------------------------------------------------------------------
 
@@ -226,7 +592,16 @@ export function getBashHandler(input: unknown): Handler {
 
   if (/^git\s+(diff|show)(\s|$)/.test(command)) return gitDiffHandler;
   if (/^git\s+log(\s|$)/.test(command)) return gitLogHandler;
+  if (/^git\s+status(\s|$)/.test(command)) return gitStatusHandler;
   if (/^terraform\s+plan(\s|$)/.test(command)) return terraformPlanHandler;
+  if (/^(npm|bun|yarn|pnpm)\s+install(\s|$)/.test(command) ||
+      /^pip\d*\s+install(\s|$)/.test(command)) return packageInstallHandler;
+  if (/^(pytest|python\s+-m\s+pytest)(\s|$)/.test(command) ||
+      /^(jest|npx\s+jest|bun\s+test|vitest|npx\s+vitest)(\s|$)/.test(command) ||
+      /^go\s+test(\s|$)/.test(command)) return testRunnerHandler;
+  if (/^docker(-compose)?\s+(ps|compose\s+ps)(\s|$)/.test(command) ||
+      /^docker\s+compose\s+ps(\s|$)/.test(command)) return dockerPsHandler;
+  if (/^(make|just)(\s|$)/.test(command)) return buildToolHandler;
 
   return shellHandler;
 }

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -10,7 +10,7 @@ import { slackHandler } from "../src/handlers/slack";
 import { jsonHandler } from "../src/handlers/json";
 import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
-import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler } from "../src/handlers/bash";
+import { getBashHandler, gitDiffHandler, gitLogHandler, terraformPlanHandler, gitStatusHandler, packageInstallHandler, testRunnerHandler, dockerPsHandler, buildToolHandler } from "../src/handlers/bash";
 import { tavilyHandler } from "../src/handlers/tavily";
 import { databaseHandler } from "../src/handlers/database";
 import { sentryHandler } from "../src/handlers/sentry";
@@ -771,6 +771,40 @@ describe("getBashHandler", () => {
     expect(getBashHandler({ command: "terraform plan -out=tfplan" })).toBe(terraformPlanHandler);
   });
 
+  it("routes git status to gitStatusHandler", () => {
+    expect(getBashHandler({ command: "git status" })).toBe(gitStatusHandler);
+    expect(getBashHandler({ command: "git status --short" })).toBe(gitStatusHandler);
+  });
+
+  it("routes npm/bun/yarn install to packageInstallHandler", () => {
+    expect(getBashHandler({ command: "npm install" })).toBe(packageInstallHandler);
+    expect(getBashHandler({ command: "bun install" })).toBe(packageInstallHandler);
+    expect(getBashHandler({ command: "yarn install --frozen-lockfile" })).toBe(packageInstallHandler);
+    expect(getBashHandler({ command: "pip install -r requirements.txt" })).toBe(packageInstallHandler);
+    expect(getBashHandler({ command: "pip3 install requests" })).toBe(packageInstallHandler);
+  });
+
+  it("routes test runners to testRunnerHandler", () => {
+    expect(getBashHandler({ command: "pytest tests/" })).toBe(testRunnerHandler);
+    expect(getBashHandler({ command: "jest --coverage" })).toBe(testRunnerHandler);
+    expect(getBashHandler({ command: "bun test" })).toBe(testRunnerHandler);
+    expect(getBashHandler({ command: "vitest run" })).toBe(testRunnerHandler);
+    expect(getBashHandler({ command: "go test ./..." })).toBe(testRunnerHandler);
+    expect(getBashHandler({ command: "npx jest" })).toBe(testRunnerHandler);
+  });
+
+  it("routes docker ps to dockerPsHandler", () => {
+    expect(getBashHandler({ command: "docker ps" })).toBe(dockerPsHandler);
+    expect(getBashHandler({ command: "docker ps -a" })).toBe(dockerPsHandler);
+    expect(getBashHandler({ command: "docker compose ps" })).toBe(dockerPsHandler);
+  });
+
+  it("routes make/just to buildToolHandler", () => {
+    expect(getBashHandler({ command: "make build" })).toBe(buildToolHandler);
+    expect(getBashHandler({ command: "just test" })).toBe(buildToolHandler);
+    expect(getBashHandler({ command: "make" })).toBe(buildToolHandler);
+  });
+
   it("routes unrecognised commands to shellHandler", () => {
     expect(getBashHandler({ command: "npm test" })).toBe(shellHandler);
   });
@@ -936,6 +970,292 @@ describe("terraformPlanHandler", () => {
     const { summary } = terraformPlanHandler("Bash", plainOutput);
     // Falls back to shellHandler — no terraform-specific content, just plain output
     expect(summary).toContain("lines");
+  });
+});
+
+// ---------------------------------------------------------------------------
+// gitStatusHandler
+// ---------------------------------------------------------------------------
+
+const GIT_STATUS_LONG = `On branch feat/foo
+Your branch is up to date with 'origin/feat/foo'.
+
+Changes to be committed:
+  (use "git restore --staged <file>..." to unstage)
+	modified:   src/tools.ts
+	new file:   src/format.ts
+
+Changes not staged for commit:
+  (use "git add <file>..." to update an unstaged file)
+	modified:   README.md
+
+Untracked files:
+  (use "git add <file>..." to include in what will be committed)
+	docs/new-guide.md
+	tmp/scratch.ts
+`;
+
+const GIT_STATUS_SHORT = `M  src/tools.ts
+A  src/format.ts
+ M README.md
+?? docs/new-guide.md
+`;
+
+describe("gitStatusHandler", () => {
+  it("reports staged files count and names (long format)", () => {
+    const { summary } = gitStatusHandler("Bash", { stdout: GIT_STATUS_LONG, stderr: "", exit_code: 0 });
+    expect(summary).toContain("staged");
+    expect(summary).toContain("src/tools.ts");
+  });
+
+  it("reports unstaged files (long format)", () => {
+    const { summary } = gitStatusHandler("Bash", { stdout: GIT_STATUS_LONG, stderr: "", exit_code: 0 });
+    expect(summary).toContain("unstaged");
+    expect(summary).toContain("README.md");
+  });
+
+  it("reports untracked files (long format)", () => {
+    const { summary } = gitStatusHandler("Bash", { stdout: GIT_STATUS_LONG, stderr: "", exit_code: 0 });
+    expect(summary).toContain("untracked");
+    expect(summary).toContain("docs/new-guide.md");
+  });
+
+  it("parses porcelain (short) format", () => {
+    const { summary } = gitStatusHandler("Bash", { stdout: GIT_STATUS_SHORT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("staged");
+    expect(summary).toContain("untracked");
+  });
+
+  it("returns clean message for empty output", () => {
+    const { summary } = gitStatusHandler("Bash", { stdout: "", stderr: "", exit_code: 0 });
+    expect(summary).toContain("clean working tree");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: GIT_STATUS_LONG, stderr: "", exit_code: 0 };
+    const { originalSize } = gitStatusHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// packageInstallHandler
+// ---------------------------------------------------------------------------
+
+const BUN_INSTALL_OUTPUT = `bun install v1.1.0
+  + express@4.19.2
+  + typescript@5.4.3
+  120 packages installed [1.23s]
+`;
+
+const NPM_INSTALL_OUTPUT = `
+added 42 packages, and audited 43 packages in 3s
+
+2 packages are looking for funding
+  run \`npm fund\` for details
+
+found 0 vulnerabilities
+`;
+
+const PIP_INSTALL_OUTPUT = `
+Collecting requests>=2.28
+  Downloading requests-2.31.0-py3-none-any.whl (62 kB)
+Successfully installed certifi-2024.2.2 charset-normalizer-3.3.2 requests-2.31.0
+`;
+
+describe("packageInstallHandler", () => {
+  it("extracts bun package count", () => {
+    const { summary } = packageInstallHandler("Bash", { stdout: BUN_INSTALL_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("120 packages installed");
+  });
+
+  it("extracts npm added count", () => {
+    const { summary } = packageInstallHandler("Bash", { stdout: NPM_INSTALL_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("added 42 packages");
+  });
+
+  it("extracts pip install count", () => {
+    const { summary } = packageInstallHandler("Bash", { stdout: PIP_INSTALL_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("pip: 3 packages installed");
+  });
+
+  it("surfaces errors from stderr", () => {
+    const output = {
+      stdout: "",
+      stderr: "error: Cannot find module 'missing-package'\nnpm error Exit status 1",
+      exit_code: 1,
+    };
+    const { summary } = packageInstallHandler("Bash", output);
+    expect(summary).toContain("error:");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: BUN_INSTALL_OUTPUT, stderr: "", exit_code: 0 };
+    const { originalSize } = packageInstallHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// testRunnerHandler
+// ---------------------------------------------------------------------------
+
+const BUN_TEST_PASS = `
+ tests/tools.test.ts:
+   ✓ forget guard rejects older_than_days = 0
+
+ 543 pass
+ 0 fail
+ Ran 543 tests across 15 files. [923.00ms]
+`;
+
+const PYTEST_OUTPUT = `
+=========================== test session starts ============================
+collected 47 items
+
+tests/test_api.py ...........
+tests/test_models.py ...
+
+=============================== 3 passed, 1 warning in 0.45s ===============
+`;
+
+const JEST_FAIL_OUTPUT = `
+  ● AuthService › login fails with invalid creds
+
+Tests: 1 failed, 4 passed, 5 total
+`;
+
+const GO_TEST_OUTPUT = `
+ok  	github.com/user/repo/pkg/auth	0.043s
+ok  	github.com/user/repo/pkg/db	0.112s
+FAIL	github.com/user/repo/pkg/api	0.034s
+--- FAIL: TestHandleRequest (0.00s)
+`;
+
+describe("testRunnerHandler", () => {
+  it("summarises bun test pass result", () => {
+    const { summary } = testRunnerHandler("Bash", { stdout: BUN_TEST_PASS, stderr: "", exit_code: 0 });
+    expect(summary).toContain("pass");
+    expect(summary).toContain("543 passed");
+  });
+
+  it("summarises pytest pass result", () => {
+    const { summary } = testRunnerHandler("Bash", { stdout: PYTEST_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("3 passed");
+  });
+
+  it("shows FAIL status and failure details for jest failures", () => {
+    const { summary } = testRunnerHandler("Bash", { stdout: JEST_FAIL_OUTPUT, stderr: "", exit_code: 1 });
+    expect(summary).toContain("FAIL");
+    expect(summary).toContain("1 failed");
+    expect(summary).toContain("4 passed");
+  });
+
+  it("handles go test output with per-package results", () => {
+    const { summary } = testRunnerHandler("Bash", { stdout: GO_TEST_OUTPUT, stderr: "", exit_code: 1 });
+    expect(summary).toContain("FAIL");
+    expect(summary).toContain("--- FAIL: TestHandleRequest");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: BUN_TEST_PASS, stderr: "", exit_code: 0 };
+    const { originalSize } = testRunnerHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// dockerPsHandler
+// ---------------------------------------------------------------------------
+
+const DOCKER_PS_OUTPUT = `CONTAINER ID   IMAGE              COMMAND                  CREATED        STATUS          PORTS                    NAMES
+a1b2c3d4e5f6   nginx:latest       "/docker-entrypoint.…"   2 hours ago    Up 2 hours      0.0.0.0:80->80/tcp       web
+b2c3d4e5f6a1   postgres:16        "docker-entrypoint.s…"   2 hours ago    Up 2 hours      0.0.0.0:5432->5432/tcp   db
+c3d4e5f6a1b2   redis:7-alpine     "docker-entrypoint.s…"   2 hours ago    Up 2 hours      6379/tcp                 cache
+`;
+
+describe("dockerPsHandler", () => {
+  it("shows container count in header", () => {
+    const { summary } = dockerPsHandler("Bash", { stdout: DOCKER_PS_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("3 containers");
+  });
+
+  it("includes container names", () => {
+    const { summary } = dockerPsHandler("Bash", { stdout: DOCKER_PS_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("web");
+    expect(summary).toContain("db");
+    expect(summary).toContain("cache");
+  });
+
+  it("includes status info", () => {
+    const { summary } = dockerPsHandler("Bash", { stdout: DOCKER_PS_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("Up");
+  });
+
+  it("returns no-containers message for empty output", () => {
+    const { summary } = dockerPsHandler("Bash", { stdout: "", stderr: "", exit_code: 0 });
+    expect(summary).toContain("no containers");
+  });
+
+  it("returns no-running message for header-only output", () => {
+    const headerOnly = `CONTAINER ID   IMAGE   COMMAND   CREATED   STATUS   PORTS   NAMES\n`;
+    const { summary } = dockerPsHandler("Bash", { stdout: headerOnly, stderr: "", exit_code: 0 });
+    expect(summary).toContain("no containers running");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: DOCKER_PS_OUTPUT, stderr: "", exit_code: 0 };
+    const { originalSize } = dockerPsHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// buildToolHandler
+// ---------------------------------------------------------------------------
+
+const MAKE_SUCCESS_OUTPUT = `make[1]: Nothing to be done for 'all'.
+`;
+
+const MAKE_ERROR_OUTPUT = `make[1]: Entering directory '/home/user/project'
+cc -Wall -o main main.c
+main.c:42:10: error: 'undefined_var' undeclared (first use in this function)
+main.c:42:10: note: each undeclared identifier is reported only once
+make[1]: *** [Makefile:15: main] Error 1
+make[1]: Leaving directory '/home/user/project'
+`;
+
+const JUST_ERROR_OUTPUT = `error: recipe \`build\` failed with exit code 1
+justfile:12
+`;
+
+describe("buildToolHandler", () => {
+  it("shows success for clean make output", () => {
+    const { summary } = buildToolHandler("Bash", { stdout: MAKE_SUCCESS_OUTPUT, stderr: "", exit_code: 0 });
+    expect(summary).toContain("build");
+    expect(summary).toContain("completed successfully");
+  });
+
+  it("shows compiler error lines", () => {
+    const { summary } = buildToolHandler("Bash", { stdout: MAKE_ERROR_OUTPUT, stderr: "", exit_code: 2 });
+    expect(summary).toContain("error");
+    expect(summary).toContain("undefined_var");
+  });
+
+  it("shows make error summary line", () => {
+    const { summary } = buildToolHandler("Bash", { stdout: MAKE_ERROR_OUTPUT, stderr: "", exit_code: 2 });
+    expect(summary).toContain("Error 1");
+  });
+
+  it("handles just error output", () => {
+    const { summary } = buildToolHandler("Bash", { stdout: JUST_ERROR_OUTPUT, stderr: "", exit_code: 1 });
+    expect(summary).toContain("error");
+  });
+
+  it("reports originalSize correctly", () => {
+    const output = { stdout: MAKE_SUCCESS_OUTPUT, stderr: "", exit_code: 0 };
+    const { originalSize } = buildToolHandler("Bash", output);
+    expect(originalSize).toBeGreaterThan(0);
   });
 });
 


### PR DESCRIPTION
## Summary
- Adds `gitStatusHandler` — parses staged/unstaged/untracked sections (long and porcelain format)
- Adds `packageInstallHandler` — extracts package count from npm/bun/pip/yarn, surfaces errors
- Adds `testRunnerHandler` — pattern-based detection covering pytest/jest/bun test/vitest/go test
- Adds `dockerPsHandler` — compact container table from `docker ps` / `docker compose ps`
- Adds `buildToolHandler` — make/just build output, errors only; falls through to shell on unrecognised

Closes #119

## Test plan
- [x] 32 new tests added (dispatcher routes + handler output parsing for all 5 handlers)
- [x] 575 tests passing locally (was 543)
- [x] `bun run typecheck` clean
- [x] dist rebuilt by pre-commit hook