### PR TITLE
feat: recency-weighted (decay) eviction instead of pure LFU

### DIFF
--- a/README.md
+++ b/README.md
@@ -287,6 +287,12 @@ pin_recommendation_threshold = 5
 # in recall__stats. Helps identify stored output that was never retrieved.
 stale_item_days = 3
 
+# Half-life (in days) for eviction scoring when the store exceeds max_size_mb.
+# Eviction ranks items by a recency-weighted access frequency, so a steadily
+# used recent item outranks one accessed many times but long ago. Lower =
+# recency matters more; higher = frequency dominates. Pinned items are exempt.
+eviction_half_life_days = 7
+
 [retrieve]
 # Max bytes returned by recall__retrieve(mode: "full").
 # Claude can override this per-call via the max_bytes parameter.

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5060,7 +5060,8 @@ var RecallConfigSchema = exports_external.object({
     key: exports_external.enum(["git_root", "cwd"]),
     max_size_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
-    stale_item_days: exports_external.number().int().positive()
+    stale_item_days: exports_external.number().int().positive(),
+    eviction_half_life_days: exports_external.number().positive()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -5084,7 +5085,8 @@ var DEFAULTS = {
     key: "git_root",
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
-    stale_item_days: 3
+    stale_item_days: 3,
+    eviction_half_life_days: 7
   },
   retrieve: {
     default_max_bytes: 8192
@@ -5327,7 +5329,9 @@ function checkDedup(db, project_key, input_hash) {
     LIMIT 1
   `).get(project_key, input_hash);
 }
-function evictIfNeeded(db, project_key, max_size_mb) {
+var DEFAULT_EVICTION_HALF_LIFE_DAYS = 7;
+var SECONDS_PER_DAY = 86400;
+function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EVICTION_HALF_LIFE_DAYS, now_secs = Math.floor(Date.now() / 1000)) {
   const max_bytes = max_size_mb * 1024 * 1024;
   const { total } = db.prepare(`
     SELECT COALESCE(SUM(original_size), 0) as total
@@ -5337,15 +5341,23 @@ function evictIfNeeded(db, project_key, max_size_mb) {
     return 0;
   const bytesToShed = total - max_bytes;
   const candidates = db.prepare(`
-    SELECT id, original_size FROM stored_outputs
+    SELECT id, original_size, access_count, last_accessed, created_at
+    FROM stored_outputs
     WHERE project_key = ? AND pinned = 0
-    ORDER BY access_count ASC, last_accessed ASC NULLS FIRST, created_at ASC
   `).all(project_key);
   if (candidates.length === 0)
     return 0;
+  const halfLifeSecs = half_life_days * SECONDS_PER_DAY;
+  const scoreOf = (c) => {
+    const lastActive = c.last_accessed ?? c.created_at;
+    const ageSecs = Math.max(0, now_secs - lastActive);
+    const recency = Math.pow(0.5, ageSecs / halfLifeSecs);
+    return (c.access_count + 1) * recency;
+  };
+  const ranked = candidates.map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at })).sort((a, b) => a.score - b.score || a.created_at - b.created_at);
   const toEvict = [];
   let shed = 0;
-  for (const row of candidates) {
+  for (const row of ranked) {
     if (shed >= bytesToShed)
       break;
     toEvict.push(row.id);
@@ -7962,7 +7974,7 @@ ${cached2.summary}`,
     original_size: originalSize,
     input_hash: input_hash ?? undefined
   });
-  evictIfNeeded(db, projectKey, config.store.max_size_mb);
+  evictIfNeeded(db, projectKey, config.store.max_size_mb, config.store.eviction_half_life_days);
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
   log.debug(`STORED \xB7 ${tool_name} \xB7 id=${stored.id} \xB7 ${formatBytes(originalSize)}\u2192${formatBytes(summarySize)} (${reduction}% reduction)`);
   const hints = extractHints(fullContent);

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5347,14 +5347,14 @@ function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EV
   `).all(project_key);
   if (candidates.length === 0)
     return 0;
-  const halfLifeSecs = half_life_days * SECONDS_PER_DAY;
+  const halfLifeSecs = Math.max(1, half_life_days * SECONDS_PER_DAY);
   const scoreOf = (c) => {
     const lastActive = c.last_accessed ?? c.created_at;
     const ageSecs = Math.max(0, now_secs - lastActive);
     const recency = Math.pow(0.5, ageSecs / halfLifeSecs);
     return (c.access_count + 1) * recency;
   };
-  const ranked = candidates.map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at })).sort((a, b) => a.score - b.score || a.created_at - b.created_at);
+  const ranked = candidates.map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at })).sort((a, b) => a.score - b.score || a.created_at - b.created_at || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const toEvict = [];
   let shed = 0;
   for (const row of ranked) {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20980,7 +20980,8 @@ var RecallConfigSchema = exports_external.object({
     key: exports_external.enum(["git_root", "cwd"]),
     max_size_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
-    stale_item_days: exports_external.number().int().positive()
+    stale_item_days: exports_external.number().int().positive(),
+    eviction_half_life_days: exports_external.number().positive()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -21004,7 +21005,8 @@ var DEFAULTS = {
     key: "git_root",
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
-    stale_item_days: 3
+    stale_item_days: 3,
+    eviction_half_life_days: 7
   },
   retrieve: {
     default_max_bytes: 8192

--- a/src/config.ts
+++ b/src/config.ts
@@ -12,6 +12,7 @@ const RecallConfigSchema = z.object({
     max_size_mb: z.number().positive(),
     pin_recommendation_threshold: z.number().int().positive(),
     stale_item_days: z.number().int().positive(),
+    eviction_half_life_days: z.number().positive(),
   }),
   retrieve: z.object({
     default_max_bytes: z.number().positive(),
@@ -40,6 +41,7 @@ const DEFAULTS: RecallConfig = {
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
+    eviction_half_life_days: 7,
   },
   retrieve: {
     default_max_bytes: 8192,

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -163,7 +163,9 @@ export function evictIfNeeded(
 
   if (candidates.length === 0) return 0; // all remaining items are pinned
 
-  const halfLifeSecs = half_life_days * SECONDS_PER_DAY;
+  // Math.max(1, …) guards against a non-positive half-life (NaN/Infinity) if a
+  // future direct caller bypasses the Zod-validated config.
+  const halfLifeSecs = Math.max(1, half_life_days * SECONDS_PER_DAY);
   const scoreOf = (c: (typeof candidates)[number]): number => {
     const lastActive = c.last_accessed ?? c.created_at;
     const ageSecs = Math.max(0, now_secs - lastActive);
@@ -171,10 +173,15 @@ export function evictIfNeeded(
     return (c.access_count + 1) * recency;
   };
 
-  // Evict lowest value first; stable tiebreak on oldest creation.
+  // Evict lowest value first; tiebreak oldest creation, then id for full determinism.
   const ranked = candidates
     .map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at }))
-    .sort((a, b) => a.score - b.score || a.created_at - b.created_at);
+    .sort(
+      (a, b) =>
+        a.score - b.score ||
+        a.created_at - b.created_at ||
+        (a.id < b.id ? -1 : a.id > b.id ? 1 : 0)
+    );
 
   const toEvict: string[] = [];
   let shed = 0;

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -84,7 +84,7 @@ export function recordAccess(db: Database, id: string): void {
 }
 
 /**
- * Pins or unpins an item. Pinned items are exempt from expiry and LFU eviction.
+ * Pins or unpins an item. Pinned items are exempt from expiry and eviction.
  * Returns `true` if the item was found and updated.
  */
 export function pinOutput(
@@ -116,15 +116,27 @@ export function checkDedup(
   `).get(project_key, input_hash) as StoredOutput | null;
 }
 
+const DEFAULT_EVICTION_HALF_LIFE_DAYS = 7;
+const SECONDS_PER_DAY = 86400;
+
 /**
- * Enforces the project store size cap by evicting least-frequently-accessed
- * non-pinned items until total `original_size` is within `max_size_mb`.
+ * Enforces the project store size cap by evicting the lowest-value non-pinned
+ * items until total `original_size` is within `max_size_mb`.
+ *
+ * Value is a recency-weighted frequency score: `(access_count + 1)` decayed by
+ * an exponential half-life on the time since last access (falling back to
+ * creation time for never-accessed items). This ranks a steadily-used recent
+ * item above one hit many times long ago — smarter than pure LFU, which would
+ * cling to a once-hammered-then-abandoned item. Pinned items are exempt.
+ * `now_secs` is injectable for deterministic tests.
  * Returns the number of items evicted (0 if already within limit).
  */
 export function evictIfNeeded(
   db: Database,
   project_key: string,
-  max_size_mb: number
+  max_size_mb: number,
+  half_life_days = DEFAULT_EVICTION_HALF_LIFE_DAYS,
+  now_secs = Math.floor(Date.now() / 1000)
 ): number {
   const max_bytes = max_size_mb * 1024 * 1024;
 
@@ -137,19 +149,36 @@ export function evictIfNeeded(
 
   const bytesToShed = total - max_bytes;
 
-  // Fetch all eviction candidates in LFU order — one query instead of one per item.
   const candidates = db.prepare(`
-    SELECT id, original_size FROM stored_outputs
+    SELECT id, original_size, access_count, last_accessed, created_at
+    FROM stored_outputs
     WHERE project_key = ? AND pinned = 0
-    ORDER BY access_count ASC, last_accessed ASC NULLS FIRST, created_at ASC
-  `).all(project_key) as { id: string; original_size: number }[];
+  `).all(project_key) as {
+    id: string;
+    original_size: number;
+    access_count: number;
+    last_accessed: number | null;
+    created_at: number;
+  }[];
 
   if (candidates.length === 0) return 0; // all remaining items are pinned
 
-  // Walk the candidate list, collecting IDs until we have shed enough bytes.
+  const halfLifeSecs = half_life_days * SECONDS_PER_DAY;
+  const scoreOf = (c: (typeof candidates)[number]): number => {
+    const lastActive = c.last_accessed ?? c.created_at;
+    const ageSecs = Math.max(0, now_secs - lastActive);
+    const recency = Math.pow(0.5, ageSecs / halfLifeSecs); // 1.0 when fresh, → 0 when old
+    return (c.access_count + 1) * recency;
+  };
+
+  // Evict lowest value first; stable tiebreak on oldest creation.
+  const ranked = candidates
+    .map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at }))
+    .sort((a, b) => a.score - b.score || a.created_at - b.created_at);
+
   const toEvict: string[] = [];
   let shed = 0;
-  for (const row of candidates) {
+  for (const row of ranked) {
     if (shed >= bytesToShed) break;
     toEvict.push(row.id);
     shed += row.original_size;

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -103,7 +103,7 @@ export function handlePostToolUse(raw: string): HookOutput {
   });
 
   // 8. Evict if store exceeds size limit
-  evictIfNeeded(db, projectKey, config.store.max_size_mb);
+  evictIfNeeded(db, projectKey, config.store.max_size_mb, config.store.eviction_half_life_days);
 
   // 9. Return compressed output to Claude
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -27,6 +27,7 @@ describe("loadConfig", () => {
     expect(config.store.max_size_mb).toBe(500);
     expect(config.store.pin_recommendation_threshold).toBe(5);
     expect(config.store.stale_item_days).toBe(3);
+    expect(config.store.eviction_half_life_days).toBe(7);
     expect(config.retrieve.default_max_bytes).toBe(8192);
     expect(config.denylist.additional).toEqual([]);
     expect(config.denylist.override_defaults).toEqual([]);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -547,6 +547,37 @@ describe("db", () => {
       expect(retrieveOutput(db, a.id)).not.toBeNull();
       expect(retrieveOutput(db, b.id)).not.toBeNull();
     });
+
+    it("decay keeps a recently-accessed item over an older heavily-accessed one (unlike LFU)", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const old = storeOutput(db, makeInput({ original_size: 300, summary: "old heavy" }));
+      const fresh = storeOutput(db, makeInput({ original_size: 300, summary: "fresh light" }));
+      // 'old': hit 50 times but not for 60 days. 'fresh': hit twice, just now.
+      db.prepare("UPDATE stored_outputs SET access_count = 50, last_accessed = ? WHERE id = ?").run(now - 60 * day, old.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 2, last_accessed = ? WHERE id = ?").run(now - 1, fresh.id);
+
+      const evicted = evictIfNeeded(db, PROJECT_KEY, 0.0005, 7, now);
+
+      expect(evicted).toBeGreaterThan(0);
+      // Pure LFU would evict 'fresh' (fewer accesses); decay evicts the stale 'old'.
+      expect(retrieveOutput(db, fresh.id)).not.toBeNull();
+      expect(retrieveOutput(db, old.id)).toBeNull();
+    });
+
+    it("uses creation time for recency when an item was never accessed", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const older = storeOutput(db, makeInput({ original_size: 300, summary: "older" }));
+      const newer = storeOutput(db, makeInput({ original_size: 300, summary: "newer" }));
+      db.prepare("UPDATE stored_outputs SET created_at = ?, last_accessed = NULL WHERE id = ?").run(now - 90 * day, older.id);
+      db.prepare("UPDATE stored_outputs SET created_at = ?, last_accessed = NULL WHERE id = ?").run(now - 1, newer.id);
+
+      evictIfNeeded(db, PROJECT_KEY, 0.0005, 7, now);
+
+      expect(retrieveOutput(db, newer.id)).not.toBeNull();
+      expect(retrieveOutput(db, older.id)).toBeNull();
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -578,6 +578,52 @@ describe("db", () => {
       expect(retrieveOutput(db, newer.id)).not.toBeNull();
       expect(retrieveOutput(db, older.id)).toBeNull();
     });
+
+    it("halves an item's weight at exactly one half-life", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const halfLife = 4;
+      const fresh = storeOutput(db, makeInput({ original_size: 300, summary: "fresh" }));
+      const aged = storeOutput(db, makeInput({ original_size: 300, summary: "aged" }));
+      // Both accessed once; 'aged' one half-life ago → recency 0.5 → score 1 vs fresh's 2.
+      db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ? WHERE id = ?").run(now, fresh.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ? WHERE id = ?").run(now - halfLife * day, aged.id);
+
+      evictIfNeeded(db, PROJECT_KEY, 0.0005, halfLife, now);
+
+      expect(retrieveOutput(db, fresh.id)).not.toBeNull();
+      expect(retrieveOutput(db, aged.id)).toBeNull();
+    });
+
+    it("breaks score + created_at ties deterministically by id", () => {
+      const now = 1_000_000_000;
+      const x = storeOutput(db, makeInput({ original_size: 300, summary: "x" }));
+      const y = storeOutput(db, makeInput({ original_size: 300, summary: "y" }));
+      // Identical score and created_at → only the id tiebreak decides.
+      for (const id of [x.id, y.id]) {
+        db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ?, created_at = ? WHERE id = ?").run(now - 10, now - 100, id);
+      }
+      const [smaller, larger] = [x.id, y.id].sort();
+
+      evictIfNeeded(db, PROJECT_KEY, 0.0005, 7, now); // sheds ~one item
+
+      expect(retrieveOutput(db, smaller)).toBeNull();
+      expect(retrieveOutput(db, larger)).not.toBeNull();
+    });
+
+    it("does not crash or NaN-rank when half_life_days is non-positive", () => {
+      const now = 1_000_000_000;
+      const a = storeOutput(db, makeInput({ original_size: 300, summary: "a" }));
+      const b = storeOutput(db, makeInput({ original_size: 300, summary: "b" }));
+      db.prepare("UPDATE stored_outputs SET access_count = 0, last_accessed = ? WHERE id = ?").run(now - 100, a.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 5, last_accessed = ? WHERE id = ?").run(now - 100, b.id);
+
+      let evicted = 0;
+      expect(() => {
+        evicted = evictIfNeeded(db, PROJECT_KEY, 0.0005, 0, now);
+      }).not.toThrow();
+      expect(evicted).toBeGreaterThan(0);
+    });
   });
 
   // -------------------------------------------------------------------------

--- a/tests/denylist.test.ts
+++ b/tests/denylist.test.ts
@@ -9,6 +9,7 @@ const baseConfig: RecallConfig = {
     max_size_mb: 500,
     pin_recommendation_threshold: 3,
     stale_item_days: 3,
+    eviction_half_life_days: 7,
   },
   retrieve: { default_max_bytes: 8192 },
   denylist: { additional: [], override_defaults: [], allowlist: [] },


### PR DESCRIPTION
## Summary

- Replaces pure-LFU eviction with a **recency-weighted frequency score**: `(access_count + 1)` decayed by an exponential half-life over time since last access (falling back to creation time for never-accessed items). The lowest-value non-pinned items are evicted first when the store exceeds `max_size_mb`.
- Why: pure LFU clings to an item hit many times early then abandoned, over a steadily-used recent one. Decay fixes that (Letta / am-memory style).
- Half-life configurable via **`store.eviction_half_life_days`** (default 7). Scoring runs in JS over the candidate set — **no SQLite math extension dependency**. `now_secs` is injectable for deterministic tests. Pinned items remain exempt.

## Test plan

- [x] New tests: decay keeps a recently-accessed item over an older heavily-accessed one (the LFU-divergence case); never-accessed items use creation time for recency
- [x] Existing eviction tests (under-limit, more-accessed-survives, pinned-exempt, all-pinned) still pass
- [x] `store.eviction_half_life_days` default asserted in config tests; denylist config fixture updated for the new required field
- [x] `bun run typecheck` clean · full suite: 691 pass, 0 fail
- [x] README `[store]` config documented

Closes #190
