### PR TITLE
chore: revert TEMP show_full_output diagnostic

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -52,4 +52,3 @@ jobs:
           prompt: ${{ github.event_name == 'pull_request' && 'Review this PR for correctness, security, and adherence to the repo conventions in CLAUDE.md. Flag CRITICAL/HIGH issues clearly; keep notes concise.' || '' }}
           trigger_phrase: "@claude"
           track_progress: "true"
-          show_full_output: "true"   # TEMP: diagnostic — revert after capture


### PR DESCRIPTION
Reverts the temporary show_full_output flag added for the claude-action auth diagnostic.