### PR TITLE
feat: manifest signature verification via GitHub Artifact Attestations

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5044,6 +5044,9 @@ var RecallConfigSchema = exports_external.object({
     override_defaults: exports_external.array(exports_external.string()),
     allowlist: exports_external.array(exports_external.string())
   }),
+  profiles: exports_external.object({
+    verify_signature: exports_external.enum(["warn", "error", "skip"])
+  }),
   debug: exports_external.object({
     enabled: exports_external.boolean()
   })
@@ -5064,6 +5067,9 @@ var DEFAULTS = {
     additional: [],
     override_defaults: [],
     allowlist: []
+  },
+  profiles: {
+    verify_signature: "warn"
   },
   debug: {
     enabled: false
@@ -7702,9 +7708,9 @@ ${summary}`,
 }
 
 // src/profiles/commands.ts
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, readdirSync as readdirSync2, rmSync } from "fs";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, readdirSync as readdirSync2, rmSync, unlinkSync } from "fs";
 import { join as join4 } from "path";
-import { homedir as homedir4 } from "os";
+import { homedir as homedir4, tmpdir } from "os";
 import { createHash as createHash3 } from "crypto";
 
 // src/learn/retrain.ts
@@ -8006,13 +8012,6 @@ function userDir() {
 function manifestShortName(e) {
   return e.short_name ?? e.id.replace(/^mcp__/, "");
 }
-async function fetchManifest() {
-  const res = await fetch(MANIFEST_URL);
-  if (!res.ok)
-    throw new Error(`manifest fetch failed: ${res.status} ${res.statusText}`);
-  const data = await res.json();
-  return data.profiles;
-}
 async function fetchProfileContent(filePath) {
   const res = await fetch(`${PROFILE_BASE_URL}${filePath}`);
   if (!res.ok)
@@ -8027,6 +8026,50 @@ function verifyHash(content, expected, id) {
   if (actual !== expected) {
     throw new Error(`Profile ${id}: hash mismatch (expected ${expected.slice(0, 8)}\u2026, got ${actual.slice(0, 8)}\u2026)`);
   }
+}
+function verifyManifest(manifestPath, mode) {
+  if (mode === "skip")
+    return;
+  let ghAvailable = false;
+  try {
+    const probe = Bun.spawnSync(["gh", "--version"], { stderr: "ignore", stdout: "ignore" });
+    ghAvailable = probe.exitCode === 0;
+  } catch {}
+  if (!ghAvailable) {
+    process.stderr.write(`[recall] manifest signature verification skipped: gh CLI not found in PATH
+`);
+    return;
+  }
+  const result = Bun.spawnSync(["gh", "attestation", "verify", manifestPath, "--repo", COMMUNITY_REPO], { stderr: "pipe", stdout: "ignore" });
+  if (result.exitCode !== 0) {
+    const errText = result.stderr ? new TextDecoder().decode(result.stderr).trim() : "";
+    const msg = `[recall] manifest signature verification failed${errText ? `: ${errText}` : ""}
+`;
+    if (mode === "error") {
+      throw new Error(msg.trim());
+    }
+    process.stderr.write(msg);
+  }
+}
+async function fetchManifest(skipVerify = false) {
+  const res = await fetch(MANIFEST_URL);
+  if (!res.ok)
+    throw new Error(`manifest fetch failed: ${res.status} ${res.statusText}`);
+  const text = await res.text();
+  if (!skipVerify) {
+    const tmpPath = join4(tmpdir(), `mcp-recall-manifest-${process.pid}.json`);
+    try {
+      writeFileSync2(tmpPath, text, "utf8");
+      const config = loadConfig();
+      verifyManifest(tmpPath, config.profiles.verify_signature);
+    } finally {
+      try {
+        unlinkSync(tmpPath);
+      } catch {}
+    }
+  }
+  const data = JSON.parse(text);
+  return data.profiles;
 }
 function saveToCommunitDir(profileId, content) {
   const dir = join4(communityDir(), profileId);
@@ -8146,13 +8189,14 @@ ${profiles.length} total (${summary})
 `);
 }
 async function cmdInstall(args) {
-  const nameOrId = args[0];
+  const skipVerify = args.includes("--skip-verify");
+  const nameOrId = args.find((a) => !a.startsWith("-"));
   if (!nameOrId) {
-    console.error("Usage: mcp-recall profiles install <name>");
+    console.error("Usage: mcp-recall profiles install <name> [--skip-verify]");
     process.exit(1);
   }
   process.stdout.write("Fetching manifest\u2026 ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log("done");
   const entry = await resolveManifestEntry(nameOrId, entries);
   assertSafeId(entry.id);
@@ -8165,14 +8209,15 @@ async function cmdInstall(args) {
   console.log(`done
 \u2713 ${filePath}`);
 }
-async function cmdUpdate() {
+async function cmdUpdate(args = []) {
+  const skipVerify = args.includes("--skip-verify");
   const installed = installedCommunityMap();
   if (installed.size === 0) {
     console.log("No community profiles installed.");
     return;
   }
   process.stdout.write("Fetching manifest\u2026 ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log(`done
 `);
   let updated = 0;
@@ -8222,8 +8267,9 @@ function cmdRemove(args) {
 }
 async function cmdSeed(args) {
   const all = args.includes("--all");
+  const skipVerify = args.includes("--skip-verify");
   process.stdout.write("Fetching manifest\u2026 ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log(`done
 `);
   const installed = installedCommunityMap();
@@ -8569,7 +8615,7 @@ async function handleProfilesCommand(args) {
       await cmdInstall(rest);
       break;
     case "update":
-      await cmdUpdate();
+      await cmdUpdate(rest);
       break;
     case "remove":
       cmdRemove(rest);

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20921,6 +20921,9 @@ var RecallConfigSchema = exports_external.object({
     override_defaults: exports_external.array(exports_external.string()),
     allowlist: exports_external.array(exports_external.string())
   }),
+  profiles: exports_external.object({
+    verify_signature: exports_external.enum(["warn", "error", "skip"])
+  }),
   debug: exports_external.object({
     enabled: exports_external.boolean()
   })
@@ -20941,6 +20944,9 @@ var DEFAULTS = {
     additional: [],
     override_defaults: [],
     allowlist: []
+  },
+  profiles: {
+    verify_signature: "warn"
   },
   debug: {
     enabled: false

--- a/src/config.ts
+++ b/src/config.ts
@@ -20,6 +20,9 @@ const RecallConfigSchema = z.object({
     override_defaults: z.array(z.string()),
     allowlist: z.array(z.string()),
   }),
+  profiles: z.object({
+    verify_signature: z.enum(["warn", "error", "skip"]),
+  }),
   debug: z.object({
     enabled: z.boolean(),
   }),
@@ -44,6 +47,9 @@ const DEFAULTS: RecallConfig = {
     additional: [],
     override_defaults: [],
     allowlist: [],
+  },
+  profiles: {
+    verify_signature: "warn" as const,
   },
   debug: {
     enabled: false,

--- a/src/profiles/commands.ts
+++ b/src/profiles/commands.ts
@@ -11,9 +11,9 @@
  *   check             — detect pattern conflicts between installed profiles
  *   test <name>       — apply a profile to a stored or file input and show the result
  */
-import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, rmSync } from "fs";
+import { readFileSync, writeFileSync, mkdirSync, readdirSync, statSync, rmSync, unlinkSync } from "fs";
 import { join } from "path";
-import { homedir } from "os";
+import { homedir, tmpdir } from "os";
 import { createHash } from "crypto";
 import { parse } from "smol-toml";
 import { loadProfiles, clearProfileCache, getShortName } from "./loader";
@@ -93,13 +93,6 @@ function manifestShortName(e: ManifestEntry): string {
   return e.short_name ?? e.id.replace(/^mcp__/, "");
 }
 
-async function fetchManifest(): Promise<ManifestEntry[]> {
-  const res = await fetch(MANIFEST_URL);
-  if (!res.ok) throw new Error(`manifest fetch failed: ${res.status} ${res.statusText}`);
-  const data = (await res.json()) as { profiles: ManifestEntry[] };
-  return data.profiles;
-}
-
 async function fetchProfileContent(filePath: string): Promise<string> {
   const res = await fetch(`${PROFILE_BASE_URL}${filePath}`);
   if (!res.ok) throw new Error(`profile fetch failed (${filePath}): ${res.status}`);
@@ -117,6 +110,64 @@ function verifyHash(content: string, expected: string | undefined, id: string): 
       `Profile ${id}: hash mismatch (expected ${expected.slice(0, 8)}…, got ${actual.slice(0, 8)}…)`
     );
   }
+}
+
+/**
+ * Verify the manifest file has a valid GitHub Artifact Attestation.
+ * Shells out to `gh attestation verify`. Degrades gracefully if gh is absent.
+ */
+export function verifyManifest(manifestPath: string, mode: "warn" | "error" | "skip"): void {
+  if (mode === "skip") return;
+
+  // Check gh is available
+  let ghAvailable = false;
+  try {
+    const probe = Bun.spawnSync(["gh", "--version"], { stderr: "ignore", stdout: "ignore" });
+    ghAvailable = probe.exitCode === 0;
+  } catch {
+    // gh not in PATH
+  }
+
+  if (!ghAvailable) {
+    process.stderr.write(
+      "[recall] manifest signature verification skipped: gh CLI not found in PATH\n"
+    );
+    return;
+  }
+
+  const result = Bun.spawnSync(
+    ["gh", "attestation", "verify", manifestPath, "--repo", COMMUNITY_REPO],
+    { stderr: "pipe", stdout: "ignore" }
+  );
+
+  if (result.exitCode !== 0) {
+    const errText = result.stderr ? new TextDecoder().decode(result.stderr).trim() : "";
+    const msg = `[recall] manifest signature verification failed${errText ? `: ${errText}` : ""}\n`;
+    if (mode === "error") {
+      throw new Error(msg.trim());
+    }
+    process.stderr.write(msg);
+  }
+}
+
+async function fetchManifest(skipVerify = false): Promise<ManifestEntry[]> {
+  const res = await fetch(MANIFEST_URL);
+  if (!res.ok) throw new Error(`manifest fetch failed: ${res.status} ${res.statusText}`);
+  const text = await res.text();
+
+  if (!skipVerify) {
+    const tmpPath = join(tmpdir(), `mcp-recall-manifest-${process.pid}.json`);
+    try {
+      writeFileSync(tmpPath, text, "utf8");
+      const config = loadConfig();
+      verifyManifest(tmpPath, config.profiles.verify_signature);
+    } finally {
+      try { unlinkSync(tmpPath); } catch { /* best effort */ }
+    }
+  }
+
+  const data = JSON.parse(text) as { profiles: ManifestEntry[] };
+  return data.profiles;
 }
 
 function saveToCommunitDir(profileId: string, content: string): string {
@@ -275,14 +326,15 @@ export function cmdList(args: string[]): void {
 // ── install ───────────────────────────────────────────────────────────────────
 
 export async function cmdInstall(args: string[]): Promise<void> {
-  const nameOrId = args[0];
+  const skipVerify = args.includes("--skip-verify");
+  const nameOrId = args.find((a) => !a.startsWith("-"));
   if (!nameOrId) {
-    console.error("Usage: mcp-recall profiles install <name>");
+    console.error("Usage: mcp-recall profiles install <name> [--skip-verify]");
     process.exit(1);
   }
 
   process.stdout.write("Fetching manifest… ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log("done");
 
   const entry = await resolveManifestEntry(nameOrId, entries);
@@ -298,7 +350,8 @@ export async function cmdInstall(args: string[]): Promise<void> {
 
 // ── update ────────────────────────────────────────────────────────────────────
 
-async function cmdUpdate(): Promise<void> {
+async function cmdUpdate(args: string[] = []): Promise<void> {
+  const skipVerify = args.includes("--skip-verify");
   const installed = installedCommunityMap();
   if (installed.size === 0) {
     console.log("No community profiles installed.");
@@ -306,7 +359,7 @@ async function cmdUpdate(): Promise<void> {
   }
 
   process.stdout.write("Fetching manifest… ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log("done\n");
 
   let updated = 0;
@@ -370,9 +423,10 @@ export function cmdRemove(args: string[]): void {
 
 export async function cmdSeed(args: string[]): Promise<void> {
   const all = args.includes("--all");
+  const skipVerify = args.includes("--skip-verify");
 
   process.stdout.write("Fetching manifest… ");
-  const entries = await fetchManifest();
+  const entries = await fetchManifest(skipVerify);
   console.log("done\n");
 
   const installed = installedCommunityMap();
@@ -801,7 +855,7 @@ export async function handleProfilesCommand(args: string[]): Promise<void> {
       await cmdInstall(rest);
       break;
     case "update":
-      await cmdUpdate();
+      await cmdUpdate(rest);
       break;
     case "remove":
       cmdRemove(rest);

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,47 +4,7 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-### #122 — Friendly profile names, deconfliction, and rich metadata (PRs open — awaiting merge)
-
-PR A: https://github.com/sakebomb/mcp-recall/pull/130
-PR B: https://github.com/sakebomb/mcp-recall-profiles/pull/6
-
-Two PRs: **PR A** (core — this repo) + **PR B** (community profiles repo).
-
-#### PR A — `mcp-recall` core (`feat/profile-friendly-names`)
-
-**Schema changes**
-- [ ] 1. Add `short_name`, `mcp_url`, `author`, `version` to `[profile]` TOML schema (Zod) — all optional; `short_name` defaults to `id.replace(/^mcp__/, "")`
-- [ ] 2. Update `manifest.json` entry type in `src/profiles/loader.ts` to include new fields
-- [ ] 3. Add `getShortName(profile)` helper — returns `short_name ?? id.replace(/^mcp__/, "")`
-
-**CLI: short name resolution**
-- [ ] 4. Add `resolveProfileId(nameOrId, profiles)` — exact id match wins; then short_name match; collision → TTY picker or non-TTY error list
-- [ ] 5. Wire resolution into `cmdInstall`, `cmdRemove` (any command that takes a profile id arg)
-
-**New: `profiles info <name>`**
-- [ ] 6. Implement `cmdInfo(args)` — shows full metadata for one profile (installed or from manifest)
-- [ ] 7. Add dispatcher entry in CLI
-
-**New: `profiles available`**
-- [ ] 8. Implement `cmdAvailable(args)` — fetches community manifest, tabulates with install status markers
-- [ ] 9. Add `--verbose` flag (show URLs)
-- [ ] 10. Add dispatcher entry in CLI
-
-**`profiles list` update**
-- [ ] 11. Rework output to use `short_name` as ID column, add `Description` column
-
-**Tests**
-- [ ] 12. `resolveProfileId` — exact match, short-name match, collision non-TTY error, no-match error
-- [ ] 13. `cmdInfo` — installed profile, available-only profile, unknown name
-- [ ] 14. `cmdAvailable` — catalog output, installed status markers, `--verbose` URLs
-- [ ] 15. `profiles list` — short names, description column
-
-#### PR B — `mcp-recall-profiles` community repo
-
-- [ ] 16. Add `short_name`, `mcp_url`, `author`, `version` to all 18 profile TOMLs
-- [ ] 17. Add same fields to `manifest.json` entries
-- [ ] 18. Update `validate.ts` to enforce unique `short_name` values across the manifest
+_nothing in progress_
 
 ## Up Next
 

--- a/tests/denylist.test.ts
+++ b/tests/denylist.test.ts
@@ -12,6 +12,7 @@ const baseConfig: RecallConfig = {
   },
   retrieve: { default_max_bytes: 8192 },
   denylist: { additional: [], override_defaults: [], allowlist: [] },
+  profiles: { verify_signature: "warn" },
   debug: { enabled: false },
 };
 

--- a/tests/profiles-commands.test.ts
+++ b/tests/profiles-commands.test.ts
@@ -1,8 +1,8 @@
-import { describe, test, expect, beforeEach, afterEach } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach, spyOn } from "bun:test";
 import { mkdtempSync, mkdirSync, writeFileSync, rmSync, existsSync } from "fs";
 import { join } from "path";
 import { tmpdir } from "os";
-import { patternsOverlap, testProfile, cmdList, cmdInstall, cmdRemove, cmdAvailable } from "../src/profiles/commands";
+import { patternsOverlap, testProfile, cmdList, cmdInstall, cmdRemove, cmdAvailable, verifyManifest } from "../src/profiles/commands";
 import { clearProfileCache, getShortName } from "../src/profiles/loader";
 
 // ── patternsOverlap ───────────────────────────────────────────────────────────
@@ -733,5 +733,145 @@ type = "text_truncate"`;
     const output = lines.join("\n");
     expect(output).toContain("https://github.com/grafana/mcp-grafana");
     expect(output).toContain("MCP URL");
+  });
+});
+
+// ── verifyManifest ────────────────────────────────────────────────────────────
+
+describe("verifyManifest", () => {
+  let tmpFile: string;
+
+  beforeEach(() => {
+    tmpFile = join(tmpdir(), `test-manifest-${process.pid}.json`);
+    writeFileSync(tmpFile, JSON.stringify({ profiles: [] }), "utf8");
+  });
+
+  afterEach(() => {
+    try { rmSync(tmpFile); } catch { /* already gone */ }
+  });
+
+  test("skip mode does nothing regardless of gh availability", () => {
+    const spy = spyOn(Bun, "spawnSync");
+    verifyManifest(tmpFile, "skip");
+    expect(spy).not.toHaveBeenCalled();
+    spy.mockRestore();
+  });
+
+  test("warn mode warns to stderr when gh exits non-zero", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
+      const args = cmd as string[];
+      // probe passes, attestation verify fails
+      if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
+      return { exitCode: 1, stderr: new TextEncoder().encode("error: no attestation found"), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
+    });
+
+    const stderrLines: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg: string | Uint8Array, ..._rest: unknown[]) => {
+      stderrLines.push(typeof msg === "string" ? msg : new TextDecoder().decode(msg));
+      return true;
+    };
+
+    try {
+      verifyManifest(tmpFile, "warn");
+    } finally {
+      process.stderr.write = origWrite;
+      spy.mockRestore();
+    }
+
+    expect(stderrLines.join("")).toContain("[recall] manifest signature verification failed");
+  });
+
+  test("warn mode does not throw when gh exits non-zero", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
+      const args = cmd as string[];
+      if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
+      return { exitCode: 1, stderr: new Uint8Array(), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
+    });
+
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = () => true;
+
+    try {
+      expect(() => verifyManifest(tmpFile, "warn")).not.toThrow();
+    } finally {
+      process.stderr.write = origWrite;
+      spy.mockRestore();
+    }
+  });
+
+  test("error mode throws when gh exits non-zero", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
+      const args = cmd as string[];
+      if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
+      return { exitCode: 1, stderr: new TextEncoder().encode("verification failed"), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
+    });
+
+    try {
+      expect(() => verifyManifest(tmpFile, "error")).toThrow(
+        /manifest signature verification failed/
+      );
+    } finally {
+      spy.mockRestore();
+    }
+  });
+
+  test("warn mode warns to stderr when gh is not in PATH", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((..._args: unknown[]) => {
+      throw new Error("spawn ENOENT");
+    });
+
+    const stderrLines: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg: string | Uint8Array, ..._rest: unknown[]) => {
+      stderrLines.push(typeof msg === "string" ? msg : new TextDecoder().decode(msg));
+      return true;
+    };
+
+    try {
+      verifyManifest(tmpFile, "warn");
+    } finally {
+      process.stderr.write = origWrite;
+      spy.mockRestore();
+    }
+
+    expect(stderrLines.join("")).toContain("gh CLI not found");
+  });
+
+  test("error mode does not throw when gh is not in PATH (degrade gracefully)", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((..._args: unknown[]) => {
+      throw new Error("spawn ENOENT");
+    });
+
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = () => true;
+
+    try {
+      expect(() => verifyManifest(tmpFile, "error")).not.toThrow();
+    } finally {
+      process.stderr.write = origWrite;
+      spy.mockRestore();
+    }
+  });
+
+  test("warn mode succeeds silently when gh exits zero", () => {
+    const spy = spyOn(Bun, "spawnSync").mockImplementation((..._args: unknown[]) => ({
+      exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true,
+    } as ReturnType<typeof Bun.spawnSync>));
+
+    const stderrLines: string[] = [];
+    const origWrite = process.stderr.write.bind(process.stderr);
+    process.stderr.write = (msg: string | Uint8Array, ..._rest: unknown[]) => {
+      stderrLines.push(typeof msg === "string" ? msg : new TextDecoder().decode(msg));
+      return true;
+    };
+
+    try {
+      expect(() => verifyManifest(tmpFile, "warn")).not.toThrow();
+      expect(stderrLines.join("")).toBe("");
+    } finally {
+      process.stderr.write = origWrite;
+      spy.mockRestore();
+    }
   });
 });


