### PR TITLE
chore: bump to v1.6.0

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,21 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ---
 
+## [1.6.0] — 2026-03-12
+
+### Added
+
+- Five new Bash tool handlers: git status, package install (npm/bun/yarn/pnpm/pip), test runners (pytest, jest, bun test, vitest, go test), docker ps, and build tools (make/just) — compressed output instead of raw terminal walls (#119)
+- `profiles info <name>` — full metadata for any profile: version, description, mcp_pattern, author, mcp_url, source tier, file path; manifest-first with local fallback for offline use (#122)
+- `profiles available` — lists community catalog with install status and optional `--verbose` for mcp_url (#122)
+- Friendly short names throughout: `profiles list`, `profiles install`, `profiles remove` all accept short names (e.g. `grafana` instead of `mcp__grafana`); TTY-aware picker on ambiguous match (#122)
+- `--help` and `--version` flags, `completions` subcommand, `profiles list --machine-readable` (#123)
+- `--all` flag for `profiles seed` (#125)
+- Profile seeding discoverability improvements (#126)
+- `recall__context` output now includes generated-at timestamp (#128)
+
+---
+
 ## [1.5.1] — 2026-03-10
 
 ### Security

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.5.1",
+  "version": "1.6.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.5.1",
+    version: "1.6.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.5.1",
+    version: "1.6.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary

- Bumps version to 1.6.0
- Updates CHANGELOG.md with all changes since v1.5.1
- Rebuilds dist

## Test plan

- [ ] CI passes (587 tests)
- [ ] After merge: tag v1.6.0 and create GitHub release to trigger npm publish