### PR TITLE
feat: add HTTP/SSE transport support to mcp-recall learn

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -8925,7 +8925,7 @@ async function listMcpTools(command, args, env, timeoutMs = 1e4) {
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "2024-11-05",
+        protocolVersion: "2025-03-26",
         capabilities: {},
         clientInfo: { name: "mcp-recall-learn", version: "1.0.0" }
       }
@@ -9009,7 +9009,7 @@ async function awaitSseResult(stream, id) {
   throw new Error("SSE stream ended without a matching response");
 }
 var INIT_PARAMS = {
-  protocolVersion: "2024-11-05",
+  protocolVersion: "2025-03-26",
   capabilities: {},
   clientInfo: { name: "mcp-recall-learn", version: "1.0.0" }
 };
@@ -9066,32 +9066,41 @@ async function tryLegacySse(url, timeoutMs) {
     const postUrlResolve = Promise.withResolvers();
     const sseStream = parseSseStream(sseResp.body, abort.signal);
     const readerDone = (async () => {
-      for await (const { event, data } of sseStream) {
-        if (event === "endpoint") {
-          const resolved = new URL(data.trim(), url).href;
-          postUrlResolve.resolve(resolved);
-          postUrl = resolved;
-          continue;
+      try {
+        for await (const { event, data } of sseStream) {
+          if (event === "endpoint") {
+            const resolved = new URL(data.trim(), url).href;
+            assertHttpScheme(resolved, "endpoint URL from SSE event");
+            postUrlResolve.resolve(resolved);
+            postUrl = resolved;
+            continue;
+          }
+          let msg;
+          try {
+            msg = JSON.parse(data);
+          } catch {
+            continue;
+          }
+          if (msg.id === undefined)
+            continue;
+          const p = pending.get(msg.id);
+          if (!p)
+            continue;
+          pending.delete(msg.id);
+          if (msg.error)
+            p.reject(new McpProtocolError(`MCP error: ${msg.error.message}`));
+          else
+            p.resolve(msg.result);
         }
-        let msg;
-        try {
-          msg = JSON.parse(data);
-        } catch {
-          continue;
+        postUrlResolve.reject(new Error("SSE stream closed before endpoint event received"));
+        for (const { reject } of pending.values()) {
+          reject(new Error("SSE stream closed before response received"));
         }
-        if (msg.id === undefined)
-          continue;
-        const p = pending.get(msg.id);
-        if (!p)
-          continue;
-        pending.delete(msg.id);
-        if (msg.error)
-          p.reject(new Error(`MCP error: ${msg.error.message}`));
-        else
-          p.resolve(msg.result);
-      }
-      for (const { reject } of pending.values()) {
-        reject(new Error("SSE stream closed before response received"));
+      } catch (e) {
+        const err = e instanceof Error ? e : new Error(String(e));
+        postUrlResolve.reject(err);
+        for (const { reject } of pending.values())
+          reject(err);
       }
     })();
     postUrl = await postUrlResolve.promise;
@@ -9122,7 +9131,14 @@ async function tryLegacySse(url, timeoutMs) {
     abort.abort();
   }
 }
+function assertHttpScheme(rawUrl, label) {
+  const { protocol } = new URL(rawUrl);
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw new Error(`${label} has unsupported URL scheme: ${protocol}`);
+  }
+}
 async function listMcpToolsHttp(url, timeoutMs = 1e4) {
+  assertHttpScheme(url, "MCP server URL");
   let streamableError = null;
   try {
     const tools = await tryStreamableHttp(url, timeoutMs);
@@ -9303,7 +9319,7 @@ Learning from ${candidates.length} MCP server(s)\u2026
         tools = result.tools;
         if (result.streamableError) {
           process.stdout.write(`
-    streamable HTTP failed (${result.streamableError}), trying legacy SSE\u2026 `);
+    streamable HTTP failed (${result.streamableError}), used legacy SSE \u2014 `);
         }
         console.log(`${tools.length} tool(s) found (${result.transport})`);
       } else {

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -8942,6 +8942,205 @@ async function listMcpTools(command, args, env, timeoutMs = 1e4) {
   }
 }
 
+// src/learn/http-client.ts
+class McpProtocolError extends Error {
+  constructor(msg) {
+    super(msg);
+    this.name = "McpProtocolError";
+  }
+}
+async function* parseSseStream(body, signal) {
+  const reader = body.getReader();
+  const dec = new TextDecoder;
+  let buf = "";
+  try {
+    while (!signal.aborted) {
+      let done, value;
+      try {
+        ({ done, value } = await reader.read());
+      } catch {
+        break;
+      }
+      if (done)
+        break;
+      buf += dec.decode(value, { stream: true });
+      const blocks = buf.split(`
+
+`);
+      buf = blocks.pop() ?? "";
+      for (const block of blocks) {
+        if (!block.trim())
+          continue;
+        let eventType;
+        const dataLines = [];
+        for (const line of block.split(`
+`)) {
+          if (line.startsWith("event: "))
+            eventType = line.slice(7).trim();
+          else if (line.startsWith("data: "))
+            dataLines.push(line.slice(6));
+          else if (line === "data")
+            dataLines.push("");
+        }
+        if (dataLines.length > 0) {
+          yield { event: eventType, data: dataLines.join(`
+`) };
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+async function awaitSseResult(stream, id) {
+  for await (const { data } of stream) {
+    let msg;
+    try {
+      msg = JSON.parse(data);
+    } catch {
+      continue;
+    }
+    if (msg.id !== id)
+      continue;
+    if (msg.error)
+      throw new McpProtocolError(`MCP error: ${msg.error.message}`);
+    return msg.result;
+  }
+  throw new Error("SSE stream ended without a matching response");
+}
+var INIT_PARAMS = {
+  protocolVersion: "2024-11-05",
+  capabilities: {},
+  clientInfo: { name: "mcp-recall-learn", version: "1.0.0" }
+};
+async function streamableRpc(url, body, signal) {
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream"
+    },
+    body: JSON.stringify(body),
+    signal
+  });
+  if (!resp.ok)
+    throw new Error(`HTTP ${resp.status}`);
+  if (body.id === undefined)
+    return;
+  const ct = resp.headers.get("content-type") ?? "";
+  if (ct.includes("application/json")) {
+    const msg = await resp.json();
+    if (msg.error)
+      throw new McpProtocolError(`MCP error: ${msg.error.message}`);
+    return msg.result;
+  }
+  if (ct.includes("text/event-stream")) {
+    const stream = parseSseStream(resp.body, signal);
+    return awaitSseResult(stream, body.id);
+  }
+  throw new Error(`Unexpected Content-Type: ${ct}`);
+}
+async function tryStreamableHttp(url, timeoutMs) {
+  const signal = AbortSignal.timeout(timeoutMs);
+  await streamableRpc(url, { jsonrpc: "2.0", id: 1, method: "initialize", params: INIT_PARAMS }, signal);
+  await streamableRpc(url, { jsonrpc: "2.0", method: "notifications/initialized" }, signal);
+  const result = await streamableRpc(url, { jsonrpc: "2.0", id: 2, method: "tools/list" }, signal);
+  return result?.tools ?? [];
+}
+async function tryLegacySse(url, timeoutMs) {
+  const abort = new AbortController;
+  const timer = setTimeout(() => abort.abort(new Error("timeout")), timeoutMs);
+  try {
+    const sseResp = await fetch(url, {
+      headers: { Accept: "text/event-stream" },
+      signal: abort.signal
+    });
+    if (!sseResp.ok)
+      throw new Error(`HTTP ${sseResp.status}`);
+    const ct = sseResp.headers.get("content-type") ?? "";
+    if (!ct.includes("text/event-stream")) {
+      throw new Error(`Expected SSE stream, got Content-Type: ${ct}`);
+    }
+    const pending = new Map;
+    let postUrl = null;
+    const postUrlResolve = Promise.withResolvers();
+    const sseStream = parseSseStream(sseResp.body, abort.signal);
+    const readerDone = (async () => {
+      for await (const { event, data } of sseStream) {
+        if (event === "endpoint") {
+          const resolved = new URL(data.trim(), url).href;
+          postUrlResolve.resolve(resolved);
+          postUrl = resolved;
+          continue;
+        }
+        let msg;
+        try {
+          msg = JSON.parse(data);
+        } catch {
+          continue;
+        }
+        if (msg.id === undefined)
+          continue;
+        const p = pending.get(msg.id);
+        if (!p)
+          continue;
+        pending.delete(msg.id);
+        if (msg.error)
+          p.reject(new Error(`MCP error: ${msg.error.message}`));
+        else
+          p.resolve(msg.result);
+      }
+      for (const { reject } of pending.values()) {
+        reject(new Error("SSE stream closed before response received"));
+      }
+    })();
+    postUrl = await postUrlResolve.promise;
+    const post = (body) => {
+      const req = fetch(postUrl, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: abort.signal
+      });
+      if (body.id === undefined)
+        return req.then(() => {
+          return;
+        });
+      return new Promise((resolve, reject) => {
+        pending.set(body.id, { resolve, reject });
+        req.catch(reject);
+      });
+    };
+    await post({ jsonrpc: "2.0", id: 1, method: "initialize", params: INIT_PARAMS });
+    await post({ jsonrpc: "2.0", method: "notifications/initialized" });
+    const result = await post({ jsonrpc: "2.0", id: 2, method: "tools/list" });
+    abort.abort();
+    await readerDone.catch(() => {});
+    return result?.tools ?? [];
+  } finally {
+    clearTimeout(timer);
+    abort.abort();
+  }
+}
+async function listMcpToolsHttp(url, timeoutMs = 1e4) {
+  let streamableError = null;
+  try {
+    const tools = await tryStreamableHttp(url, timeoutMs);
+    return { tools, transport: "streamable-http" };
+  } catch (e) {
+    if (e instanceof McpProtocolError)
+      throw e;
+    streamableError = e instanceof Error ? e.message : String(e);
+  }
+  try {
+    const tools = await tryLegacySse(url, timeoutMs);
+    return { tools, transport: "legacy-sse", streamableError: streamableError ?? undefined };
+  } catch (e) {
+    const sseError = e instanceof Error ? e.message : String(e);
+    throw new Error(`streamable HTTP: ${streamableError}; legacy SSE: ${sseError}`);
+  }
+}
+
 // src/learn/generate.ts
 var LIST_VERBS = /^(list|search|find|query|get_all|fetch_all)/i;
 var SINGLE_VERBS = /^(get|fetch|read|describe|show|retrieve)/i;
@@ -9079,14 +9278,14 @@ async function handleLearnCommand(args) {
       return false;
     if (targets.length > 0 && !targets.includes(key))
       return false;
-    if (!cfg.command) {
-      console.log(`  ${key}: skipped (HTTP/SSE server \u2014 only stdio supported)`);
+    if (!cfg.command && !cfg.url) {
+      console.log(`  ${key}: skipped (no command or url in config)`);
       return false;
     }
     return true;
   });
   if (candidates.length === 0) {
-    console.log("No stdio MCP servers found to learn from.");
+    console.log("No MCP servers found to learn from.");
     return;
   }
   console.log(`
@@ -9099,13 +9298,23 @@ Learning from ${candidates.length} MCP server(s)\u2026
     process.stdout.write(`  ${key}: connecting\u2026 `);
     let tools;
     try {
-      tools = await listMcpTools(cfg.command, cfg.args ?? [], cfg.env ?? {}, 1e4);
+      if (cfg.url) {
+        const result = await listMcpToolsHttp(cfg.url, 1e4);
+        tools = result.tools;
+        if (result.streamableError) {
+          process.stdout.write(`
+    streamable HTTP failed (${result.streamableError}), trying legacy SSE\u2026 `);
+        }
+        console.log(`${tools.length} tool(s) found (${result.transport})`);
+      } else {
+        tools = await listMcpTools(cfg.command, cfg.args ?? [], cfg.env ?? {}, 1e4);
+        console.log(`${tools.length} tool(s) found`);
+      }
     } catch (e) {
       console.log(`failed \u2014 ${e instanceof Error ? e.message : String(e)}`);
       skipped++;
       continue;
     }
-    console.log(`${tools.length} tool(s) found`);
     const toml = generateProfile(key, tools);
     if (dryRun) {
       console.log(`

--- a/src/learn/client.ts
+++ b/src/learn/client.ts
@@ -114,7 +114,7 @@ export async function listMcpTools(
       id: 1,
       method: "initialize",
       params: {
-        protocolVersion: "2024-11-05",
+        protocolVersion: "2025-03-26",
         capabilities: {},
         clientInfo: { name: "mcp-recall-learn", version: "1.0.0" },
       },

--- a/src/learn/http-client.ts
+++ b/src/learn/http-client.ts
@@ -1,0 +1,304 @@
+/**
+ * HTTP MCP client — supports both current Streamable HTTP and legacy HTTP+SSE
+ * transports. Used by `mcp-recall learn` to introspect remote MCP servers.
+ *
+ * Transport selection:
+ *   1. Try Streamable HTTP (POST JSON-RPC, JSON or SSE response) — current spec.
+ *   2. On failure, fall back to legacy HTTP+SSE (GET SSE stream, POST to
+ *      dynamically provided endpoint URL) — deprecated but still common.
+ */
+
+import type { McpTool } from "./client";
+
+/**
+ * Thrown when the MCP server returns a JSON-RPC error (protocol-level failure).
+ * These are not transport errors and must not trigger the legacy-SSE fallback.
+ */
+class McpProtocolError extends Error {
+  constructor(msg: string) {
+    super(msg);
+    this.name = "McpProtocolError";
+  }
+}
+
+export type HttpTransport = "streamable-http" | "legacy-sse";
+
+export interface HttpListResult {
+  tools: McpTool[];
+  transport: HttpTransport;
+  /** Set when streamable HTTP failed and legacy SSE was used instead. */
+  streamableError?: string;
+}
+
+interface JsonRpcMsg {
+  jsonrpc: string;
+  id?: number;
+  result?: unknown;
+  error?: { code: number; message: string };
+  method?: string;
+  params?: unknown;
+}
+
+// ── SSE stream parser ─────────────────────────────────────────────────────────
+
+interface SseEvent {
+  event?: string;
+  data: string;
+}
+
+/** Yields complete SSE events from a ReadableStream. */
+async function* parseSseStream(
+  body: ReadableStream<Uint8Array>,
+  signal: AbortSignal
+): AsyncGenerator<SseEvent> {
+  const reader = body.getReader();
+  const dec = new TextDecoder();
+  let buf = "";
+
+  try {
+    while (!signal.aborted) {
+      let done: boolean, value: Uint8Array | undefined;
+      try {
+        ({ done, value } = await reader.read());
+      } catch {
+        break; // stream cancelled (e.g. AbortSignal fired)
+      }
+      if (done) break;
+      buf += dec.decode(value, { stream: true });
+
+      // Events are separated by blank lines
+      const blocks = buf.split("\n\n");
+      buf = blocks.pop() ?? "";
+
+      for (const block of blocks) {
+        if (!block.trim()) continue;
+        let eventType: string | undefined;
+        const dataLines: string[] = [];
+
+        for (const line of block.split("\n")) {
+          if (line.startsWith("event: ")) eventType = line.slice(7).trim();
+          else if (line.startsWith("data: ")) dataLines.push(line.slice(6));
+          else if (line === "data") dataLines.push("");
+        }
+
+        if (dataLines.length > 0) {
+          yield { event: eventType, data: dataLines.join("\n") };
+        }
+      }
+    }
+  } finally {
+    reader.releaseLock();
+  }
+}
+
+/** Reads an SSE stream looking for a JSON-RPC response matching `id`. */
+async function awaitSseResult(
+  stream: AsyncGenerator<SseEvent>,
+  id: number
+): Promise<unknown> {
+  for await (const { data } of stream) {
+    let msg: JsonRpcMsg;
+    try {
+      msg = JSON.parse(data) as JsonRpcMsg;
+    } catch {
+      continue;
+    }
+    if (msg.id !== id) continue;
+    if (msg.error) throw new McpProtocolError(`MCP error: ${msg.error.message}`);
+    return msg.result;
+  }
+  throw new Error("SSE stream ended without a matching response");
+}
+
+// ── Streamable HTTP transport ─────────────────────────────────────────────────
+
+const INIT_PARAMS = {
+  protocolVersion: "2024-11-05",
+  capabilities: {},
+  clientInfo: { name: "mcp-recall-learn", version: "1.0.0" },
+};
+
+/**
+ * Posts a single JSON-RPC request and returns the result.
+ * Response may be plain JSON or an SSE stream (both are valid per spec).
+ * Notifications (no `id`) are fire-and-forget.
+ */
+async function streamableRpc(
+  url: string,
+  body: JsonRpcMsg,
+  signal: AbortSignal
+): Promise<unknown> {
+  const resp = await fetch(url, {
+    method: "POST",
+    headers: {
+      "Content-Type": "application/json",
+      Accept: "application/json, text/event-stream",
+    },
+    body: JSON.stringify(body),
+    signal,
+  });
+
+  if (!resp.ok) throw new Error(`HTTP ${resp.status}`);
+  if (body.id === undefined) return; // notification — no result expected
+
+  const ct = resp.headers.get("content-type") ?? "";
+
+  if (ct.includes("application/json")) {
+    const msg = (await resp.json()) as JsonRpcMsg;
+    if (msg.error) throw new McpProtocolError(`MCP error: ${msg.error.message}`);
+    return msg.result;
+  }
+
+  if (ct.includes("text/event-stream")) {
+    const stream = parseSseStream(resp.body!, signal);
+    return awaitSseResult(stream, body.id);
+  }
+
+  throw new Error(`Unexpected Content-Type: ${ct}`);
+}
+
+async function tryStreamableHttp(url: string, timeoutMs: number): Promise<McpTool[]> {
+  const signal = AbortSignal.timeout(timeoutMs);
+
+  await streamableRpc(
+    url,
+    { jsonrpc: "2.0", id: 1, method: "initialize", params: INIT_PARAMS },
+    signal
+  );
+  await streamableRpc(
+    url,
+    { jsonrpc: "2.0", method: "notifications/initialized" },
+    signal
+  );
+  const result = (await streamableRpc(
+    url,
+    { jsonrpc: "2.0", id: 2, method: "tools/list" },
+    signal
+  )) as { tools?: McpTool[] };
+
+  return result?.tools ?? [];
+}
+
+// ── Legacy HTTP+SSE transport ─────────────────────────────────────────────────
+
+async function tryLegacySse(url: string, timeoutMs: number): Promise<McpTool[]> {
+  const abort = new AbortController();
+  const timer = setTimeout(() => abort.abort(new Error("timeout")), timeoutMs);
+
+  try {
+    const sseResp = await fetch(url, {
+      headers: { Accept: "text/event-stream" },
+      signal: abort.signal,
+    });
+    if (!sseResp.ok) throw new Error(`HTTP ${sseResp.status}`);
+
+    const ct = sseResp.headers.get("content-type") ?? "";
+    if (!ct.includes("text/event-stream")) {
+      throw new Error(`Expected SSE stream, got Content-Type: ${ct}`);
+    }
+
+    // Responses arrive on the SSE stream; requests are POSTed to postUrl.
+    // We buffer pending promises keyed by request id.
+    const pending = new Map<
+      number,
+      { resolve: (v: unknown) => void; reject: (e: Error) => void }
+    >();
+    let postUrl: string | null = null;
+    const postUrlResolve = Promise.withResolvers<string>();
+
+    // Background reader — wires SSE events to pending promises
+    const sseStream = parseSseStream(sseResp.body!, abort.signal);
+    const readerDone = (async () => {
+      for await (const { event, data } of sseStream) {
+        if (event === "endpoint") {
+          // Resolve relative paths against the base URL
+          const resolved = new URL(data.trim(), url).href;
+          postUrlResolve.resolve(resolved);
+          postUrl = resolved;
+          continue;
+        }
+        // Default event = JSON-RPC message
+        let msg: JsonRpcMsg;
+        try {
+          msg = JSON.parse(data) as JsonRpcMsg;
+        } catch {
+          continue;
+        }
+        if (msg.id === undefined) continue;
+        const p = pending.get(msg.id);
+        if (!p) continue;
+        pending.delete(msg.id);
+        if (msg.error) p.reject(new Error(`MCP error: ${msg.error.message}`));
+        else p.resolve(msg.result);
+      }
+      // Stream closed — reject any still-pending requests
+      for (const { reject } of pending.values()) {
+        reject(new Error("SSE stream closed before response received"));
+      }
+    })();
+
+    postUrl = await postUrlResolve.promise;
+
+    const post = (body: JsonRpcMsg): Promise<unknown> => {
+      const req = fetch(postUrl!, {
+        method: "POST",
+        headers: { "Content-Type": "application/json" },
+        body: JSON.stringify(body),
+        signal: abort.signal,
+      });
+
+      if (body.id === undefined) return req.then(() => undefined);
+
+      return new Promise((resolve, reject) => {
+        pending.set(body.id!, { resolve, reject });
+        req.catch(reject);
+      });
+    };
+
+    await post({ jsonrpc: "2.0", id: 1, method: "initialize", params: INIT_PARAMS });
+    await post({ jsonrpc: "2.0", method: "notifications/initialized" });
+    const result = (await post({ jsonrpc: "2.0", id: 2, method: "tools/list" })) as {
+      tools?: McpTool[];
+    };
+
+    abort.abort();
+    await readerDone.catch(() => {}); // ignore — we triggered the abort intentionally
+
+    return result?.tools ?? [];
+  } finally {
+    clearTimeout(timer);
+    abort.abort();
+  }
+}
+
+// ── Public API ────────────────────────────────────────────────────────────────
+
+/**
+ * Lists tools from an HTTP MCP server.
+ *
+ * Tries Streamable HTTP first. If that fails, falls back to legacy HTTP+SSE.
+ * Returns both the tool list and the transport that succeeded so callers can
+ * report it. Throws with both failure reasons if neither transport works.
+ */
+export async function listMcpToolsHttp(
+  url: string,
+  timeoutMs = 10_000
+): Promise<HttpListResult> {
+  let streamableError: string | null = null;
+
+  try {
+    const tools = await tryStreamableHttp(url, timeoutMs);
+    return { tools, transport: "streamable-http" };
+  } catch (e) {
+    if (e instanceof McpProtocolError) throw e; // protocol error, not a transport problem
+    streamableError = e instanceof Error ? e.message : String(e);
+  }
+
+  try {
+    const tools = await tryLegacySse(url, timeoutMs);
+    return { tools, transport: "legacy-sse", streamableError: streamableError ?? undefined };
+  } catch (e) {
+    const sseError = e instanceof Error ? e.message : String(e);
+    throw new Error(`streamable HTTP: ${streamableError}; legacy SSE: ${sseError}`);
+  }
+}

--- a/src/learn/http-client.ts
+++ b/src/learn/http-client.ts
@@ -113,7 +113,7 @@ async function awaitSseResult(
 // ── Streamable HTTP transport ─────────────────────────────────────────────────
 
 const INIT_PARAMS = {
-  protocolVersion: "2024-11-05",
+  protocolVersion: "2025-03-26",
   capabilities: {},
   clientInfo: { name: "mcp-recall-learn", version: "1.0.0" },
 };
@@ -209,31 +209,39 @@ async function tryLegacySse(url: string, timeoutMs: number): Promise<McpTool[]> 
     // Background reader — wires SSE events to pending promises
     const sseStream = parseSseStream(sseResp.body!, abort.signal);
     const readerDone = (async () => {
-      for await (const { event, data } of sseStream) {
-        if (event === "endpoint") {
-          // Resolve relative paths against the base URL
-          const resolved = new URL(data.trim(), url).href;
-          postUrlResolve.resolve(resolved);
-          postUrl = resolved;
-          continue;
+      try {
+        for await (const { event, data } of sseStream) {
+          if (event === "endpoint") {
+            const resolved = new URL(data.trim(), url).href;
+            assertHttpScheme(resolved, "endpoint URL from SSE event");
+            postUrlResolve.resolve(resolved);
+            postUrl = resolved;
+            continue;
+          }
+          // Default event = JSON-RPC message
+          let msg: JsonRpcMsg;
+          try {
+            msg = JSON.parse(data) as JsonRpcMsg;
+          } catch {
+            continue;
+          }
+          if (msg.id === undefined) continue;
+          const p = pending.get(msg.id);
+          if (!p) continue;
+          pending.delete(msg.id);
+          if (msg.error) p.reject(new McpProtocolError(`MCP error: ${msg.error.message}`));
+          else p.resolve(msg.result);
         }
-        // Default event = JSON-RPC message
-        let msg: JsonRpcMsg;
-        try {
-          msg = JSON.parse(data) as JsonRpcMsg;
-        } catch {
-          continue;
+        // Stream closed without an endpoint event — unblock the await below
+        postUrlResolve.reject(new Error("SSE stream closed before endpoint event received"));
+        for (const { reject } of pending.values()) {
+          reject(new Error("SSE stream closed before response received"));
         }
-        if (msg.id === undefined) continue;
-        const p = pending.get(msg.id);
-        if (!p) continue;
-        pending.delete(msg.id);
-        if (msg.error) p.reject(new Error(`MCP error: ${msg.error.message}`));
-        else p.resolve(msg.result);
-      }
-      // Stream closed — reject any still-pending requests
-      for (const { reject } of pending.values()) {
-        reject(new Error("SSE stream closed before response received"));
+      } catch (e) {
+        // Forward unexpected errors (e.g. scheme violations) to any awaiting callers
+        const err = e instanceof Error ? e : new Error(String(e));
+        postUrlResolve.reject(err);
+        for (const { reject } of pending.values()) reject(err);
       }
     })();
 
@@ -280,10 +288,18 @@ async function tryLegacySse(url: string, timeoutMs: number): Promise<McpTool[]> 
  * Returns both the tool list and the transport that succeeded so callers can
  * report it. Throws with both failure reasons if neither transport works.
  */
+function assertHttpScheme(rawUrl: string, label: string): void {
+  const { protocol } = new URL(rawUrl);
+  if (protocol !== "http:" && protocol !== "https:") {
+    throw new Error(`${label} has unsupported URL scheme: ${protocol}`);
+  }
+}
+
 export async function listMcpToolsHttp(
   url: string,
   timeoutMs = 10_000
 ): Promise<HttpListResult> {
+  assertHttpScheme(url, "MCP server URL");
   let streamableError: string | null = null;
 
   try {

--- a/src/learn/index.ts
+++ b/src/learn/index.ts
@@ -12,6 +12,7 @@ import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { listMcpTools } from "./client";
+import type { McpTool } from "./client";
 import { listMcpToolsHttp } from "./http-client";
 import { generateProfile } from "./generate";
 import { clearProfileCache } from "../profiles/loader";
@@ -72,13 +73,13 @@ export async function handleLearnCommand(args: string[]): Promise<void> {
 
   for (const [key, cfg] of candidates) {
     process.stdout.write(`  ${key}: connecting… `);
-    let tools;
+    let tools: McpTool[];
     try {
       if (cfg.url) {
         const result = await listMcpToolsHttp(cfg.url, 10_000);
         tools = result.tools;
         if (result.streamableError) {
-          process.stdout.write(`\n    streamable HTTP failed (${result.streamableError}), trying legacy SSE… `);
+          process.stdout.write(`\n    streamable HTTP failed (${result.streamableError}), used legacy SSE — `);
         }
         console.log(`${tools.length} tool(s) found (${result.transport})`);
       } else {

--- a/src/learn/index.ts
+++ b/src/learn/index.ts
@@ -12,6 +12,7 @@ import { readFileSync, writeFileSync, mkdirSync } from "fs";
 import { join } from "path";
 import { homedir } from "os";
 import { listMcpTools } from "./client";
+import { listMcpToolsHttp } from "./http-client";
 import { generateProfile } from "./generate";
 import { clearProfileCache } from "../profiles/loader";
 
@@ -47,19 +48,19 @@ export async function handleLearnCommand(args: string[]): Promise<void> {
     process.exit(1);
   }
 
-  // Filter out recall itself and any HTTP servers
+  // Filter out recall itself and servers with neither command nor url
   const candidates = Object.entries(servers).filter(([key, cfg]) => {
     if (key === "recall") return false;
     if (targets.length > 0 && !targets.includes(key)) return false;
-    if (!cfg.command) {
-      console.log(`  ${key}: skipped (HTTP/SSE server — only stdio supported)`);
+    if (!cfg.command && !cfg.url) {
+      console.log(`  ${key}: skipped (no command or url in config)`);
       return false;
     }
     return true;
   });
 
   if (candidates.length === 0) {
-    console.log("No stdio MCP servers found to learn from.");
+    console.log("No MCP servers found to learn from.");
     return;
   }
 
@@ -73,19 +74,22 @@ export async function handleLearnCommand(args: string[]): Promise<void> {
     process.stdout.write(`  ${key}: connecting… `);
     let tools;
     try {
-      tools = await listMcpTools(
-        cfg.command!,
-        cfg.args ?? [],
-        cfg.env ?? {},
-        10_000
-      );
+      if (cfg.url) {
+        const result = await listMcpToolsHttp(cfg.url, 10_000);
+        tools = result.tools;
+        if (result.streamableError) {
+          process.stdout.write(`\n    streamable HTTP failed (${result.streamableError}), trying legacy SSE… `);
+        }
+        console.log(`${tools.length} tool(s) found (${result.transport})`);
+      } else {
+        tools = await listMcpTools(cfg.command!, cfg.args ?? [], cfg.env ?? {}, 10_000);
+        console.log(`${tools.length} tool(s) found`);
+      }
     } catch (e) {
       console.log(`failed — ${e instanceof Error ? e.message : String(e)}`);
       skipped++;
       continue;
     }
-
-    console.log(`${tools.length} tool(s) found`);
 
     const toml = generateProfile(key, tools);
 

--- a/tests/learn-http-client.test.ts
+++ b/tests/learn-http-client.test.ts
@@ -1,0 +1,252 @@
+import { describe, test, expect, afterEach } from "bun:test";
+// eslint-disable-next-line @typescript-eslint/no-explicit-any
+type Server = any;
+import { listMcpToolsHttp } from "../src/learn/http-client";
+
+// ── helpers ───────────────────────────────────────────────────────────────────
+
+const MOCK_TOOLS = [
+  { name: "list_issues", description: "List issues" },
+  { name: "get_issue", description: "Get an issue" },
+];
+
+const INIT_RESULT = {
+  protocolVersion: "2024-11-05",
+  capabilities: {},
+  serverInfo: { name: "test-server", version: "1.0.0" },
+};
+
+function jsonRpc(id: number, result: unknown) {
+  return JSON.stringify({ jsonrpc: "2.0", id, result });
+}
+
+function sseChunk(data: string, event?: string): string {
+  return (event ? `event: ${event}\ndata: ${data}\n\n` : `data: ${data}\n\n`);
+}
+
+const servers: Server[] = [];
+
+function stopAll() {
+  for (const s of servers) s.stop(true);
+  servers.length = 0;
+}
+
+// ── Streamable HTTP (JSON response) ──────────────────────────────────────────
+
+describe("listMcpToolsHttp — streamable HTTP (JSON)", () => {
+  afterEach(stopAll);
+
+  test("returns tools and transport label", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (req.method !== "POST") return new Response(null, { status: 405 });
+        return req.json().then((body: { id?: number }) => {
+          if (body.id === 1) return new Response(jsonRpc(1, INIT_RESULT), { headers: { "Content-Type": "application/json" } });
+          if (body.id === 2) return new Response(jsonRpc(2, { tools: MOCK_TOOLS }), { headers: { "Content-Type": "application/json" } });
+          return new Response(null, { status: 204 }); // notification
+        });
+      },
+    });
+    servers.push(s);
+
+    const result = await listMcpToolsHttp(s.url.href, 5_000);
+    expect(result.transport).toBe("streamable-http");
+    expect(result.tools).toEqual(MOCK_TOOLS);
+    expect(result.streamableError).toBeUndefined();
+  });
+
+  test("returns empty tools list when server returns none", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return req.json().then((body: { id?: number }) => {
+          if (body.id === 1) return new Response(jsonRpc(1, INIT_RESULT), { headers: { "Content-Type": "application/json" } });
+          if (body.id === 2) return new Response(jsonRpc(2, { tools: [] }), { headers: { "Content-Type": "application/json" } });
+          return new Response(null, { status: 204 });
+        });
+      },
+    });
+    servers.push(s);
+
+    const result = await listMcpToolsHttp(s.url.href, 5_000);
+    expect(result.tools).toEqual([]);
+  });
+
+  test("returns empty list when server omits tools key", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return req.json().then((body: { id?: number }) => {
+          if (body.id === 1) return new Response(jsonRpc(1, INIT_RESULT), { headers: { "Content-Type": "application/json" } });
+          if (body.id === 2) return new Response(jsonRpc(2, {}), { headers: { "Content-Type": "application/json" } });
+          return new Response(null, { status: 204 });
+        });
+      },
+    });
+    servers.push(s);
+
+    const result = await listMcpToolsHttp(s.url.href, 5_000);
+    expect(result.tools).toEqual([]);
+  });
+
+  test("surfaces MCP error from server", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return req.json().then((body: { id?: number }) => {
+          const err = JSON.stringify({ jsonrpc: "2.0", id: body.id, error: { code: -32601, message: "not supported" } });
+          return new Response(err, { headers: { "Content-Type": "application/json" } });
+        });
+      },
+    });
+    servers.push(s);
+
+    await expect(listMcpToolsHttp(s.url.href, 5_000)).rejects.toThrow("MCP error: not supported");
+  });
+});
+
+// ── Streamable HTTP (SSE response) ────────────────────────────────────────────
+
+describe("listMcpToolsHttp — streamable HTTP (SSE response)", () => {
+  afterEach(stopAll);
+
+  test("parses tools from SSE-streamed response", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        return req.json().then((body: { id?: number }) => {
+          if (!body.id) return new Response(null, { status: 204 });
+          const payload = body.id === 1
+            ? jsonRpc(1, INIT_RESULT)
+            : jsonRpc(2, { tools: MOCK_TOOLS });
+
+          const stream = new ReadableStream({
+            start(controller) {
+              controller.enqueue(new TextEncoder().encode(sseChunk(payload, "message")));
+              controller.close();
+            },
+          });
+          return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+        });
+      },
+    });
+    servers.push(s);
+
+    const result = await listMcpToolsHttp(s.url.href, 5_000);
+    expect(result.transport).toBe("streamable-http");
+    expect(result.tools).toEqual(MOCK_TOOLS);
+  });
+});
+
+// ── Legacy HTTP+SSE transport ─────────────────────────────────────────────────
+
+describe("listMcpToolsHttp — legacy SSE", () => {
+  afterEach(stopAll);
+
+  /**
+   * Builds a minimal legacy SSE MCP server:
+   *   GET /sse  → SSE stream; first event is `endpoint` pointing at /messages
+   *   POST /messages  → accepts JSON-RPC, pushes response back on SSE stream
+   */
+  function makeLegacySseServer() {
+    // Channel to send JSON-RPC responses back to the SSE stream
+    const responseQueue: string[] = [];
+    let sseController: ReadableStreamDefaultController<Uint8Array> | null = null;
+
+    function pushResponse(payload: string) {
+      const chunk = new TextEncoder().encode(sseChunk(payload, "message"));
+      if (sseController) {
+        sseController.enqueue(chunk);
+      } else {
+        responseQueue.push(payload);
+      }
+    }
+
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        const url = new URL(req.url);
+
+        if (req.method === "GET" && url.pathname === "/sse") {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              sseController = ctrl;
+              // Send endpoint event
+              const postUrl = `/messages`;
+              ctrl.enqueue(new TextEncoder().encode(sseChunk(postUrl, "endpoint")));
+              // Flush any responses that arrived before the stream opened
+              for (const p of responseQueue) {
+                ctrl.enqueue(new TextEncoder().encode(sseChunk(p, "message")));
+              }
+              responseQueue.length = 0;
+            },
+          });
+          return new Response(stream, {
+            headers: { "Content-Type": "text/event-stream", "Cache-Control": "no-cache" },
+          });
+        }
+
+        if (req.method === "POST" && url.pathname === "/messages") {
+          return req.json().then((body: { id?: number }) => {
+            if (body.id === 1) pushResponse(jsonRpc(1, INIT_RESULT));
+            else if (body.id === 2) pushResponse(jsonRpc(2, { tools: MOCK_TOOLS }));
+            return new Response(null, { status: 202 });
+          });
+        }
+
+        return new Response(null, { status: 404 });
+      },
+    });
+
+    servers.push(s);
+    return s;
+  }
+
+  test("returns tools via legacy SSE when streamable HTTP returns 404", async () => {
+    const s = makeLegacySseServer();
+    const sseUrl = new URL("/sse", s.url).href;
+
+    // This server only handles GET /sse and POST /messages; POSTing to /sse
+    // returns 404, which triggers the legacy-SSE fallback in listMcpToolsHttp.
+    const result = await listMcpToolsHttp(sseUrl, 5_000);
+    expect(result.transport).toBe("legacy-sse");
+    expect(result.tools).toEqual(MOCK_TOOLS);
+  });
+
+  test("streamableError is populated when legacy SSE is used", async () => {
+    const s = makeLegacySseServer();
+    const sseUrl = new URL("/sse", s.url).href;
+
+    const result = await listMcpToolsHttp(sseUrl, 5_000);
+    expect(result.streamableError).toBeDefined();
+    expect(typeof result.streamableError).toBe("string");
+  });
+});
+
+// ── Error cases ───────────────────────────────────────────────────────────────
+
+describe("listMcpToolsHttp — error cases", () => {
+  afterEach(stopAll);
+
+  test("throws with both failure reasons when neither transport works", async () => {
+    const s = Bun.serve({
+      port: 0,
+      fetch() {
+        return new Response(null, { status: 500 });
+      },
+    });
+    servers.push(s);
+
+    await expect(listMcpToolsHttp(s.url.href, 2_000)).rejects.toThrow(
+      /streamable HTTP:.*legacy SSE:/
+    );
+  });
+
+  test("throws when URL is unreachable", async () => {
+    // Port 1 is almost always refused
+    await expect(listMcpToolsHttp("http://127.0.0.1:1/mcp", 2_000)).rejects.toThrow(
+      /streamable HTTP:.*legacy SSE:/
+    );
+  });
+});

--- a/tests/learn-http-client.test.ts
+++ b/tests/learn-http-client.test.ts
@@ -249,4 +249,56 @@ describe("listMcpToolsHttp — error cases", () => {
       /streamable HTTP:.*legacy SSE:/
     );
   });
+
+  test("throws immediately on non-http/https scheme (S1)", async () => {
+    await expect(listMcpToolsHttp("file:///etc/passwd", 5_000)).rejects.toThrow(
+      /unsupported URL scheme/
+    );
+  });
+
+  test("throws when SSE endpoint event contains non-http URL (S2)", async () => {
+    // Server that accepts GET /sse and sends a file:// endpoint event
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (req.method === "GET") {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) {
+              ctrl.enqueue(new TextEncoder().encode(sseChunk("file:///etc/passwd", "endpoint")));
+            },
+          });
+          return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+        }
+        return new Response(null, { status: 404 });
+      },
+    });
+    servers.push(s);
+
+    const sseUrl = s.url.href;
+    await expect(listMcpToolsHttp(sseUrl, 5_000)).rejects.toThrow(
+      /unsupported URL scheme/
+    );
+  });
+
+  test("throws when SSE stream closes without sending endpoint event (Q3)", async () => {
+    // Server that accepts GET /sse but closes the stream immediately
+    const s = Bun.serve({
+      port: 0,
+      fetch(req) {
+        if (req.method === "GET") {
+          const stream = new ReadableStream<Uint8Array>({
+            start(ctrl) { ctrl.close(); },
+          });
+          return new Response(stream, { headers: { "Content-Type": "text/event-stream" } });
+        }
+        return new Response(null, { status: 404 });
+      },
+    });
+    servers.push(s);
+
+    const sseUrl = s.url.href;
+    await expect(listMcpToolsHttp(sseUrl, 5_000)).rejects.toThrow(
+      /endpoint event/
+    );
+  });
 });


### PR DESCRIPTION
## Summary

- Adds `src/learn/http-client.ts` with two transport implementations: Streamable HTTP (current MCP spec) and legacy HTTP+SSE (deprecated but still common)
- `mcp-recall learn` now handles servers with a `url` field in `~/.claude.json`, not just `command`-based stdio servers
- Failure output is transparent: shows the intermediate streamable HTTP error before falling back, and both errors if neither transport works

## Test plan

- [x] `bun test tests/learn-http-client.test.ts` — 9 tests covering streamable HTTP (JSON response), streamable HTTP (SSE response), legacy SSE, error cases, and fallback behavior
- [x] `bun test` — full suite, 673 pass 0 fail
- [x] `bun run typecheck` — clean