### PR TITLE
feat: add bundled profiles for Gmail, Context7, and Docker

### DIFF
--- a/profiles/mcp__claude_ai_gmail/default.toml
+++ b/profiles/mcp__claude_ai_gmail/default.toml
@@ -1,0 +1,14 @@
+[profile]
+id          = "mcp__claude_ai_gmail"
+version     = "1.0.0"
+description = "Gmail MCP catch-all — truncates any tool output not matched by a more specific profile"
+mcp_pattern = "mcp__claude_ai_Gmail__*"
+short_name  = "gmail"
+author      = "sakebomb"
+mcp_url     = "https://gmail.mcp.claude.com"
+
+[strategy]
+type            = "json_truncate"
+max_depth       = 2
+max_array_items = 3
+fallback_chars  = 500

--- a/profiles/mcp__claude_ai_gmail/read_message.toml
+++ b/profiles/mcp__claude_ai_gmail/read_message.toml
@@ -1,0 +1,23 @@
+[profile]
+id          = "mcp__claude_ai_gmail__read_message"
+version     = "1.0.0"
+description = "Gmail single message — extracts id, threadId, snippet, and labelIds; skips full payload"
+mcp_pattern = "mcp__claude_ai_Gmail__gmail_read_message"
+short_name  = "gmail-message"
+author      = "sakebomb"
+mcp_url     = "https://gmail.mcp.claude.com"
+sample_tool = "mcp__claude_ai_Gmail__gmail_read_message"
+
+[strategy]
+type                = "json_extract"
+items_path          = ["."]
+fields              = ["id", "threadId", "snippet", "labelIds"]
+max_items           = 1
+max_chars_per_field = 300
+fallback_chars      = 500
+
+[strategy.labels]
+"id"       = "ID"
+"threadId" = "Thread"
+"snippet"  = "Preview"
+"labelIds" = "Labels"

--- a/profiles/mcp__claude_ai_gmail/read_thread.toml
+++ b/profiles/mcp__claude_ai_gmail/read_thread.toml
@@ -1,0 +1,15 @@
+[profile]
+id          = "mcp__claude_ai_gmail__read_thread"
+version     = "1.0.0"
+description = "Gmail thread — depth-truncates to show thread snippet and first 3 messages without full payloads"
+mcp_pattern = "mcp__claude_ai_Gmail__gmail_read_thread"
+short_name  = "gmail-thread"
+author      = "sakebomb"
+mcp_url     = "https://gmail.mcp.claude.com"
+sample_tool = "mcp__claude_ai_Gmail__gmail_read_thread"
+
+[strategy]
+type            = "json_truncate"
+max_depth       = 2
+max_array_items = 3
+fallback_chars  = 500

--- a/profiles/mcp__context7/default.toml
+++ b/profiles/mcp__context7/default.toml
@@ -1,0 +1,21 @@
+[profile]
+id          = "mcp__context7"
+version     = "1.0.0"
+description = "Context7 query-docs — extracts section titles and content previews from documentation responses"
+mcp_pattern = "mcp__context7__query-docs"
+short_name  = "context7"
+author      = "sakebomb"
+mcp_url     = "https://github.com/upstash/context7"
+sample_tool = "mcp__context7__query-docs"
+
+[strategy]
+type                = "json_extract"
+items_path          = [""]
+fields              = ["title", "content"]
+max_items           = 5
+max_chars_per_field = 600
+fallback_chars      = 500
+
+[strategy.labels]
+"title"   = "Section"
+"content" = "Content"

--- a/profiles/mcp__context7/resolve.toml
+++ b/profiles/mcp__context7/resolve.toml
@@ -1,0 +1,15 @@
+[profile]
+id          = "mcp__context7__resolve"
+version     = "1.0.0"
+description = "Context7 resolve-library-id — truncates library search results to top-level fields"
+mcp_pattern = "mcp__context7__resolve-library-id"
+short_name  = "context7-resolve"
+author      = "sakebomb"
+mcp_url     = "https://github.com/upstash/context7"
+sample_tool = "mcp__context7__resolve-library-id"
+
+[strategy]
+type            = "json_truncate"
+max_depth       = 2
+max_array_items = 5
+fallback_chars  = 500

