### PR TITLE
chore: fix saveToCommunitDir typo, add status output example

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Fixed
+
+- Renamed `saveToCommunitDir` → `saveToCommunityDir` (typo)
+
+### Added
+
+- `README.md`: `mcp-recall status` output example showing all rows including CLAUDE.md
+
 ---
 
 ## [1.6.0] — 2026-03-12

--- a/README.md
+++ b/README.md
@@ -146,7 +146,24 @@ mcp-recall install       # register hooks + MCP server in Claude Code
 mcp-recall status        # verify
 ```
 
-`mcp-recall install` writes the MCP server entry and both hooks directly to `~/.claude.json` and `~/.claude/settings.json`. It's idempotent — safe to re-run after updates.
+`mcp-recall install` writes the MCP server entry and hooks to `~/.claude.json` and `~/.claude/settings.json`, and adds a short instruction block to `~/.claude/CLAUDE.md` so Claude knows how to use the recall tools. It's idempotent — safe to re-run after updates.
+
+A fully installed `mcp-recall status` looks like this:
+
+```
+Installation: installed
+
+  ~/.claude.json                    ✓ mcpServers.recall
+  ~/.claude/settings.json           ✓ SessionStart hook
+                                    ✓ PostToolUse hook
+  ~/.claude/CLAUDE.md               ✓ mcp-recall instructions
+
+  Build artifacts
+    dist/server.js                  ✓ /path/to/dist/server.js
+    dist/cli.js                     ✓ /path/to/dist/cli.js
+
+  ✓ Profiles: 12 installed (4 user, 8 community)
+```
 
 Update: `bun update -g mcp-recall && mcp-recall install`
 

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -8071,7 +8071,7 @@ async function fetchManifest(skipVerify = false) {
   const data = JSON.parse(text);
   return data.profiles;
 }
-function saveToCommunitDir(profileId, content) {
+function saveToCommunityDir(profileId, content) {
   const dir = join4(communityDir(), profileId);
   mkdirSync2(dir, { recursive: true });
   const filePath = join4(dir, "default.toml");
@@ -8204,7 +8204,7 @@ async function cmdInstall(args) {
   process.stdout.write(`Installing ${sanitize(entry.id)} v${sanitize(entry.version)}\u2026 `);
   const content = await fetchProfileContent(entry.file);
   verifyHash(content, entry.sha256, entry.id);
-  const filePath = saveToCommunitDir(entry.id, content);
+  const filePath = saveToCommunityDir(entry.id, content);
   clearProfileCache();
   console.log(`done
 \u2713 ${filePath}`);
@@ -8235,7 +8235,7 @@ async function cmdUpdate(args = []) {
     assertSafeFile(entry.file);
     const content = await fetchProfileContent(entry.file);
     verifyHash(content, entry.sha256, entry.id);
-    saveToCommunitDir(id, content);
+    saveToCommunityDir(id, content);
     console.log(`  \u2713 ${id}: ${currentVersion} \u2192 ${entry.version}`);
     updated++;
   }
@@ -8286,7 +8286,7 @@ async function cmdSeed(args) {
       assertSafeFile(entry.file);
       const content = await fetchProfileContent(entry.file);
       verifyHash(content, entry.sha256, entry.id);
-      saveToCommunitDir(entry.id, content);
+      saveToCommunityDir(entry.id, content);
       console.log(`  \u2713 ${entry.id} installed`);
       installCount++;
     }
@@ -8332,7 +8332,7 @@ ${installCount} profile(s) installed (${alreadyCount} already installed, ${entri
       assertSafeFile(entry.file);
       const content = await fetchProfileContent(entry.file);
       verifyHash(content, entry.sha256, entry.id);
-      saveToCommunitDir(entry.id, content);
+      saveToCommunityDir(entry.id, content);
       console.log(`  \u2713 ${entry.id} installed (matched ${key})`);
       installCount++;
     }

--- a/src/profiles/commands.ts
+++ b/src/profiles/commands.ts
@@ -170,7 +170,7 @@ async function fetchManifest(skipVerify = false): Promise<ManifestEntry[]> {
   return data.profiles;
 }
 
-function saveToCommunitDir(profileId: string, content: string): string {
+function saveToCommunityDir(profileId: string, content: string): string {
   const dir = join(communityDir(), profileId);
   mkdirSync(dir, { recursive: true });
   const filePath = join(dir, "default.toml");
@@ -343,7 +343,7 @@ export async function cmdInstall(args: string[]): Promise<void> {
   process.stdout.write(`Installing ${sanitize(entry.id)} v${sanitize(entry.version)}… `);
   const content = await fetchProfileContent(entry.file);
   verifyHash(content, entry.sha256, entry.id);
-  const filePath = saveToCommunitDir(entry.id, content);
+  const filePath = saveToCommunityDir(entry.id, content);
   clearProfileCache();
   console.log(`done\n✓ ${filePath}`);
 }
@@ -377,7 +377,7 @@ async function cmdUpdate(args: string[] = []): Promise<void> {
     assertSafeFile(entry.file);
     const content = await fetchProfileContent(entry.file);
     verifyHash(content, entry.sha256, entry.id);
-    saveToCommunitDir(id, content);
+    saveToCommunityDir(id, content);
     console.log(`  ✓ ${id}: ${currentVersion} → ${entry.version}`);
     updated++;
   }
@@ -444,7 +444,7 @@ export async function cmdSeed(args: string[]): Promise<void> {
       assertSafeFile(entry.file);
       const content = await fetchProfileContent(entry.file);
       verifyHash(content, entry.sha256, entry.id);
-      saveToCommunitDir(entry.id, content);
+      saveToCommunityDir(entry.id, content);
       console.log(`  ✓ ${entry.id} installed`);
       installCount++;
     }
@@ -497,7 +497,7 @@ export async function cmdSeed(args: string[]): Promise<void> {
       assertSafeFile(entry.file);
       const content = await fetchProfileContent(entry.file);
       verifyHash(content, entry.sha256, entry.id);
-      saveToCommunitDir(entry.id, content);
+      saveToCommunityDir(entry.id, content);
       console.log(`  ✓ ${entry.id} installed (matched ${key})`);
       installCount++;
     }


### PR DESCRIPTION
## Summary

- Rename `saveToCommunitDir` → `saveToCommunityDir` (pre-existing typo in `src/profiles/commands.ts`) — no behaviour change
- Add `mcp-recall status` output example to README showing the full installation state including the new CLAUDE.md row

## Test plan

- [ ] `bun test tests/profiles-commands.test.ts` — all 37 pass
- [ ] `bun run typecheck` — clean