### PR TITLE
chore: add CODE_OF_CONDUCT and polish README badges

### DIFF
--- a/CODE_OF_CONDUCT.md
+++ b/CODE_OF_CONDUCT.md
@@ -1,0 +1,41 @@
+# Code of Conduct
+
+## Our Pledge
+
+We as contributors and maintainers pledge to make participation in mcp-recall a harassment-free experience for everyone, regardless of age, body size, visible or invisible disability, ethnicity, sex characteristics, gender identity and expression, level of experience, education, socio-economic status, nationality, personal appearance, race, religion, or sexual identity and orientation.
+
+We pledge to act and interact in ways that contribute to an open, welcoming, diverse, inclusive, and healthy community.
+
+## Our Standards
+
+Examples of behavior that contributes to a positive environment:
+
+- Using welcoming and inclusive language
+- Being respectful of differing viewpoints and experiences
+- Gracefully accepting constructive criticism
+- Focusing on what is best for the community
+- Showing empathy towards other community members
+
+Examples of unacceptable behavior:
+
+- The use of sexualized language or imagery, and sexual attention or advances of any kind
+- Trolling, insulting or derogatory comments, and personal or political attacks
+- Public or private harassment
+- Publishing others' private information without explicit permission
+- Other conduct which could reasonably be considered inappropriate in a professional setting
+
+## Enforcement Responsibilities
+
+Project maintainers are responsible for clarifying and enforcing our standards of acceptable behavior and will take appropriate and fair corrective action in response to any behavior that they deem inappropriate, threatening, offensive, or harmful.
+
+## Scope
+
+This Code of Conduct applies within all project spaces, and also applies when an individual is officially representing the project in public spaces.
+
+## Enforcement
+
+Instances of abusive, harassing, or otherwise unacceptable behavior may be reported by opening a [GitHub issue](https://github.com/sakebomb/mcp-recall/issues) or contacting the maintainer directly via GitHub. All complaints will be reviewed and investigated promptly and fairly.
+
+## Attribution
+
+This Code of Conduct is adapted from the [Contributor Covenant](https://www.contributor-covenant.org), version 2.1.

--- a/README.md
+++ b/README.md
@@ -1,9 +1,13 @@
 # mcp-recall
 
-![CI](https://github.com/sakebomb/mcp-recall/actions/workflows/ci.yml/badge.svg)
+[![CI](https://github.com/sakebomb/mcp-recall/actions/workflows/ci.yml/badge.svg)](https://github.com/sakebomb/mcp-recall/actions/workflows/ci.yml)
+[![npm](https://img.shields.io/npm/v/mcp-recall.svg)](https://www.npmjs.com/package/mcp-recall)
+[![npm downloads](https://img.shields.io/npm/dw/mcp-recall.svg)](https://www.npmjs.com/package/mcp-recall)
 ![License: MIT](https://img.shields.io/badge/License-MIT-blue.svg)
 ![Runtime: Bun](https://img.shields.io/badge/runtime-Bun-f472b6.svg)
+![TypeScript](https://img.shields.io/badge/TypeScript-strict-3178c6.svg)
 ![Claude Code Plugin](https://img.shields.io/badge/Claude%20Code-plugin-orange.svg)
+[![PRs Welcome](https://img.shields.io/badge/PRs-welcome-brightgreen.svg)](CONTRIBUTING.md)
 
 **Your context window is finite. MCP tool outputs aren't. mcp-recall bridges the gap.**
 


### PR DESCRIPTION
## Summary
- Adds `CODE_OF_CONDUCT.md` (Contributor Covenant 2.1) — completes GitHub Community Standards checklist
- Adds npm version + weekly downloads badges (shows the package is published and tracking traction)
- Adds TypeScript strict badge
- Adds PRs Welcome badge (signals community openness)
- CI and npm badges now link through to their respective pages

## Test plan
- [x] No code changes — docs/config only
- [x] CI passes