--- a/profiles/mcp__docker/container_list.toml
+++ b/profiles/mcp__docker/container_list.toml
@@ -1,0 +1,23 @@
+[profile]
+id          = "mcp__docker__container_list"
+version     = "1.0.0"
+description = "Docker container list — extracts name, image, status, and state per container"
+mcp_pattern = "mcp__docker__docker_container_list"
+short_name  = "docker-list"
+author      = "sakebomb"
+mcp_url     = "https://github.com/docker/mcp-servers"
+sample_tool = "mcp__docker__docker_container_list"
+
+[strategy]
+type                = "json_extract"
+items_path          = [""]
+fields              = ["Names", "Image", "Status", "State"]
+max_items           = 25
+max_chars_per_field = 100
+fallback_chars      = 500
+
+[strategy.labels]
+"Names"  = "Name"
+"Image"  = "Image"
+"Status" = "Status"
+"State"  = "State"

--- a/profiles/mcp__docker/default.toml
+++ b/profiles/mcp__docker/default.toml
@@ -1,0 +1,14 @@
+[profile]
+id          = "mcp__docker"
+version     = "1.0.0"
+description = "Docker MCP catch-all — depth-truncates JSON for inspect, system info, and other tool outputs"
+mcp_pattern = "mcp__docker__*"
+short_name  = "docker"
+author      = "sakebomb"
+mcp_url     = "https://github.com/docker/mcp-servers"
+
+[strategy]
+type            = "json_truncate"
+max_depth       = 3
+max_array_items = 5
+fallback_chars  = 500

--- a/profiles/mcp__docker/logs.toml
+++ b/profiles/mcp__docker/logs.toml
@@ -1,0 +1,13 @@
+[profile]
+id          = "mcp__docker__logs"
+version     = "1.0.0"
+description = "Docker container logs — truncates raw log output to the first 1500 characters"
+mcp_pattern = "mcp__docker__docker_container_logs"
+short_name  = "docker-logs"
+author      = "sakebomb"
+mcp_url     = "https://github.com/docker/mcp-servers"
+sample_tool = "mcp__docker__docker_container_logs"
+
+[strategy]
+type      = "text_truncate"
+max_chars = 1500

--- a/profiles/mcp__jira/default.toml
+++ b/profiles/mcp__jira/default.toml
@@ -1,9 +1,11 @@
 [profile]
 id          = "mcp__jira"
-version     = "1.0.0"
-description = "Jira issue and search results — extracts key, summary, status, assignee, priority"
+version     = "1.1.0"
+description = "Jira issue and search results — extracts key, type, summary, status, assignee, priority"
 mcp_pattern = "mcp__jira__*"
+short_name  = "jira"
 author      = "sakebomb"
+mcp_url     = "https://developer.atlassian.com/cloud/jira/platform/rest/v3/"
 sample_tool = "mcp__jira__search_issues"
 
 [strategy]
@@ -11,6 +13,7 @@ type       = "json_extract"
 items_path = ["issues", "nodes"]
 fields     = [
   "key",
+  "fields.issuetype.name",
   "fields.summary",
   "fields.status.name",
   "fields.assignee.displayName",
@@ -22,6 +25,7 @@ fallback_chars      = 500
 
 [strategy.labels]
 "key"                         = "Key"
+"fields.issuetype.name"       = "Type"
 "fields.summary"              = "Summary"
 "fields.status.name"          = "Status"
 "fields.assignee.displayName" = "Assignee"


### PR DESCRIPTION
## Summary

- Adds 8 new bundled TOML profiles covering Gmail, Context7, and Docker — three MCP families with no prior compression coverage
- Updates `mcp__jira` to v1.1.0 with `fields.issuetype.name` (Type), `short_name`, and `mcp_url`

**Gmail** (`mcp__claude_ai_gmail/`): catch-all `json_truncate`, plus exact-match profiles for `read_message` (`json_extract`: id/threadId/snippet/labels) and `read_thread` (`json_truncate` depth=2 to preserve snippet while cutting `payload.headers`)

**Context7** (`mcp__context7/`): `json_extract` for `query-docs` (title + content, 5 sections, 600 chars each); `json_truncate` for `resolve-library-id`

**Docker** (`mcp__docker/`): `json_truncate` catch-all (depth=3 covers `inspect`); `json_extract` for `container_list` (Name/Image/Status/State); `text_truncate` at 1500 chars for `container_logs`

## Test plan

- [ ] `bun test tests/profiles.test.ts` — 24 pass, 0 fail
- [ ] `bun test` — 604 pass, 2 fail (pre-existing failures unrelated to profiles)
- [ ] `mcp-recall profiles list` shows new profiles after `bun run build`
- [ ] `mcp-recall profiles check` passes validation on all new profiles