### PR TITLE
docs: design specs for #187/#188/#189 (for sign-off)

### DIFF
--- a/tasks/specs/187-deterministic-fallback-compression.md
+++ b/tasks/specs/187-deterministic-fallback-compression.md
@@ -1,8 +1,8 @@
 # Spec: Deterministic fallback compression (#187)
 
-> Status: **DRAFT — awaiting sign-off.** No code until approved.
-> Decision (2026-07-23): **deterministic only, no LLM, no network.** Keeps the
-> zero-dependency, local-first, provider-agnostic guarantee intact.
+> Status: **APPROVED — build next (2026-07-23).** Deterministic-only, no LLM/network.
+> Fixed sensible window sizes (config deferred per YAGNI); scoped to the
+> auto-intercept fallback path. Keeps the zero-dependency, local-first guarantee.
 
 ## What
 

--- a/tasks/specs/187-deterministic-fallback-compression.md
+++ b/tasks/specs/187-deterministic-fallback-compression.md
@@ -1,0 +1,64 @@
+# Spec: Deterministic fallback compression (#187)
+
+> Status: **DRAFT — awaiting sign-off.** No code until approved.
+> Decision (2026-07-23): **deterministic only, no LLM, no network.** Keeps the
+> zero-dependency, local-first, provider-agnostic guarantee intact.
+
+## What
+
+Improve the summary quality for tool outputs that match **no** dedicated handler
+or profile and currently fall through to the generic `text`/`json` handlers,
+which essentially head-truncate. Replace naive truncation with a structure-aware
+deterministic summarizer.
+
+## Why
+
+The 15 handlers cover known tools well, but the long tail of unrecognized MCP
+outputs gets a low-value summary (first N chars). Better fallback summaries mean
+Claude retrieves less often and orients faster — the same goal as the dedicated
+handlers, extended to the tools we don't have a profile for yet. Doing this
+deterministically preserves the product's core "local, no API" invariant (the
+reason we rejected the opt-in-LLM alternative).
+
+## Success criteria
+
+- Unrecognized outputs get a summary that surfaces structure (shape, key lines,
+  head+tail, counts) rather than a blind prefix.
+- Zero new runtime dependencies; no network; fully deterministic (same input →
+  same summary), so it's unit-testable.
+- Never larger than the current fallback; measurable byte reduction on a sample
+  corpus of real unrecognized outputs.
+- Existing handler dispatch and all current tests unchanged.
+
+## Approach (proposed)
+
+A `fallbackSummarize(content)` that classifies the payload cheaply and applies a
+matching strategy:
+
+1. **Log / line-oriented** (many newlines): keep first K + last K lines, plus any
+   lines matching `error|warn|fail|exception` (capped), with an elided-count note.
+2. **Tabular / delimited** (consistent delimiters per line): header row + row
+   count + first few rows (defer to CSV handler heuristics where they already exist).
+3. **Deeply-nested JSON not caught upstream**: reuse the existing depth/array
+   truncation (already compact after #191).
+4. **Prose / unknown**: head + tail window with a middle-elision marker, instead
+   of head-only.
+
+Selection is a small ordered set of predicates; each strategy is a pure function
+with its own tests. Wire in as the `text` handler's replacement (or a pre-step
+before it) so dispatch order is unchanged.
+
+## Risks / trade-offs
+
+- Heuristic misclassification → a suboptimal (never incorrect) summary; mitigated
+  by always falling back to head+tail.
+- Scope creep toward re-implementing every handler; kept in check by only
+  handling the genuinely-unrecognized path.
+
+## Open questions for sign-off
+
+1. Head/tail window sizes and error-line cap — pick defaults or make them config?
+2. Should this also feed the `recall__note`/manual paths, or strictly the
+   auto-intercept fallback?
+3. Is a sample corpus of "unrecognized" outputs available to benchmark against,
+   or should I synthesize one?

