### PR TITLE
feat: add graduated retrieval tiers to recall__retrieve

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,7 +288,7 @@ pin_recommendation_threshold = 5
 stale_item_days = 3
 
 [retrieve]
-# Max bytes returned by recall__retrieve() when no query is provided.
+# Max bytes returned by recall__retrieve(mode: "full").
 # Claude can override this per-call via the max_bytes parameter.
 default_max_bytes = 8192
 
@@ -335,7 +335,7 @@ Ten `recall__*` tools are available to Claude in every session. The `recall__` p
 | Tool | Use when |
 |---|---|
 | `recall__context` | Start of session — get pinned items, notes, and recent activity |
-| `recall__retrieve(id, query?)` | Need detail from a prior tool call |
+| `recall__retrieve(id, query?, mode?)` | Need detail from a prior tool call — `summary` / `peek` / `full` tiers |
 | `recall__search(query, tool?)` | Find stored output by content, no ID needed |
 | `recall__pin(id)` | Protect an item from expiry and eviction |
 | `recall__note(text, title?)` | Store a conclusion or decision as project memory |

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -52,13 +52,21 @@ Last session (2026-03-01):
 Fetch stored content from a previous tool call.
 
 ```
-recall__retrieve(id, query?, max_bytes?)
+recall__retrieve(id, query?, mode?, max_bytes?)
 ```
 
-- Omit `query` to return the compressed summary
-- Pass `query` to return an FTS excerpt focused on the relevant section — falls back to full content (capped at `max_bytes`) if the query has no match
-- Override `max_bytes` when you need more than the default 8 KB on a full-content retrieval
-- Every call records an access, which informs `sort: "accessed"` and LFU eviction order
+Graduated retrieval across three tiers — escalate only as far as you need:
+
+| `mode` | Returns | Default when |
+|---|---|---|
+| `summary` | The compressed summary (cheapest) | no `query` given |
+| `peek` | A bounded context window — the top matching chunks for a `query`, or the head chunks without one — much smaller than the full document | a `query` is given |
+| `full` | The verbatim content, capped at `max_bytes` (default 8 KB) | — |
+
+- `mode` is optional and backward-compatible: with no `mode`, a `query` defaults to `peek` and its absence to `summary`.
+- `peek` with a `query` falls back to full content if the item has no matching chunks (e.g. rows stored before chunking).
+- Override `max_bytes` when you need more than the default 8 KB from `mode: "full"`.
+- Every call records an access, which informs `sort: "accessed"` and LFU eviction order.
 
 ---
 

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -65,6 +65,7 @@ Graduated retrieval across three tiers — escalate only as far as you need:
 
 - `mode` is optional and backward-compatible: with no `mode`, a `query` defaults to `peek` and its absence to `summary`.
 - `peek` with a `query` falls back to full content if the item has no matching chunks (e.g. rows stored before chunking).
+- `peek` is bounded independently of `max_bytes` (a few chunks); `max_bytes` caps only `mode: "full"`.
 - Override `max_bytes` when you need more than the default 8 KB from `mode: "full"`.
 - Every call records an access, which informs `sort: "accessed"` and LFU eviction order.
 

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19799,6 +19799,32 @@ function retrieveSnippet(db, id, query) {
     return null;
   }
 }
