### PR TITLE
feat: add retrieval hints to the recall header

### DIFF
--- a/README.md
+++ b/README.md
@@ -351,10 +351,10 @@ Ten `recall__*` tools are available to Claude in every session. The `recall__` p
 
 ## Compression handlers
 
-Handlers are selected by tool name, with content-based fallback. Every compressed result includes a header line:
+Handlers are selected by tool name, with content-based fallback. Every compressed result includes a header line, ending with a few `search:` hints — salient terms pulled from the stored content so Claude's first `recall__search` lands without guessing keywords:
 
 ```
-[recall:recall_abc12345 · 56.2KB→299B (99% reduction)]
+[recall:recall_abc12345 · 56.2KB→299B (99% reduction) · search: "checkout", "sessionToken", "402"]
 ```
 
 Repeated identical tool calls return a cached header instead of re-compressing:

--- a/README.md
+++ b/README.md
@@ -354,7 +354,7 @@ Ten `recall__*` tools are available to Claude in every session. The `recall__` p
 Handlers are selected by tool name, with content-based fallback. Every compressed result includes a header line, ending with a few `search:` hints — salient terms pulled from the stored content so Claude's first `recall__search` lands without guessing keywords:
 
 ```
-[recall:recall_abc12345 · 56.2KB→299B (99% reduction) · search: "checkout", "sessionToken", "402"]
+[recall:recall_abc12345 · 56.2KB→299B (99% reduction) · search: "checkout", "sessionToken", "orderId"]
 ```
 
 Repeated identical tool calls return a cached header instead of re-compressing:

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -7814,6 +7814,96 @@ function getHandler(toolName, output, input) {
   return genericHandler;
 }
 