### PR DESCRIPTION
## Summary

- Adds `verifyManifest()` that shells out to `gh attestation verify <path> --repo sakebomb/mcp-recall-profiles` after downloading `manifest.json`
- All manifest-consuming commands (`install`, `seed`, `update`) now verify the attestation before trusting the manifest
- New `profiles.verify_signature` config flag: `"warn"` (default) | `"error"` | `"skip"`
  - `"warn"`: log to stderr and continue if verification fails or `gh` is absent
  - `"error"`: abort on failure
  - `"skip"`: bypass entirely (air-gapped/offline environments)
- New `--skip-verify` flag on `install`, `seed`, `update` (overrides config mode)
- Degrades gracefully when `gh` is not in PATH — warns to stderr, never throws

**Depends on:** sakebomb/mcp-recall-profiles#7 (sign-manifest workflow) being merged and at least one manifest commit signed before `"error"` mode will pass without `--skip-verify`.

## What's protected

- CDN poisoning: attacker serving a tampered `manifest.json` from a compromised CDN
- Partial repo compromise: attacker pushing a new manifest without triggering the signing workflow

## What's not protected

- Full `sakebomb` account compromise (attacker could trigger a new signed workflow run)
- Mitigate with pinned action SHAs in the signing workflow (follow-up)

## Test plan

- [x] `bun test` — 594 pass (7 new tests in `verifyManifest` describe block)
- [x] `bun run typecheck` — clean
- [ ] After mcp-recall-profiles#7 merges and manifest is signed: run `mcp-recall profiles install grafana` and confirm no warning
- [ ] Set `verify_signature = "error"` in config and confirm install works
- [ ] Set `verify_signature = "error"` and run `--skip-verify` and confirm it bypasses