### PR TITLE
fix: second code-review batch — parser, secrets, db, docs

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5418,8 +5418,7 @@ function getContext(db, project_key, opts = {}) {
   if (lastDate) {
     const startOfDay = Math.floor(new Date(`${lastDate}T00:00:00Z`).getTime() / 1000);
     const endOfDay = startOfDay + 86400;
-    const excludeIds = [...pinned, ...notes, ...recent].map((i) => i.id);
-    const notIn = excludeIds.length > 0 ? `AND id NOT IN (${excludeIds.map(() => "?").join(",")})` : "";
+    const excludeSet = new Set([...pinned, ...notes, ...recent].map((i) => i.id));
     const rows = db.prepare(`
       SELECT * FROM stored_outputs
       WHERE project_key = ?
@@ -5427,11 +5426,10 @@ function getContext(db, project_key, opts = {}) {
         AND tool_name != 'recall__note'
         AND created_at >= ? AND created_at < ?
         AND access_count > 0
-        ${notIn}
       ORDER BY access_count DESC
-      LIMIT 5
-    `).all(project_key, startOfDay, endOfDay, ...excludeIds);
-    hot.push(...rows);
+      LIMIT ?
+    `).all(project_key, startOfDay, endOfDay, 5 + excludeSet.size);
+    hot.push(...rows.filter((r) => !excludeSet.has(r.id)).slice(0, 5));
   }
   return { pinned, notes, recent, hot, last_session };
 }
@@ -5522,6 +5520,7 @@ function formatRelativeTime(ms) {
 }
 
 // src/tools.ts
+var CONTEXT_EMPTY_RESPONSE = "[recall: no context available yet \u2014 use recall tools to build up your context store]";
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -5536,7 +5535,7 @@ function toolContext(db, projectKey, args) {
   const today = new Date(now).toISOString().slice(0, 10);
   const isEmpty = data.pinned.length === 0 && data.notes.length === 0 && data.recent.length === 0 && data.hot.length === 0 && data.last_session === null;
   if (isEmpty) {
-    return `[recall: no context available yet \u2014 use recall tools to build up your context store]`;
+    return CONTEXT_EMPTY_RESPONSE;
   }
   const lines = [
     `Context \u2014 ${today}`,
@@ -5612,10 +5611,10 @@ function handleSessionStart(raw) {
   const today = new Date().toISOString().slice(0, 10);
   recordSession(db, today);
   pruneExpired(db, projectKey, config.store.expire_after_session_days);
-  const data = getContext(db, projectKey);
-  const isEmpty = data.pinned.length === 0 && data.notes.length === 0 && data.recent.length === 0 && data.hot.length === 0 && data.last_session === null;
-  if (!isEmpty) {
-    let snapshot = toolContext(db, projectKey, {});
+  let snapshot = toolContext(db, projectKey, {});
+  if (snapshot === CONTEXT_EMPTY_RESPONSE) {
+    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 nothing to inject`);
+  } else {
     if (snapshot.length > INJECT_MAX_CHARS) {
       snapshot = snapshot.slice(0, INJECT_MAX_CHARS) + `
 \u2026 (truncated \u2014 call recall__context for the full view)`;
@@ -5623,8 +5622,6 @@ function handleSessionStart(raw) {
     process.stdout.write(snapshot + `
 `);
     log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 injected ${snapshot.length} chars`);
-  } else {
-    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 nothing to inject`);
   }
 }
 