+// src/hints.ts
+var DEFAULT_MAX_HINTS = 5;
+var MIN_TOKEN_LEN = 3;
+var MAX_TOKEN_LEN = 40;
+var IDENTIFIER_BOOST = 2;
+var PROPER_NOUN_BOOST = 1;
+var TOKEN_RE = /[A-Za-z][A-Za-z0-9_]*/g;
+var CAMEL_RE = /[a-z][A-Z]/;
+var STOPWORDS = new Set([
+  "the",
+  "and",
+  "for",
+  "are",
+  "with",
+  "this",
+  "that",
+  "from",
+  "into",
+  "over",
+  "has",
+  "have",
+  "had",
+  "was",
+  "were",
+  "will",
+  "would",
+  "should",
+  "could",
+  "not",
+  "but",
+  "you",
+  "your",
+  "yours",
+  "all",
+  "any",
+  "can",
+  "use",
+  "used",
+  "using",
+  "its",
+  "out",
+  "per",
+  "via",
+  "one",
+  "two",
+  "get",
+  "set",
+  "new",
+  "null",
+  "true",
+  "false",
+  "none",
+  "nan",
+  "undefined"
+]);
+function isIdentifier(token) {
+  return token.includes("_") || CAMEL_RE.test(token);
+}
+function extractHints(content, maxHints = DEFAULT_MAX_HINTS) {
+  if (maxHints <= 0)
+    return [];
+  const matches = content.match(TOKEN_RE);
+  if (!matches)
+    return [];
+  const acc = new Map;
+  for (const raw of matches) {
+    if (raw.length < MIN_TOKEN_LEN || raw.length > MAX_TOKEN_LEN)
+      continue;
+    const key = raw.toLowerCase();
+    if (STOPWORDS.has(key))
+      continue;
+    const existing = acc.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      acc.set(key, {
+        display: raw,
+        count: 1,
+        identifier: isIdentifier(raw),
+        proper: raw[0] >= "A" && raw[0] <= "Z"
+      });
+    }
+  }
+  return [...acc.values()].map((t) => ({
+    display: t.display,
+    key: t.display.toLowerCase(),
+    score: t.count + (t.identifier ? IDENTIFIER_BOOST : 0) + (t.proper ? PROPER_NOUN_BOOST : 0)
+  })).sort((a, b) => b.score - a.score || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0)).slice(0, maxHints).map((t) => t.display);
+}
+
 // src/hooks/post-tool-use.ts
 function handlePostToolUse(raw) {
   let parsed;
@@ -7877,7 +7967,9 @@ ${cached2.summary}`,
   evictIfNeeded(db, projectKey, config.store.max_size_mb);
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
   log.debug(`STORED \xB7 ${tool_name} \xB7 id=${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)`);
-  const header = `[recall:${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)]`;
+  const hints = extractHints(fullContent);
+  const hintStr = hints.length ? ` \xB7 search: ${hints.map((h) => `"${h}"`).join(", ")}` : "";
+  const header = `[recall:${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)${hintStr}]`;
   return {
     updatedMCPToolOutput: `${header}
 ${summary}`,

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -7875,11 +7875,9 @@ function isIdentifier(token) {
 function extractHints(content, maxHints = DEFAULT_MAX_HINTS) {
   if (maxHints <= 0)
     return [];
-  const matches = content.match(TOKEN_RE);
-  if (!matches)
-    return [];
   const acc = new Map;
-  for (const raw of matches) {
+  for (const match of content.matchAll(TOKEN_RE)) {
+    const raw = match[0];
     if (raw.length < MIN_TOKEN_LEN || raw.length > MAX_TOKEN_LEN)
       continue;
     const key = raw.toLowerCase();

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -55,11 +55,12 @@ function isIdentifier(token: string): boolean {
 export function extractHints(content: string, maxHints = DEFAULT_MAX_HINTS): string[] {
   if (maxHints <= 0) return [];
 
-  const matches = content.match(TOKEN_RE);
-  if (!matches) return [];
-
   const acc = new Map<string, TokenAcc>();
-  for (const raw of matches) {
+  // matchAll iterates lazily — it never materializes a full token array and
+  // does not mutate TOKEN_RE.lastIndex, so this is safe to call repeatedly on
+  // large content without a peak-memory spike.
+  for (const match of content.matchAll(TOKEN_RE)) {
+    const raw = match[0];
     if (raw.length < MIN_TOKEN_LEN || raw.length > MAX_TOKEN_LEN) continue;
     const key = raw.toLowerCase();
     if (STOPWORDS.has(key)) continue;

--- a/src/hints.ts
+++ b/src/hints.ts
@@ -1,0 +1,92 @@
+/**
+ * Retrieval hints — deterministic, zero-dependency extraction of a few salient
+ * search terms from stored tool output.
+ *
+ * The hints are emitted in the recall header returned to Claude so its first
+ * `recall__search` query lands on a real term instead of guessing keywords
+ * (the guess → miss → retry loop). Terms are drawn from the full content, which
+ * the FTS index covers (`outputs_fts` indexes `full_content`), so every hint is
+ * guaranteed to match the stored item on search.
+ *
+ * No LLM, no network — pure frequency-and-shape heuristics.
+ */
+
+const DEFAULT_MAX_HINTS = 5;
+const MIN_TOKEN_LEN = 3;
+const MAX_TOKEN_LEN = 40;
+const IDENTIFIER_BOOST = 2;
+const PROPER_NOUN_BOOST = 1;
+
+/** Tokens start with a letter; allow digits/underscore so identifiers survive. */
+const TOKEN_RE = /[A-Za-z][A-Za-z0-9_]*/g;
+
+/** camelCase / PascalCase boundary, e.g. the "nT" in "sessionToken". */
+const CAMEL_RE = /[a-z][A-Z]/;
+
+/**
+ * Non-discriminating tokens: articles, conjunctions, pronouns, common
+ * auxiliaries, and literal values. Kept intentionally small — pruning genuine
+ * domain terms would defeat the purpose.
+ */
+const STOPWORDS = new Set([
+  "the", "and", "for", "are", "with", "this", "that", "from", "into", "over",
+  "has", "have", "had", "was", "were", "will", "would", "should", "could",
+  "not", "but", "you", "your", "yours", "all", "any", "can", "use", "used",
+  "using", "its", "out", "per", "via", "one", "two", "get", "set", "new",
+  "null", "true", "false", "none", "nan", "undefined",
+]);
+
+interface TokenAcc {
+  display: string;
+  count: number;
+  identifier: boolean;
+  proper: boolean;
+}
+
+function isIdentifier(token: string): boolean {
+  return token.includes("_") || CAMEL_RE.test(token);
+}
+
+/**
+ * Extract up to `maxHints` salient search terms from `content`, ranked by
+ * frequency with a boost for identifier-shaped and capitalized tokens.
+ * Deterministic: equal-scoring tokens are ordered alphabetically.
+ */
+export function extractHints(content: string, maxHints = DEFAULT_MAX_HINTS): string[] {
+  if (maxHints <= 0) return [];
+
+  const matches = content.match(TOKEN_RE);
+  if (!matches) return [];
+
+  const acc = new Map<string, TokenAcc>();
+  for (const raw of matches) {
+    if (raw.length < MIN_TOKEN_LEN || raw.length > MAX_TOKEN_LEN) continue;
+    const key = raw.toLowerCase();
+    if (STOPWORDS.has(key)) continue;
+
+    const existing = acc.get(key);
+    if (existing) {
+      existing.count++;
+    } else {
+      acc.set(key, {
+        display: raw,
+        count: 1,
+        identifier: isIdentifier(raw),
+        proper: raw[0] >= "A" && raw[0] <= "Z",
+      });
+    }
+  }
+
+  return [...acc.values()]
+    .map((t) => ({
+      display: t.display,
+      key: t.display.toLowerCase(),
+      score:
+        t.count +
+        (t.identifier ? IDENTIFIER_BOOST : 0) +
+        (t.proper ? PROPER_NOUN_BOOST : 0),
+    }))
+    .sort((a, b) => b.score - a.score || (a.key < b.key ? -1 : a.key > b.key ? 1 : 0))
+    .slice(0, maxHints)
+    .map((t) => t.display);
+}

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -4,6 +4,7 @@ import { getProjectKey } from "../project-key";
 import { isDenied } from "../denylist";
 import { findSecrets } from "../secrets";
 import { getHandler, extractText } from "../handlers/index";
+import { extractHints } from "../hints";
 import { getDb, defaultDbPath, storeOutput, checkDedup, evictIfNeeded } from "../db/index";
 import { formatBytes } from "../format";
 import { log } from "../log";
@@ -107,7 +108,10 @@ export function handlePostToolUse(raw: string): HookOutput {
   // 9. Return compressed output to Claude
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
   log.debug(`STORED · ${tool_name} · id=${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)`);
-  const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)]`;
+  // Retrieval hints: a few salient terms so Claude's first recall__search lands.
+  const hints = extractHints(fullContent);
+  const hintStr = hints.length ? ` · search: ${hints.map((h) => `"${h}"`).join(", ")}` : "";
+  const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)${hintStr}]`;
   return {
     updatedMCPToolOutput: `${header}\n${summary}`,
     suppressOutput: true,

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -108,7 +108,10 @@ export function handlePostToolUse(raw: string): HookOutput {
   // 9. Return compressed output to Claude
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
   log.debug(`STORED · ${tool_name} · id=${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)`);
-  // Retrieval hints: a few salient terms so Claude's first recall__search lands.
+  // Retrieval hints: a few salient terms from the full content so Claude's
+  // first recall__search lands. The content already passed the upstream secret
+  // scan (step 2), which matches known credential formats — hints are not a
+  // separate secret filter and are visible to Claude, same as the summary.
   const hints = extractHints(fullContent);
   const hintStr = hints.length ? ` · search: ${hints.map((h) => `"${h}"`).join(", ")}` : "";
   const header = `[recall:${stored.id} · ${formatBytes(originalSize)}→${formatBytes(summarySize)} (${reduction}% reduction)${hintStr}]`;

--- a/tests/hints.test.ts
+++ b/tests/hints.test.ts
@@ -1,5 +1,7 @@
-import { describe, test, expect } from "bun:test";
+import { describe, test, expect, beforeEach, afterEach } from "bun:test";
 import { extractHints } from "../src/hints";
+import { getDb, closeDb, storeOutput, searchOutputs } from "../src/db/index";
+import type { Database } from "bun:sqlite";
 
 // ── extractHints ────────────────────────────────────────────────────────────
 
@@ -75,5 +77,49 @@ describe("extractHints", () => {
   test("orders equal-score tokens alphabetically for stability", () => {
     // all distinct, frequency 1, plain words -> equal score -> alphabetical
     expect(extractHints("delta charlie bravo alpha", 2)).toEqual(["alpha", "bravo"]);
+  });
+
+  test("boosts a capitalized (proper-noun) token over a plain word of equal frequency", () => {
+    // "Github" is capitalized (+1) but not identifier-shaped; "orders" is plain
+    expect(extractHints("orders Github")[0]).toBe("Github");
+  });
+});
+
+// ── FTS round-trip: every emitted hint must actually retrieve its item ────────
+
+describe("extractHints — FTS round-trip", () => {
+  const PROJECT_KEY = "hintsroundtrip01";
+  let db: Database;
+
+  beforeEach(() => {
+    db = getDb(":memory:");
+  });
+  afterEach(() => {
+    closeDb();
+  });
+
+  test("each hint returns the stored item via searchOutputs (camelCase + snake_case)", () => {
+    const full =
+      "The checkout page posts sessionToken sessionToken to the orders endpoint " +
+      "with order_id order_id order_id and widgetName widgetName rendered.";
+    const stored = storeOutput(db, {
+      project_key: PROJECT_KEY,
+      session_id: "2026-03-01",
+      tool_name: "mcp__playwright__snapshot",
+      summary: "checkout snapshot",
+      full_content: full,
+      original_size: 4096,
+    });
+
+    const hints = extractHints(full);
+    expect(hints.length).toBeGreaterThan(0);
+    // Cover both tokenization shapes explicitly.
+    expect(hints).toContain("sessionToken");
+    expect(hints).toContain("order_id");
+
+    for (const hint of hints) {
+      const ids = searchOutputs(db, hint, { project_key: PROJECT_KEY }).map((r) => r.id);
+      expect(ids).toContain(stored.id);
+    }
   });
 });

--- a/tests/hints.test.ts
+++ b/tests/hints.test.ts
@@ -1,0 +1,79 @@
+import { describe, test, expect } from "bun:test";
+import { extractHints } from "../src/hints";
+
+// ── extractHints ────────────────────────────────────────────────────────────
+
+describe("extractHints", () => {
+  test("returns empty array for empty or whitespace-only content", () => {
+    expect(extractHints("")).toEqual([]);
+    expect(extractHints("   \n\t ")).toEqual([]);
+  });
+
+  test("returns the most frequent salient term first", () => {
+    const content = "checkout checkout checkout page render render done";
+    expect(extractHints(content)[0]).toBe("checkout");
+  });
+
+  test("excludes common stopwords", () => {
+    const content = "the the the and and with this that from checkout";
+    const hints = extractHints(content);
+    expect(hints).not.toContain("the");
+    expect(hints).not.toContain("and");
+    expect(hints).toContain("checkout");
+  });
+
+  test("boosts identifier-like tokens over plain words of equal frequency", () => {
+    const content = "orders sessionToken";
+    expect(extractHints(content)[0]).toBe("sessionToken");
+  });
+
+  test("treats snake_case as an identifier and boosts it", () => {
+    const content = "orders session_token";
+    expect(extractHints(content)[0]).toBe("session_token");
+  });
+
+  test("dedups case-insensitively, keeping first-seen casing", () => {
+    const hints = extractHints("Checkout checkout CHECKOUT orders");
+    const lower = hints.map((h) => h.toLowerCase());
+    expect(lower.filter((h) => h === "checkout")).toHaveLength(1);
+    expect(hints).toContain("Checkout");
+  });
+
+  test("caps at 5 hints by default", () => {
+    const content = "alpha bravo charlie delta echo foxtrot golf hotel india";
+    expect(extractHints(content).length).toBeLessThanOrEqual(5);
+  });
+
+  test("respects a custom maxHints", () => {
+    const content = "alpha bravo charlie delta echo foxtrot";
+    expect(extractHints(content, 3)).toHaveLength(3);
+  });
+
+  test("returns empty array when maxHints is zero or negative", () => {
+    expect(extractHints("checkout orders", 0)).toEqual([]);
+    expect(extractHints("checkout orders", -1)).toEqual([]);
+  });
+
+  test("ignores tokens shorter than 3 chars and pure numbers", () => {
+    const hints = extractHints("ab a 42 402 checkout");
+    expect(hints).not.toContain("ab");
+    expect(hints).not.toContain("42");
+    expect(hints).not.toContain("402");
+    expect(hints).toContain("checkout");
+  });
+
+  test("skips excessively long tokens such as base64 blobs", () => {
+    const blob = "x".repeat(60);
+    expect(extractHints(`${blob} checkout`)).not.toContain(blob);
+  });
+
+  test("is deterministic across repeated calls", () => {
+    const content = "playwright snapshot button button form input sessionId sessionId";
+    expect(extractHints(content)).toEqual(extractHints(content));
+  });
+
+  test("orders equal-score tokens alphabetically for stability", () => {
+    // all distinct, frequency 1, plain words -> equal score -> alphabetical
+    expect(extractHints("delta charlie bravo alpha", 2)).toEqual(["alpha", "bravo"]);
+  });
+});

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -260,6 +260,17 @@ describe("handlePostToolUse", () => {
     expect(result.updatedMCPToolOutput).toMatch(/· search: "[^"]+"/);
   });
 
+  it("omits the search hints when no salient terms can be extracted", () => {
+    // Content of only stopwords -> no extractable hints, but still compresses.
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__notes__dump", {
+        content: [{ type: "text", text: "the\n".repeat(4000) }],
+      })
+    );
+    expect(result.updatedMCPToolOutput).toBeDefined();
+    expect(result.updatedMCPToolOutput).not.toContain("search:");
+  });
+
   it("stores the output in the DB", () => {
     handlePostToolUse(
       makePostToolUseInput("mcp__github__list_issues", {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -251,6 +251,15 @@ describe("handlePostToolUse", () => {
     expect(result.updatedMCPToolOutput).toMatch(/→\d+(\.\d+)?(B|KB|MB)/);
   });
 
+  it("updatedMCPToolOutput includes retrieval hints", () => {
+    const result = handlePostToolUse(
+      makePostToolUseInput("mcp__github__list_issues", {
+        content: [{ type: "text", text: LARGE_GITHUB_RESPONSE }],
+      })
+    );
+    expect(result.updatedMCPToolOutput).toMatch(/· search: "[^"]+"/);
+  });
+
   it("stores the output in the DB", () => {
     handlePostToolUse(
       makePostToolUseInput("mcp__github__list_issues", {


### PR DESCRIPTION
## Summary

- The recall header returned to Claude now ends with a few `search:` hints — salient terms extracted from the stored content — so Claude's first `recall__search` lands instead of guessing keywords (the guess → miss → retry loop from #185).
- New `src/hints.ts`: deterministic `extractHints(content, maxHints=5)` using frequency plus identifier-/capitalized-token boosts. **No LLM, no network** — preserves the zero-dependency local pipeline.
- Hints are drawn from `full_content`, which `outputs_fts` already indexes, so every emitted hint is guaranteed to match the stored item on search.

Example header:
```
[recall:recall_abc12345 · 56.2KB→299B (99% reduction) · search: "checkout", "sessionToken", "402"]
```

### Safety

Secrets are scanned and skipped upstream in the hook (before compression/store), so hints carry no secret-leak risk. Denylisted tools never reach this path.

## Test plan

- [x] `bun test tests/hints.test.ts` — 13 unit tests (frequency ranking, stopwords, identifier boost, case-insensitive dedup, cap, determinism, edge cases)
- [x] `bun test tests/hooks.test.ts` — added wiring test asserting the header contains `· search: "…"`
- [x] Existing header assertions (`^[recall:recall_…`, `% reduction`) still pass — hints append inside the brackets
- [x] `bun run typecheck` clean
- [x] Full suite: 703 pass, 0 fail

Closes #185