--- a/tasks/specs/188-memory-tool-backend.md
+++ b/tasks/specs/188-memory-tool-backend.md
@@ -1,0 +1,61 @@
+# Spec: Anthropic memory-tool backend (#188)
+
+> Status: **DRAFT — awaiting sign-off.** No code until approved.
+> Larger scope (L). This is an expansion of the addressable surface, not a fix.
+
+## What
+
+Expose mcp-recall's SQLite+FTS store as a backend for Anthropic's
+**`memory_20250818`** tool, so any memory-tool-aware client (not just Claude Code
+via hooks) can persist and retrieve through recall.
+
+## Why
+
+Today mcp-recall reaches users only through the Claude Code PostToolUse hook. The
+memory tool is a GA, client-agnostic interface where the developer supplies the
+storage backend (`view`/`create`/`str_replace`/`insert`/`delete`/`rename` over a
+`/memories` namespace). Implementing that interface on top of the recall store
+makes mcp-recall usable as an FTS-backed memory layer from the Messages API,
+other agent runtimes, etc. — positioning it as the MCP-output layer that sits
+*ahead of* native compaction rather than a Claude-Code-only plugin.
+
+## Success criteria
+
+- A documented adapter that satisfies the `memory_20250818` command surface
+  against the recall SQLite store.
+- A non-Claude-Code client (e.g. a Messages API script) can create, read, edit,
+  and delete memory entries that persist across sessions via recall.
+- The existing hook-based pipeline is untouched and unaffected.
+- Local-first / zero-hosted-dependency posture preserved.
+
+## Approach (proposed, to be validated against the current tool contract)
+
+1. **Confirm the live contract first** (per repo policy: verify the SDK/tool
+   surface before coding). Pull the current `memory_20250818` command set and
+   payload shapes from platform docs; do not assume from memory.
+2. **Map the file model to the store.** The memory tool is path-oriented
+   (`/memories/<path>`); recall is id + FTS + project-scoped. Proposed mapping:
+   treat a memory path as a stable key (its own column or reuse `input_hash`
+   semantics), content as `full_content`, and surface `view` over a directory as
+   a listing. `str_replace`/`insert` edit `full_content` and re-chunk/re-index.
+3. **New entrypoint**, not a change to `server.ts`'s recall__ tools — a separate
+   adapter module + a thin CLI/exported handler so it composes without touching
+   the hook path.
+4. **Reuse** storeOutput/retrieve/search/forget; add only the path↔id mapping.
+
+## Risks / trade-offs
+
+- Impedance mismatch: the tool's mutable-file model vs recall's
+  append-and-retrieve model. Editing (`str_replace`) implies in-place mutation +
+  re-chunk + FTS refresh — more than the current write-once flow.
+- Contract drift: the tool is newer; the spec must be re-validated against live
+  docs at implementation time.
+- Scope: risk of half-implementing the surface. Define the minimal viable command
+  subset first (view/create/delete), defer edit ops if needed.
+
+## Open questions for sign-off
+
+1. Is broadening beyond the Claude Code plugin niche a direction you want now, or
+   park this until the in-plugin features settle?
+2. Minimum viable command subset for a first cut (view/create/delete only)?
+3. Path↔id mapping: new `mem_path` column vs a dedicated table — preference?

--- a/tasks/specs/188-memory-tool-backend.md
+++ b/tasks/specs/188-memory-tool-backend.md
@@ -1,7 +1,8 @@
 # Spec: Anthropic memory-tool backend (#188)
 
-> Status: **DRAFT — awaiting sign-off.** No code until approved.
-> Larger scope (L). This is an expansion of the addressable surface, not a fix.
+> Status: **DEFERRED (2026-07-23)** — not a no, a not-yet. Revisit when there's
+> real demand to use recall outside the Claude Code plugin. Larger scope (L);
+> an expansion of the addressable surface, not a fix.
 
 ## What
 

--- a/tasks/specs/189-hybrid-embeddings-retrieval.md
+++ b/tasks/specs/189-hybrid-embeddings-retrieval.md
@@ -1,8 +1,8 @@
 # Spec: Optional local hybrid FTS + embeddings retrieval (#189)
 