@@ -5697,7 +5694,7 @@ var SECRET_PATTERNS = [
   },
   {
     name: "OpenAI API key",
-    pattern: /sk-(?!ant-)[A-Za-z0-9]{32,}/
+    pattern: /sk-(?!ant-)[\w-]{32,}/
   },
   {
     name: "AWS access key ID",
@@ -6219,7 +6216,7 @@ var gitLogHandler = (_toolName, output) => {
     if (line.startsWith("commit ")) {
       hash = line.slice(7, 14);
       seenBlank = false;
-    } else if (hash && line.trim() === "" && !seenBlank) {
+    } else if (hash && !seenBlank && (line.startsWith("Author:") || line.startsWith("Date:") || line.startsWith("Merge:") || line.startsWith("gpgsig ") || line.startsWith(" ") && line.trim() !== "")) {} else if (hash && line.trim() === "" && !seenBlank) {
       seenBlank = true;
     } else if (hash && seenBlank && line.startsWith("    ") && line.trim()) {
       const subject = line.trim().slice(0, 72);
@@ -7432,7 +7429,9 @@ function getBundledProfilesDir() {
   try {
     statSync(devPath);
     return devPath;
-  } catch {
+  } catch (e) {
+    if (e.code !== "ENOENT")
+      throw e;
     return distPath;
   }
 }

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19931,8 +19931,7 @@ function getContext(db, project_key, opts = {}) {
   if (lastDate) {
     const startOfDay = Math.floor(new Date(`${lastDate}T00:00:00Z`).getTime() / 1000);
     const endOfDay = startOfDay + 86400;
-    const excludeIds = [...pinned, ...notes, ...recent].map((i) => i.id);
-    const notIn = excludeIds.length > 0 ? `AND id NOT IN (${excludeIds.map(() => "?").join(",")})` : "";
+    const excludeSet = new Set([...pinned, ...notes, ...recent].map((i) => i.id));
     const rows = db.prepare(`
       SELECT * FROM stored_outputs
       WHERE project_key = ?
@@ -19940,11 +19939,10 @@ function getContext(db, project_key, opts = {}) {
         AND tool_name != 'recall__note'
         AND created_at >= ? AND created_at < ?
         AND access_count > 0
-        ${notIn}
       ORDER BY access_count DESC
-      LIMIT 5
-    `).all(project_key, startOfDay, endOfDay, ...excludeIds);
-    hot.push(...rows);
+      LIMIT ?
+    `).all(project_key, startOfDay, endOfDay, 5 + excludeSet.size);
+    hot.push(...rows.filter((r) => !excludeSet.has(r.id)).slice(0, 5));
   }
   return { pinned, notes, recent, hot, last_session };
 }
@@ -21061,6 +21059,7 @@ function formatRelativeTime(ms) {
 }
 
 // src/tools.ts
+var CONTEXT_EMPTY_RESPONSE = "[recall: no context available yet \u2014 use recall tools to build up your context store]";
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -21216,7 +21215,7 @@ function toolContext(db, projectKey, args) {
   const today = new Date(now).toISOString().slice(0, 10);
   const isEmpty = data.pinned.length === 0 && data.notes.length === 0 && data.recent.length === 0 && data.hot.length === 0 && data.last_session === null;
   if (isEmpty) {
-    return `[recall: no context available yet \u2014 use recall tools to build up your context store]`;
+    return CONTEXT_EMPTY_RESPONSE;
   }
   const lines = [
     `Context \u2014 ${today}`,
@@ -21394,7 +21393,7 @@ var server = new McpServer({
   version: version2
 });
 server.tool("recall__retrieve", "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.", {
-  id: exports_external.string().describe("8-char or full item ID"),
+  id: exports_external.string().describe("recall_* item ID"),
   query: exports_external.string().optional().describe("FTS query to return a focused excerpt"),
   max_bytes: exports_external.number().optional().describe("Override default 8KB cap on returned bytes (used when FTS returns no match)")
 }, safeTool((args) => ({
@@ -21422,7 +21421,7 @@ server.tool("recall__note", "Store arbitrary text as a recall note \u2014 conclu
 server.tool("recall__export", "Export all stored items for this project as JSON. Use before a full clear to preserve data.", {}, safeTool(() => ({
   content: [{ type: "text", text: toolExport(db, projectKey) }]
 })));
-server.tool("recall__forget", "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true.", {
+server.tool("recall__forget", "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true. Note: single-ID deletes (id:) always bypass pin protection.", {
   id: exports_external.string().optional().describe("Delete a single item by ID"),
   tool: exports_external.string().optional().describe("Delete all items matching tool name substring"),
   session_id: exports_external.string().optional().describe("Delete all items from a session"),

--- a/src/db/index.ts
+++ b/src/db/index.ts
@@ -765,10 +765,10 @@ export function getContext(
   if (lastDate) {
     const startOfDay = Math.floor(new Date(`${lastDate}T00:00:00Z`).getTime() / 1000);
     const endOfDay = startOfDay + 86400;
-    const excludeIds = [...pinned, ...notes, ...recent].map((i) => i.id);
-    const notIn = excludeIds.length > 0
-      ? `AND id NOT IN (${excludeIds.map(() => "?").join(",")})`
-      : "";
+    // Filter duplicates in JS to avoid unbounded NOT IN bind-param expansion.
+    // Pinned and note items are already excluded by SQL predicates; only
+    // recent items can overlap, but we build the full set for safety.
+    const excludeSet = new Set([...pinned, ...notes, ...recent].map((i) => i.id));
     const rows = db.prepare(`
       SELECT * FROM stored_outputs
       WHERE project_key = ?
@@ -776,11 +776,10 @@ export function getContext(
         AND tool_name != 'recall__note'
         AND created_at >= ? AND created_at < ?
         AND access_count > 0
-        ${notIn}
       ORDER BY access_count DESC
-      LIMIT 5
-    `).all(project_key, startOfDay, endOfDay, ...excludeIds) as StoredOutput[];
-    hot.push(...rows);
+      LIMIT ?
+    `).all(project_key, startOfDay, endOfDay, 5 + excludeSet.size) as StoredOutput[];
+    hot.push(...rows.filter((r) => !excludeSet.has(r.id)).slice(0, 5));
   }
 
   return { pinned, notes, recent, hot, last_session };

--- a/src/denylist.ts
+++ b/src/denylist.ts
@@ -67,6 +67,8 @@ export function isDenied(toolName: string, config: RecallConfig): boolean {
  * Supports * as a wildcard matching any sequence of characters.
  * Matching is case-sensitive. Compiled regexes are cached.
  */
+// Bounded in practice: BUILTIN_PATTERNS is fixed and user-supplied additional
+// patterns are small relative to the tool namespace.
 const regexCache = new Map<string, RegExp>();
 
 export function matchesPattern(toolName: string, pattern: string): boolean {

--- a/src/handlers/bash.ts
+++ b/src/handlers/bash.ts
@@ -153,7 +153,9 @@ export const gitLogHandler: Handler = (
     return { summary, originalSize };
   }
 
-  // Full format: extract short hash + subject line from each "commit <hash>" block
+  // Full format: extract short hash + subject line from each "commit <hash>" block.
+  // Skip known git header lines (Author:, Date:, Merge:, gpgsig continuation lines
+  // starting with a space) so GPG-signed commits parse correctly.
   const commits: string[] = [];
   let hash = "";
   let seenBlank = false;
@@ -162,6 +164,14 @@ export const gitLogHandler: Handler = (
     if (line.startsWith("commit ")) {
       hash = line.slice(7, 14);
       seenBlank = false;
+    } else if (hash && !seenBlank && (
+      line.startsWith("Author:") ||
+      line.startsWith("Date:") ||
+      line.startsWith("Merge:") ||
+      line.startsWith("gpgsig ") ||
+      (line.startsWith(" ") && line.trim() !== "")  // gpgsig continuation lines
+    )) {
+      // skip git metadata headers before the blank separator
     } else if (hash && line.trim() === "" && !seenBlank) {
       seenBlank = true;
     } else if (hash && seenBlank && line.startsWith("    ") && line.trim()) {

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,7 +1,7 @@
 import { loadConfig } from "../config";
 import { getProjectKey } from "../project-key";
-import { getDb, defaultDbPath, recordSession, pruneExpired, getContext } from "../db/index";
-import { toolContext } from "../tools";
+import { getDb, defaultDbPath, recordSession, pruneExpired } from "../db/index";
+import { toolContext, CONTEXT_EMPTY_RESPONSE } from "../tools";
 import { log } from "../log";
 
 interface SessionStartInput {
@@ -36,16 +36,10 @@ export function handleSessionStart(raw: string): void {
 
   // Inject a compact context snapshot into Claude's initial context via stdout.
   // Claude Code adds SessionStart hook stdout as context before the first message.
-  const data = getContext(db, projectKey);
-  const isEmpty =
-    data.pinned.length === 0 &&
-    data.notes.length === 0 &&
-    data.recent.length === 0 &&
-    data.hot.length === 0 &&
-    data.last_session === null;
-
-  if (!isEmpty) {
-    let snapshot = toolContext(db, projectKey, {});
+  let snapshot = toolContext(db, projectKey, {});
+  if (snapshot === CONTEXT_EMPTY_RESPONSE) {
+    log.debug(`session-start · project=${projectKey.slice(0, 8)} · nothing to inject`);
+  } else {
     if (snapshot.length > INJECT_MAX_CHARS) {
       snapshot =
         snapshot.slice(0, INJECT_MAX_CHARS) +
@@ -53,7 +47,5 @@ export function handleSessionStart(raw: string): void {
     }
     process.stdout.write(snapshot + "\n");
     log.debug(`session-start · project=${projectKey.slice(0, 8)} · injected ${snapshot.length} chars`);
-  } else {
-    log.debug(`session-start · project=${projectKey.slice(0, 8)} · nothing to inject`);
   }
 }

--- a/src/profiles/loader.ts
+++ b/src/profiles/loader.ts
@@ -41,7 +41,8 @@ function getBundledProfilesDir(): string {
   try {
     statSync(devPath);
     return devPath;
-  } catch {
+  } catch (e) {
+    if ((e as NodeJS.ErrnoException).code !== "ENOENT") throw e;
     return distPath;
   }
 }

--- a/src/secrets.ts
+++ b/src/secrets.ts
@@ -26,7 +26,7 @@ export const SECRET_PATTERNS: SecretPattern[] = [
   },
   {
     name: "OpenAI API key",
-    pattern: /sk-(?!ant-)[A-Za-z0-9]{32,}/,
+    pattern: /sk-(?!ant-)[\w-]{32,}/,
   },
   {
     name: "AWS access key ID",

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,7 +58,7 @@ server.tool(
   "recall__retrieve",
   "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.",
   {
-    id: z.string().describe("8-char or full item ID"),
+    id: z.string().describe("recall_* item ID"),
     query: z.string().optional().describe("FTS query to return a focused excerpt"),
     max_bytes: z
       .number()
@@ -118,7 +118,7 @@ server.tool(
 
 server.tool(
   "recall__forget",
-  "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true.",
+  "Delete stored items by ID, tool pattern, session, age, or clear all. Pinned items are skipped unless force: true. Note: single-ID deletes (id:) always bypass pin protection.",
   {
     id: z.string().optional().describe("Delete a single item by ID"),
     tool: z.string().optional().describe("Delete all items matching tool name substring"),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -4,6 +4,9 @@
  * Server.ts wires these to the MCP SDK.
  */
 
+export const CONTEXT_EMPTY_RESPONSE =
+  "[recall: no context available yet — use recall tools to build up your context store]";
+
 import type { Database } from "bun:sqlite";
 import {
   retrieveOutput,
@@ -337,7 +340,7 @@ export function toolContext(
     data.last_session === null;
 
   if (isEmpty) {
-    return `[recall: no context available yet — use recall tools to build up your context store]`;
+    return CONTEXT_EMPTY_RESPONSE;
   }
 
   const lines: string[] = [

--- a/tests/db-concurrent.test.ts
+++ b/tests/db-concurrent.test.ts
@@ -70,8 +70,8 @@ describe("concurrent DB access", () => {
     const { dir, dbPath } = tempDb();
     cleanupDir = dir;
 
-    const db1 = getDb(dbPath);                    // initialises schema + WAL
-    db1.run("PRAGMA wal_checkpoint(PASSIVE)");    // flush schema to main DB file before db2 opens
+    const db1 = getDb(dbPath);                     // initialises schema + WAL
+    db1.run("PRAGMA wal_checkpoint(TRUNCATE)");   // flush + truncate WAL so db2 sees schema in main DB file
     const db2 = openSecondConnection(dbPath);     // second writer
 
     for (let i = 0; i < 15; i++) {

--- a/tests/db-concurrent.test.ts
+++ b/tests/db-concurrent.test.ts
@@ -70,8 +70,9 @@ describe("concurrent DB access", () => {
     const { dir, dbPath } = tempDb();
     cleanupDir = dir;
 
-    const db1 = getDb(dbPath);               // initialises schema + WAL
-    const db2 = openSecondConnection(dbPath); // second writer
+    const db1 = getDb(dbPath);                    // initialises schema + WAL
+    db1.run("PRAGMA wal_checkpoint(PASSIVE)");    // flush schema to main DB file before db2 opens
+    const db2 = openSecondConnection(dbPath);     // second writer
 
     for (let i = 0; i < 15; i++) {
       storeOutput(db1, makeInput({ summary: `db1 item ${i}` }));

--- a/tests/secrets.test.ts
+++ b/tests/secrets.test.ts
@@ -38,6 +38,13 @@ describe("containsSecret", () => {
     expect(containsSecret(`OPENAI_API_KEY=${key}`)).toBe(true);
   });
 
+  it("detects OpenAI project key (sk-proj-)", () => {
+    const key = "sk-proj-" + "A".repeat(40);
+    expect(containsSecret(`OPENAI_API_KEY=${key}`)).toBe(true);
+    const hits = findSecrets(key);
+    expect(hits).toContain("OpenAI API key");
+  });
+
   it("OpenAI pattern does not false-positive on Anthropic keys (sk-ant-)", () => {
     // sk-ant- keys must be caught by the Anthropic pattern, not reported as OpenAI
     const key = "sk-ant-" + "A".repeat(32);


### PR DESCRIPTION
## Summary

- **GPG-signed commit parser** (`handlers/bash.ts`): `gitLogHandler` full-format parser now skips `Author:`, `Date:`, `Merge:`, and `gpgsig` header/continuation lines before the blank separator, preventing premature `seenBlank` trigger that caused garbage subject lines for signed commits
- **OpenAI secret pattern** (`secrets.ts`): expanded char class from `[A-Za-z0-9]` to `[\w-]` so modern `sk-proj-*` and `sk-svcacct-*` format keys are now detected (existing `sk-ant-` exclusion preserved)
- **`getContext` unbounded NOT IN** (`db/index.ts`): replaced spread-based `NOT IN (?, ?, ...)` with JS-side `Set` filter + bounded over-fetch — eliminates the SQLite 999 bind-param limit risk
- **`session-start` double DB round-trip** (`hooks/session-start.ts`): call `toolContext` once; check return value against exported `CONTEXT_EMPTY_RESPONSE` sentinel instead of calling `getContext` separately
- **`getBundledProfilesDir` error handling** (`profiles/loader.ts`): only catches `ENOENT`; permission and other errors now propagate
- **Stale ID description** (`server.ts`): `"8-char or full item ID"` → `"recall_* item ID"`; forget tool description notes single-ID deletes bypass pin protection
- **Regex cache comment** (`denylist.ts`): notes why unbounded growth is not a real concern

## Test plan

- [ ] `bun test` — 657 pass, 0 fail (+1 new `sk-proj-` test)
- [ ] `bun run typecheck` — clean
- [ ] GPG parser: manually verify with `git log` on a signed-commit repo