### PR TITLE
ci: pin bun to 1.3.14 instead of latest

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -15,7 +15,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.1.3
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -34,7 +34,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.1.3
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile
@@ -50,7 +50,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.1.3
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - name: Install dependencies
         run: bun install --frozen-lockfile

--- a/.github/workflows/publish.yml
+++ b/.github/workflows/publish.yml
@@ -16,7 +16,7 @@ jobs:
 
       - uses: oven-sh/setup-bun@v2.1.3
         with:
-          bun-version: latest
+          bun-version: 1.3.14
 
       - uses: actions/setup-node@v6
         with:


### PR DESCRIPTION
## Summary
- Pins `bun-version` to `1.3.14` (was `latest`) in all four `oven-sh/setup-bun` steps across `ci.yml` (3) and `publish.yml` (1).

## Why
`bun-version: latest` made the **Bundle freshness** check non-deterministic: any bun release that changes codegen makes a fresh `bun run build` differ from the committed `dist/`, failing the check on unrelated PRs until someone rebuilds. (This just bit the Claude Code Action PR — `1.3.14` dropped an empty `else {}` block the older bundle still had.) Pinning makes bun upgrades a deliberate, reviewable change.

## Test plan
- [x] Both workflow files parse as valid YAML
- [ ] CI green on this PR (Test & typecheck, Stress tests, Bundle freshness) — dist/ already rebuilt with 1.3.14 on main, so freshness should pass