-> Status: **DRAFT — awaiting sign-off.** No code until approved.
-> Decision (2026-07-23): **spec first, decide the backend before building.**
-> Larger scope (L); directly touches the zero-dependency pitch.
+> Status: **DEFERRED (2026-07-23)** — build only once a real semantic-miss is
+> observed that FTS + shipped hints (#185) + peek (#186) don't cover. If built:
+> option C (brute-force cosine, no native extension), default-off. Larger scope (L).
 
 ## What
 

--- a/tasks/specs/189-hybrid-embeddings-retrieval.md
+++ b/tasks/specs/189-hybrid-embeddings-retrieval.md
@@ -1,0 +1,65 @@
+# Spec: Optional local hybrid FTS + embeddings retrieval (#189)
+
+> Status: **DRAFT — awaiting sign-off.** No code until approved.
+> Decision (2026-07-23): **spec first, decide the backend before building.**
+> Larger scope (L); directly touches the zero-dependency pitch.
+
+## What
+
+Add an **optional, local, default-off** semantic retrieval layer that combines
+the existing FTS5 (BM25-ish) keyword search with vector similarity, so
+`recall__search` catches matches where the query and stored content share meaning
+but not exact tokens.
+
+## Why
+
+FTS5 is keyword-exact. For DOM snapshots, prose, and paraphrased queries, the
+right item is often missed because the query words don't literally appear. mem0 /
+am-memory / RAG-MCP all use hybrid keyword+vector for exactly this. Retrieval
+hints (#185) and the peek tier (#186) reduce the cost of a *hit*; embeddings
+increase the *hit rate*.
+
+## Success criteria
+
+- Hybrid (keyword + vector) scoring available behind a config flag, **off by
+  default**.
+- With the flag off, behavior, dependencies, and install footprint are **identical
+  to today** — the zero-dependency, local-only guarantee is untouched.
+- With the flag on, everything still runs **locally** (no hosted embedding API).
+- A benchmark on a prose/DOM sample shows measurably higher recall than FTS-only.
+
+## Approach — backend options to decide (the core of this spec)
+
+Vector storage + embedding generation must both stay local. Candidates:
+
+| Option | Vector store | Embeddings | Footprint / risk |
+|---|---|---|---|
+| **A. `sqlite-vec` + local ONNX model** | `sqlite-vec` extension loaded into bun:sqlite | small model (e.g. all-MiniLM) via ONNX runtime | Needs a loadable extension + a model file download on opt-in; verify bun:sqlite `loadExtension` support |
+| **B. `sqlite-vec` + `transformers.js`** | `sqlite-vec` | `@huggingface/transformers` (WASM) | Pure-JS embeddings, no native ONNX; larger JS dep, slower first run |
+| **C. In-table vectors + JS cosine** | plain SQLite BLOB column, brute-force cosine in JS | either of the above | No extension dependency; O(n) scan — fine at recall's corpus sizes, simplest to ship |
+
+Leaning **C for v1** (no native extension dependency, smallest blast radius; brute-force
+cosine over a project's bounded item set is cheap) with the embedding model as the
+only opt-in download. A/B become an optimization if corpus sizes grow.
+
+Hybrid score = weighted blend of normalized FTS rank and cosine similarity
+(weight configurable); fuse then re-rank the top candidates.
+
+## Risks / trade-offs
+
+- **Dependency footprint** is the whole tension — even opt-in, adding an embedding
+  model/runtime changes the project's character. Must be genuinely isolated to the
+  flag-on path (lazy import, model fetched only when enabled).
+- `bun:sqlite` extension-loading support for `sqlite-vec` is unverified — option C
+  sidesteps it.
+- Embedding model download size + first-run latency; index must be built/backfilled
+  for existing items.
+- Determinism: vector scores are model-dependent; tests pin a model + fixtures.
+
+## Open questions for sign-off
+
+1. Is any embedding-model download acceptable on opt-in, or must "local" also mean
+   "no download" (which would rule embeddings out entirely)?
+2. Option **C (brute-force cosine, no extension)** as the v1 target — agree?
+3. Ship this at all, or is FTS + hints (#185) + peek (#186) sufficient and #189
+   should be closed? (Reasonable to defer until a real recall-miss is observed.)


### PR DESCRIPTION
## Summary

Draft design specs for the three roadmap items we agreed to **spec before building**. No code — these exist to get your sign-off (and to record the decisions already made) before any implementation.

- **#187** — deterministic fallback compression. Records the decision to stay **LLM-free / zero-dependency** and proposes a structure-aware summarizer for outputs no handler recognizes.
- **#188** — expose mcp-recall as an Anthropic `memory_20250818` backend. Larger scope; flags the file-model↔store impedance mismatch and proposes a minimal-viable command subset.
- **#189** — optional local hybrid FTS + embeddings. Lays out three backend options and leans toward brute-force cosine (no native extension) for v1, default-off.

Each spec ends with **open questions for sign-off**. Review inline or on the files under `tasks/specs/`.

## Test plan

- [ ] Docs-only — no code paths touched
- [ ] Decide per-spec: approve / adjust scope / defer or close

Refs #187, #188, #189
