### PR TITLE
refactor: replace magic numbers and weak error types

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5522,6 +5522,8 @@ function formatRelativeTime(ms) {
 
 // src/tools.ts
 var CONTEXT_EMPTY_RESPONSE = "[recall: no context available yet \u2014 use recall tools to build up your context store]";
+var CONTEXT_EXCERPT_LEN = 100;
+var LIST_TOOL_COL_WIDTH = 40;
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -5546,9 +5548,9 @@ function toolContext(db, projectKey, args) {
   if (data.pinned.length > 0) {
     lines.push("", `Pinned (${data.pinned.length}):`);
     for (const item of data.pinned) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  \uD83D\uDCCC ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  \uD83D\uDCCC ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -5565,9 +5567,9 @@ function toolContext(db, projectKey, args) {
     const days = args.days ?? 7;
     lines.push("", `Recently accessed (last ${days} day${days === 1 ? "" : "s"}, ${data.recent.length} item${data.recent.length === 1 ? "" : "s"}):`);
     for (const item of data.recent) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -5575,9 +5577,9 @@ function toolContext(db, projectKey, args) {
     const date = data.last_session?.date ?? "";
     lines.push("", `Hot from last session (${date}, ${data.hot.length} item${data.hot.length === 1 ? "" : "s"}):`);
     for (const item of data.hot) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -9524,6 +9526,9 @@ import { existsSync as existsSync2 } from "fs";
 import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
+function isEnoent(e) {
+  return typeof e === "object" && e !== null && e.code === "ENOENT";
+}
 var BOLD = "\x1B[1m";
 var GREEN = "\x1B[32m";
 var YELLOW = "\x1B[33m";
@@ -9596,7 +9601,7 @@ async function injectClaudeMd(filePath, dryRun = false) {
   try {
     existing = await readFile(filePath, "utf8");
   } catch (e) {
-    if (e.code !== "ENOENT")
+    if (!isEnoent(e))
       throw e;
   }
   const startIdx = existing.indexOf(CLAUDE_MD_MARKER_START);
@@ -9626,7 +9631,7 @@ async function removeClaudeMd(filePath) {
   try {
     existing = await readFile(filePath, "utf8");
   } catch (e) {
-    if (e.code === "ENOENT")
+    if (isEnoent(e))
       return false;
     throw e;
   }

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -21061,6 +21061,12 @@ function formatRelativeTime(ms) {
 
 // src/tools.ts
 var CONTEXT_EMPTY_RESPONSE = "[recall: no context available yet \u2014 use recall tools to build up your context store]";
+var SEARCH_EXCERPT_LEN = 120;
+var NOTE_EXCERPT_LEN = 200;
+var CONTEXT_EXCERPT_LEN = 100;
+var SNIPPET_MAX = 150;
+var LIST_TOOL_COL_WIDTH = 40;
+var LIST_ID_COL_WIDTH = 16;
 function formatDate(unixSecs) {
   return new Date(unixSecs * 1000).toISOString().slice(0, 10);
 }
@@ -21107,10 +21113,9 @@ function toolSearch(db, projectKey, args) {
   if (items.length === 0) {
     return `[recall: no results for "${args.query}"]`;
   }
-  const SNIPPET_MAX = 150;
   const lines = items.map((item, i) => {
-    const excerpt = item.summary.slice(0, 120).replace(/\n/g, " ");
-    const ellipsis = item.summary.length > 120 ? "\u2026" : "";
+    const excerpt = item.summary.slice(0, SEARCH_EXCERPT_LEN).replace(/\n/g, " ");
+    const ellipsis = item.summary.length > SEARCH_EXCERPT_LEN ? "\u2026" : "";
     const summaryLine = `${i + 1}. ${item.id} \xB7 ${item.tool_name} \xB7 ${formatDate(item.created_at)}
    ${excerpt}${ellipsis}`;
     const snippet = retrieveSnippet(db, item.id, args.query);
@@ -21138,8 +21143,8 @@ function toolPin(db, projectKey, args) {
 }
 function toolNote(db, projectKey, args) {
   const title = args.title ?? "(note)";
-  const excerpt = args.text.slice(0, 200);
-  const ellipsis = args.text.length > 200 ? "\u2026" : "";
+  const excerpt = args.text.slice(0, NOTE_EXCERPT_LEN);
+  const ellipsis = args.text.length > NOTE_EXCERPT_LEN ? "\u2026" : "";
   const summary = `${title}: ${excerpt}${ellipsis}`;
   const originalSize = Buffer.byteLength(args.text, "utf8");
   const sessionId = new Date().toISOString().slice(0, 10);
@@ -21203,9 +21208,9 @@ function toolListStored(db, projectKey, args) {
   const rows = items.map((item) => {
     const reduction = reductionPct(item.original_size, item.summary_size);
     const pin = item.pinned ? " \uD83D\uDCCC" : "";
-    return `${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}\u2192${formatBytes(item.summary_size).padEnd(8)}  ${reduction}${pin}`;
+    return `${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}\u2192${formatBytes(item.summary_size).padEnd(8)}  ${reduction}${pin}`;
   });
-  const header = `${"ID".padEnd(16)}  ${"Tool".padEnd(40)}  ${"Date".padEnd(10)}  ${"Size".padStart(7)} ${"\u2192".padEnd(9)}  Red.`;
+  const header = `${"ID".padEnd(LIST_ID_COL_WIDTH)}  ${"Tool".padEnd(LIST_TOOL_COL_WIDTH)}  ${"Date".padEnd(10)}  ${"Size".padStart(7)} ${"\u2192".padEnd(9)}  Red.`;
   const separator = "-".repeat(header.length);
   return [header, separator, ...rows].join(`
 `);
@@ -21226,9 +21231,9 @@ function toolContext(db, projectKey, args) {
   if (data.pinned.length > 0) {
     lines.push("", `Pinned (${data.pinned.length}):`);
     for (const item of data.pinned) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  \uD83D\uDCCC ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  \uD83D\uDCCC ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -21245,9 +21250,9 @@ function toolContext(db, projectKey, args) {
     const days = args.days ?? 7;
     lines.push("", `Recently accessed (last ${days} day${days === 1 ? "" : "s"}, ${data.recent.length} item${data.recent.length === 1 ? "" : "s"}):`);
     for (const item of data.recent) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -21255,9 +21260,9 @@ function toolContext(db, projectKey, args) {
     const date4 = data.last_session?.date ?? "";
     lines.push("", `Hot from last session (${date4}, ${data.hot.length} item${data.hot.length === 1 ? "" : "s"}):`);
     for (const item of data.hot) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  \xD7${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -21294,8 +21299,8 @@ function toolSessionSummary(db, projectKey, args) {
   if (data.top_accessed.length > 0) {
     lines.push("", "Most accessed:");
     for (const item of data.top_accessed) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
       lines.push(`  ${item.id} (\xD7${item.access_count}) ${item.tool_name}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
@@ -21303,8 +21308,8 @@ function toolSessionSummary(db, projectKey, args) {
   if (data.pinned.length > 0) {
     lines.push("", `Pinned: ${data.pinned.length}`);
     for (const item of data.pinned) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "\u2026" : "";
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "\u2026" : "";
       lines.push(`  \uD83D\uDCCC ${item.id}  ${item.tool_name}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
@@ -21357,7 +21362,7 @@ function toolStats(db, projectKey, args = {}) {
     if (suggestions.pin_candidates.length > 0) {
       lines.push("  \uD83D\uDCCC Consider pinning:");
       for (const item of suggestions.pin_candidates) {
-        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  accessed ${item.access_count}\xD7`);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  accessed ${item.access_count}\xD7`);
       }
     }
     if (suggestions.stale_candidates.length > 0) {
@@ -21367,7 +21372,7 @@ function toolStats(db, projectKey, args = {}) {
       const now = Math.floor(Date.now() / 1000);
       for (const item of suggestions.stale_candidates) {
         const ageDays = Math.floor((now - item.created_at) / 86400);
-        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
       }
     }
   }

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -15,6 +15,12 @@ import path from "path";
 import os from "os";
 import { loadProfiles } from "../profiles/loader";
 
+// ── Utilities ────────────────────────────────────────────────────────────────
+
+function isEnoent(e: unknown): boolean {
+  return typeof e === "object" && e !== null && (e as NodeJS.ErrnoException).code === "ENOENT";
+}
+
 // ── ANSI ─────────────────────────────────────────────────────────────────────
 
 const BOLD  = "\x1b[1m";
@@ -118,8 +124,8 @@ export async function injectClaudeMd(
   let existing = "";
   try {
     existing = await readFile(filePath, "utf8");
-  } catch (e: any) {
-    if (e.code !== "ENOENT") throw e;
+  } catch (e: unknown) {
+    if (!isEnoent(e)) throw e;
   }
 
   const startIdx = existing.indexOf(CLAUDE_MD_MARKER_START);
@@ -151,8 +157,8 @@ export async function removeClaudeMd(filePath: string): Promise<boolean> {
   let existing = "";
   try {
     existing = await readFile(filePath, "utf8");
-  } catch (e: any) {
-    if (e.code === "ENOENT") return false;
+  } catch (e: unknown) {
+    if (isEnoent(e)) return false;
     throw e;
   }
 

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -30,6 +30,17 @@ import { loadConfig } from "./config";
 import { formatBytes, formatRelativeTime } from "./format";
 
 // ---------------------------------------------------------------------------
+// Display constants
+// ---------------------------------------------------------------------------
+
+const SEARCH_EXCERPT_LEN  = 120; // chars shown per result in recall__search
+const NOTE_EXCERPT_LEN    = 200; // chars shown in recall__note store confirmation
+const CONTEXT_EXCERPT_LEN = 100; // chars shown per item in recall__context
+const SNIPPET_MAX         = 150; // max chars of FTS snippet shown in search results
+const LIST_TOOL_COL_WIDTH = 40;  // tool name column in recall__list_stored
+const LIST_ID_COL_WIDTH   = 16;  // id column in recall__list_stored header
+
+// ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
 
@@ -121,11 +132,9 @@ export function toolSearch(
     return `[recall: no results for "${args.query}"]`;
   }
 
-  const SNIPPET_MAX = 150;
-
   const lines = items.map((item, i) => {
-    const excerpt = item.summary.slice(0, 120).replace(/\n/g, " ");
-    const ellipsis = item.summary.length > 120 ? "…" : "";
+    const excerpt = item.summary.slice(0, SEARCH_EXCERPT_LEN).replace(/\n/g, " ");
+    const ellipsis = item.summary.length > SEARCH_EXCERPT_LEN ? "…" : "";
     const summaryLine = `${i + 1}. ${item.id} · ${item.tool_name} · ${formatDate(item.created_at)}\n   ${excerpt}${ellipsis}`;
 
     const snippet = retrieveSnippet(db, item.id, args.query);
@@ -177,8 +186,8 @@ export function toolNote(
   args: NoteArgs
 ): string {
   const title = args.title ?? "(note)";
-  const excerpt = args.text.slice(0, 200);
-  const ellipsis = args.text.length > 200 ? "…" : "";
+  const excerpt = args.text.slice(0, NOTE_EXCERPT_LEN);
+  const ellipsis = args.text.length > NOTE_EXCERPT_LEN ? "…" : "";
   const summary = `${title}: ${excerpt}${ellipsis}`;
   const originalSize = Buffer.byteLength(args.text, "utf8");
   const sessionId = new Date().toISOString().slice(0, 10);
@@ -305,10 +314,10 @@ export function toolListStored(
   const rows = items.map((item) => {
     const reduction = reductionPct(item.original_size, item.summary_size);
     const pin = item.pinned ? " 📌" : "";
-    return `${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}→${formatBytes(item.summary_size).padEnd(8)}  ${reduction}${pin}`;
+    return `${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  ${formatBytes(item.original_size).padStart(7)}→${formatBytes(item.summary_size).padEnd(8)}  ${reduction}${pin}`;
   });
 
-  const header = `${"ID".padEnd(16)}  ${"Tool".padEnd(40)}  ${"Date".padEnd(10)}  ${"Size".padStart(7)} ${"→".padEnd(9)}  Red.`;
+  const header = `${"ID".padEnd(LIST_ID_COL_WIDTH)}  ${"Tool".padEnd(LIST_TOOL_COL_WIDTH)}  ${"Date".padEnd(10)}  ${"Size".padStart(7)} ${"→".padEnd(9)}  Red.`;
   const separator = "-".repeat(header.length);
 
   return [header, separator, ...rows].join("\n");
@@ -352,9 +361,9 @@ export function toolContext(
   if (data.pinned.length > 0) {
     lines.push("", `Pinned (${data.pinned.length}):`);
     for (const item of data.pinned) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "…" : "";
-      lines.push(`  📌 ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "…" : "";
+      lines.push(`  📌 ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -373,9 +382,9 @@ export function toolContext(
     const days = args.days ?? 7;
     lines.push("", `Recently accessed (last ${days} day${days === 1 ? "" : "s"}, ${data.recent.length} item${data.recent.length === 1 ? "" : "s"}):`);
     for (const item of data.recent) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "…" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ×${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "…" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  ×${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -384,9 +393,9 @@ export function toolContext(
     const date = data.last_session?.date ?? "";
     lines.push("", `Hot from last session (${date}, ${data.hot.length} item${data.hot.length === 1 ? "" : "s"}):`);
     for (const item of data.hot) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "…" : "";
-      lines.push(`  ${item.id}  ${item.tool_name.padEnd(40)}  ${formatDate(item.created_at)}  ×${item.access_count}`);
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "…" : "";
+      lines.push(`  ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  ${formatDate(item.created_at)}  ×${item.access_count}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
   }
@@ -443,8 +452,8 @@ export function toolSessionSummary(
   if (data.top_accessed.length > 0) {
     lines.push("", "Most accessed:");
     for (const item of data.top_accessed) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "…" : "";
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "…" : "";
       lines.push(`  ${item.id} (×${item.access_count}) ${item.tool_name}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
@@ -453,8 +462,8 @@ export function toolSessionSummary(
   if (data.pinned.length > 0) {
     lines.push("", `Pinned: ${data.pinned.length}`);
     for (const item of data.pinned) {
-      const excerpt = item.summary.slice(0, 100).replace(/\n/g, " ");
-      const ellipsis = item.summary.length > 100 ? "…" : "";
+      const excerpt = item.summary.slice(0, CONTEXT_EXCERPT_LEN).replace(/\n/g, " ");
+      const ellipsis = item.summary.length > CONTEXT_EXCERPT_LEN ? "…" : "";
       lines.push(`  📌 ${item.id}  ${item.tool_name}`);
       lines.push(`    ${excerpt}${ellipsis}`);
     }
@@ -542,7 +551,7 @@ export function toolStats(
     if (suggestions.pin_candidates.length > 0) {
       lines.push("  📌 Consider pinning:");
       for (const item of suggestions.pin_candidates) {
-        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  accessed ${item.access_count}×`);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  accessed ${item.access_count}×`);
       }
     }
 
@@ -552,7 +561,7 @@ export function toolStats(
       const now = Math.floor(Date.now() / 1000);
       for (const item of suggestions.stale_candidates) {
         const ageDays = Math.floor((now - item.created_at) / 86400);
-        lines.push(`     ${item.id}  ${item.tool_name.padEnd(40)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
+        lines.push(`     ${item.id}  ${item.tool_name.padEnd(LIST_TOOL_COL_WIDTH)}  created ${ageDays} day${ageDays === 1 ? "" : "s"} ago`);
       }
     }
   }


### PR DESCRIPTION
## Summary

- Named display layout constants in `tools.ts` (`SEARCH_EXCERPT_LEN`, `NOTE_EXCERPT_LEN`, `CONTEXT_EXCERPT_LEN`, `SNIPPET_MAX`, `LIST_TOOL_COL_WIDTH`, `LIST_ID_COL_WIDTH`) replacing 6 scattered magic numbers
- Replaced `catch (e: any)` with `catch (e: unknown)` + `isEnoent()` type guard in `install/index.ts`, eliminating the only two type suppressions in `src/`

## Test plan

- [x] 693 tests pass, 0 failures
- [x] `tsc --noEmit` clean
- [x] No behaviour changes — purely naming and typing improvements