+var PEEK_MAX_CHUNKS = 3;
+var PEEK_CHUNK_JOINER = `
+ [\u2026] 
+`;
+function retrievePeek(db, id, query, maxChunks = PEEK_MAX_CHUNKS) {
+  const exists = db.prepare(`SELECT 1 FROM stored_outputs WHERE id = ?`).get(id);
+  if (!exists)
+    return null;
+  if (query) {
+    const safeQuery = sanitizeFtsQuery(query);
+    try {
+      const rows2 = db.prepare(`SELECT content FROM content_chunks
+           WHERE content_chunks MATCH ? AND output_id = ?
+           ORDER BY rank
+           LIMIT ?`).all(safeQuery, id, maxChunks);
+      if (rows2.length > 0)
+        return rows2.map((r) => r.content).join(PEEK_CHUNK_JOINER);
+    } catch {}
+    return null;
+  }
+  const rows = db.prepare(`SELECT content FROM content_chunks
+       WHERE output_id = ?
+       ORDER BY chunk_index
+       LIMIT ?`).all(id, maxChunks);
+  return rows.length > 0 ? rows.map((r) => r.content).join(PEEK_CHUNK_JOINER) : null;
+}
 function searchOutputs(db, query, options) {
   const limit = options.limit ?? 10;
   const safeQuery = sanitizeFtsQuery(query);
@@ -21087,20 +21113,30 @@ function toolRetrieve(db, args) {
   }
   recordAccess(db, args.id);
   const header = itemHeader(item);
-  if (args.query) {
-    const snippet = retrieveSnippet(db, args.id, args.query);
-    if (snippet) {
-      return `${header}
-${snippet}`;
-    }
+  const mode = args.mode ?? (args.query ? "peek" : "summary");
+  const fullCapped = () => {
     const content = item.full_content.slice(0, cap);
     const truncated = item.full_content.length > cap ? `
 \u2026(truncated at ${formatBytes(cap)})` : "";
     return `${header}
 ${content}${truncated}`;
-  }
-  return `${header}
+  };
+  if (mode === "summary")
+    return `${header}
 ${item.summary}`;
+  if (mode === "full")
+    return fullCapped();
+  const peek = retrievePeek(db, args.id, args.query);
+  if (peek)
+    return `${header}
+${peek}`;
+  if (args.query) {
+    const snippet = retrieveSnippet(db, args.id, args.query);
+    if (snippet)
+      return `${header}
+${snippet}`;
+  }
+  return fullCapped();
 }
 function toolSearch(db, projectKey, args) {
   const limit = args.limit ?? 5;
@@ -21436,10 +21472,11 @@ var server = new McpServer({
   name: "recall",
   version: version2
 });
-server.tool("recall__retrieve", "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.", {
+server.tool("recall__retrieve", "Fetch stored content from a previous tool call, in graduated tiers. mode='summary' (default without a query) returns the compressed summary; mode='peek' (default with a query) returns a bounded context window \u2014 top matching chunks for a query, or head chunks without \u2014 far cheaper than full; mode='full' returns the verbatim content (capped by max_bytes). Escalate summary \u2192 peek \u2192 full only as needed.", {
   id: exports_external.string().describe("recall_* item ID"),
-  query: exports_external.string().optional().describe("FTS query to return a focused excerpt"),
-  max_bytes: exports_external.number().optional().describe("Override default 8KB cap on returned bytes (used when FTS returns no match)")
+  query: exports_external.string().optional().describe("FTS query to focus a peek on matching chunks"),
+  mode: exports_external.enum(["summary", "peek", "full"]).optional().describe("Retrieval tier. Defaults to 'peek' when a query is given, else 'summary'."),
+  max_bytes: exports_external.number().optional().describe("Override default 8KB cap on returned bytes (applies to mode='full')")
 }, safeTool((args) => ({
   content: [{ type: "text", text: toolRetrieve(db, args) }]
 })));

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19810,12 +19810,13 @@ function retrievePeek(db, id, query, maxChunks = PEEK_MAX_CHUNKS) {
   if (query) {
     const safeQuery = sanitizeFtsQuery(query);
     try {
-      const rows2 = db.prepare(`SELECT content FROM content_chunks
+      const rows2 = db.prepare(`SELECT content, chunk_index FROM content_chunks
            WHERE content_chunks MATCH ? AND output_id = ?
            ORDER BY rank
            LIMIT ?`).all(safeQuery, id, maxChunks);
-      if (rows2.length > 0)
-        return rows2.map((r) => r.content).join(PEEK_CHUNK_JOINER);
+      if (rows2.length > 0) {
+        return [...rows2].sort((a, b) => a.chunk_index - b.chunk_index).map((r) => r.content).join(PEEK_CHUNK_JOINER);
+      }
     } catch {}
     return null;
   }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -238,13 +238,20 @@ export function retrievePeek(
     try {
       const rows = db
         .prepare(
-          `SELECT content FROM content_chunks
+          `SELECT content, chunk_index FROM content_chunks
            WHERE content_chunks MATCH ? AND output_id = ?
            ORDER BY rank
            LIMIT ?`
         )
-        .all(safeQuery, id, maxChunks) as { content: string }[];
-      if (rows.length > 0) return rows.map((r) => r.content).join(PEEK_CHUNK_JOINER);
+        .all(safeQuery, id, maxChunks) as { content: string; chunk_index: number }[];
+      if (rows.length > 0) {
+        // Select the top-K by relevance, then present them in document order so
+        // the […] joiner reflects real gaps, not a relevance reshuffle.
+        return [...rows]
+          .sort((a, b) => a.chunk_index - b.chunk_index)
+          .map((r) => r.content)
+          .join(PEEK_CHUNK_JOINER);
+      }
     } catch {
       // FTS parse error — signal fallback to the caller
     }

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -213,6 +213,55 @@ export function retrieveSnippet(
   }
 }
 
+/** Chunks a "peek" returns — a bounded context window, not the full document. */
+const PEEK_MAX_CHUNKS = 3;
+const PEEK_CHUNK_JOINER = "\n […] \n";
+
+/**
+ * Peek: a bounded, multi-chunk context window into a stored item — the middle
+ * retrieval tier between `searchOutputs` (index) and full content. With a query,
+ * returns the top matching chunks (ranked); without one, the first chunks as a
+ * head preview. Returns null when the item has no stored chunks (e.g. rows
+ * created before chunking) so the caller can fall back.
+ */
+export function retrievePeek(
+  db: Database,
+  id: string,
+  query: string | undefined,
+  maxChunks = PEEK_MAX_CHUNKS
+): string | null {
+  const exists = db.prepare(`SELECT 1 FROM stored_outputs WHERE id = ?`).get(id);
+  if (!exists) return null;
+
+  if (query) {
+    const safeQuery = sanitizeFtsQuery(query);
+    try {
+      const rows = db
+        .prepare(
+          `SELECT content FROM content_chunks
+           WHERE content_chunks MATCH ? AND output_id = ?
+           ORDER BY rank
+           LIMIT ?`
+        )
+        .all(safeQuery, id, maxChunks) as { content: string }[];
+      if (rows.length > 0) return rows.map((r) => r.content).join(PEEK_CHUNK_JOINER);
+    } catch {
+      // FTS parse error — signal fallback to the caller
+    }
+    return null;
+  }
+
+  const rows = db
+    .prepare(
+      `SELECT content FROM content_chunks
+       WHERE output_id = ?
+       ORDER BY chunk_index
+       LIMIT ?`
+    )
+    .all(id, maxChunks) as { content: string }[];
+  return rows.length > 0 ? rows.map((r) => r.content).join(PEEK_CHUNK_JOINER) : null;
+}
+
 /**
  * Full-text searches across stored outputs for a project.
  * Results are ordered by FTS rank (best match first), capped at `options.limit` (default 10).

--- a/src/server.ts
+++ b/src/server.ts
@@ -58,14 +58,18 @@ const server = new McpServer({
 
 server.tool(
   "recall__retrieve",
-  "Fetch stored content from a previous tool call. Pass a query to return the most relevant excerpt via FTS. Use when you need more detail from a compressed result.",
+  "Fetch stored content from a previous tool call, in graduated tiers. mode='summary' (default without a query) returns the compressed summary; mode='peek' (default with a query) returns a bounded context window — top matching chunks for a query, or head chunks without — far cheaper than full; mode='full' returns the verbatim content (capped by max_bytes). Escalate summary → peek → full only as needed.",
   {
     id: z.string().describe("recall_* item ID"),
-    query: z.string().optional().describe("FTS query to return a focused excerpt"),
+    query: z.string().optional().describe("FTS query to focus a peek on matching chunks"),
+    mode: z
+      .enum(["summary", "peek", "full"])
+      .optional()
+      .describe("Retrieval tier. Defaults to 'peek' when a query is given, else 'summary'."),
     max_bytes: z
       .number()
       .optional()
-      .describe("Override default 8KB cap on returned bytes (used when FTS returns no match)"),
+      .describe("Override default 8KB cap on returned bytes (applies to mode='full')"),
   },
   safeTool((args) => ({
     content: [{ type: "text", text: toolRetrieve(db, args) }],

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -11,6 +11,7 @@ import type { Database } from "bun:sqlite";
 import {
   retrieveOutput,
   retrieveSnippet,
+  retrievePeek,
   recordAccess,
   pinOutput,
   searchOutputs,
@@ -61,16 +62,26 @@ function itemHeader(item: StoredOutput): string {
 // recall__retrieve
 // ---------------------------------------------------------------------------
 
+export type RetrieveMode = "summary" | "peek" | "full";
+
 export interface RetrieveArgs {
   id: string;
   query?: string;
   max_bytes?: number;
+  mode?: RetrieveMode;
 }
 
-export function toolRetrieve(
-  db: Database,
-  args: RetrieveArgs
-): string {
+/**
+ * Graduated retrieval across three tiers:
+ * - `summary` — the compressed summary (cheapest; the default when no query).
+ * - `peek`    — a bounded context window (top matching chunks with a query,
+ *               head chunks without) — the middle tier, far smaller than full.
+ * - `full`    — the verbatim content, capped at `max_bytes`.
+ *
+ * Backward-compatible: with no explicit `mode`, a query defaults to `peek` and
+ * its absence to `summary`, matching the prior focused-excerpt / summary split.
+ */
+export function toolRetrieve(db: Database, args: RetrieveArgs): string {
   const config = loadConfig();
   const cap = args.max_bytes ?? config.retrieve.default_max_bytes;
 
@@ -82,19 +93,28 @@ export function toolRetrieve(
   recordAccess(db, args.id);
   const header = itemHeader(item);
 
-  if (args.query) {
-    // Try FTS snippet first for a focused, relevant excerpt
-    const snippet = retrieveSnippet(db, args.id, args.query);
-    if (snippet) {
-      return `${header}\n${snippet}`;
-    }
-    // No FTS match: fall back to full content capped at max_bytes
-    const content = item.full_content.slice(0, cap);
-    const truncated = item.full_content.length > cap ? `\n…(truncated at ${formatBytes(cap)})` : "";
-    return `${header}\n${content}${truncated}`;
-  }
+  const mode: RetrieveMode = args.mode ?? (args.query ? "peek" : "summary");
 
-  return `${header}\n${item.summary}`;
+  const fullCapped = (): string => {
+    const content = item.full_content.slice(0, cap);
+    const truncated =
+      item.full_content.length > cap ? `\n…(truncated at ${formatBytes(cap)})` : "";
+    return `${header}\n${content}${truncated}`;
+  };
+
+  if (mode === "summary") return `${header}\n${item.summary}`;
+  if (mode === "full") return fullCapped();
+
+  // mode === "peek": bounded context window, with graceful fallbacks.
+  const peek = retrievePeek(db, args.id, args.query);
+  if (peek) return `${header}\n${peek}`;
+  // Pre-chunking items with a query: legacy single-snippet path.
+  if (args.query) {
+    const snippet = retrieveSnippet(db, args.id, args.query);
+    if (snippet) return `${header}\n${snippet}`;
+  }
+  // Nothing to peek at (no chunks / no match): fall back to full content.
+  return fullCapped();
 }
 
 // ---------------------------------------------------------------------------

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -439,6 +439,56 @@ describe("MCP tool handlers", () => {
   });
 
   // -------------------------------------------------------------------------
+  // toolRetrieve — graduated modes (#186)
+  // -------------------------------------------------------------------------
+
+  describe("toolRetrieve — graduated modes", () => {
+    it("mode 'summary' returns the summary even when a query is given", () => {
+      const stored = storeOutput(db, makeInput());
+      const result = toolRetrieve(db, { id: stored.id, mode: "summary", query: "broken" });
+      expect(result).toContain("labels: bug"); // summary-only text
+      expect(result).not.toContain('"number":1'); // raw JSON lives only in full_content
+    });
+
+    it("mode 'full' returns verbatim content, not the summary", () => {
+      const stored = storeOutput(db, makeInput());
+      const result = toolRetrieve(db, { id: stored.id, mode: "full" });
+      expect(result).toContain('"number":1');
+    });
+
+    it("mode 'full' applies the max_bytes cap", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "y".repeat(2000) }));
+      const result = toolRetrieve(db, { id: stored.id, mode: "full", max_bytes: 100 });
+      expect(result).toContain("truncated");
+    });
+
+    it("mode 'peek' with a query returns matching chunk content", () => {
+      const stored = storeOutput(
+        db,
+        makeInput({ full_content: "deployment uses kubernetes and helm across services" })
+      );
+      const result = toolRetrieve(db, { id: stored.id, mode: "peek", query: "kubernetes" });
+      expect(result).toContain("kubernetes");
+    });
+
+    it("mode 'peek' without a query returns a head preview", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "alpha beta gamma delta epsilon" }));
+      const result = toolRetrieve(db, { id: stored.id, mode: "peek" });
+      expect(result).toContain("alpha");
+    });
+
+    it("peek returns a bounded multi-chunk window smaller than full", () => {
+      // > 10 chunks (CHUNK_SIZE=512), "needle" recurring across them
+      const full = Array.from({ length: 60 }, (_, i) => `segment${i} needle ${"z".repeat(100)}`).join("\n");
+      const stored = storeOutput(db, makeInput({ full_content: full }));
+      const peek = toolRetrieve(db, { id: stored.id, mode: "peek", query: "needle" });
+      const whole = toolRetrieve(db, { id: stored.id, mode: "full" });
+      expect(peek).toContain("[…]"); // multiple chunks joined
+      expect(peek.length).toBeLessThan(whole.length);
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // toolPin
   // -------------------------------------------------------------------------
 

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -486,6 +486,28 @@ describe("MCP tool handlers", () => {
       expect(peek).toContain("[…]"); // multiple chunks joined
       expect(peek.length).toBeLessThan(whole.length);
     });
+
+    it("mode 'peek' falls back to full content when the query matches no chunk", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "hello world content here" }));
+      const result = toolRetrieve(db, { id: stored.id, mode: "peek", query: "zzznomatchxyz" });
+      expect(result).toContain("hello world content here");
+    });
+
+    it("mode 'peek' returns the full context window regardless of max_bytes", () => {
+      const full = Array.from({ length: 40 }, (_, i) => `needle${i} ${"z".repeat(100)}`).join("\n");
+      const stored = storeOutput(db, makeInput({ full_content: full }));
+      // max_bytes applies only to 'full'; a peek must not be truncated by it.
+      const result = toolRetrieve(db, { id: stored.id, mode: "peek", query: "needle5", max_bytes: 10 });
+      expect(result).not.toContain("truncated");
+      expect(result.length).toBeGreaterThan(10);
+    });
+
+    it("mode 'peek' tolerates FTS operator characters in the query", () => {
+      const stored = storeOutput(db, makeInput({ full_content: "alpha beta gamma delta" }));
+      expect(() =>
+        toolRetrieve(db, { id: stored.id, mode: "peek", query: 'alpha AND "beta' })
+      ).not.toThrow();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- Adds an explicit `mode` param to `recall__retrieve` — **`summary` | `peek` | `full`** — so Claude escalates detail only as far as it needs instead of jumping from the search index straight to full content (the 3-layer retrieval idea from #186, borrowed from claude-mem).
  - `summary` — the compressed summary (cheapest)
  - `peek` — a **bounded context window**: top matching chunks for a query, or head chunks without one — far smaller than the full document (the new middle tier)
  - `full` — verbatim content, capped at `max_bytes`
- New `retrievePeek()` in the DB layer returns the top-K ranked matching chunks (or first-K as a head preview), falling back gracefully for rows stored before chunking.

### Backward compatibility

`mode` is optional. With no `mode`, a query still defaults to a focused excerpt (`peek`) and its absence to the `summary` — so every existing caller behaves as before. All prior `toolRetrieve` tests pass unchanged; `peek` simply returns a slightly wider window (top-K chunks) than the previous single chunk.

## Test plan

- [x] New `toolRetrieve — graduated modes` tests: `summary`/`peek`/`full`, `max_bytes` cap on full, peek-with-query vs head-preview, and a bounded multi-chunk window proven smaller than full
- [x] Existing retrieve tests (summary default, query→excerpt, no-match fallback, access counting) still pass
- [x] `bun run typecheck` clean · full suite: 695 pass, 0 fail
- [x] Docs updated: `docs/tools.md` tier table + README tool reference and config comment

Closes #186
