### PR TITLE
feat: DB lifecycle hardening — gc, free-page reclamation, pin-budget stats

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -11,6 +11,7 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 - **`mcp-recall gc` command** — reclaims disk from the per-project database store. Lists every project DB with a status (active / orphaned / legacy) and its reclaimable size; deletes orphaned DBs (recorded project path no longer exists on disk) and stale legacy DBs on `--force`. Defaults to a dry run. Flags: `--force`, `--stale-days N` (default 90), `--vacuum` (full-VACUUM survivors to reclaim free pages and upgrade legacy `auto_vacuum=NONE` databases). The active project's DB is never a deletion candidate (#200)
 - **Project-path metadata** — session start records the resolved project path in a per-DB `meta` table, enabling orphan detection in `gc` (#200)
 - **Pin-budget awareness in `recall__stats`** — reports pinned item count and pinned bytes, and warns when pinned data (which is exempt from eviction) reaches a high fraction of the `store.max_size_mb` cap (#200)
+- **Store-maintenance reminder** — when the on-disk store grows past `store.gc_reminder_mb` (default 2048; 0 disables), session start injects a one-line hint to run `mcp-recall gc`, and `mcp-recall status` shows the store's total size and database count. Detection is a cheap `stat` (no databases opened); nothing is ever deleted automatically (#200)
 
 ### Fixed
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,16 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Added
+
+- **`mcp-recall gc` command** — reclaims disk from the per-project database store. Lists every project DB with a status (active / orphaned / legacy) and its reclaimable size; deletes orphaned DBs (recorded project path no longer exists on disk) and stale legacy DBs on `--force`. Defaults to a dry run. Flags: `--force`, `--stale-days N` (default 90), `--vacuum` (full-VACUUM survivors to reclaim free pages and upgrade legacy `auto_vacuum=NONE` databases). The active project's DB is never a deletion candidate (#200)
+- **Project-path metadata** — session start records the resolved project path in a per-DB `meta` table, enabling orphan detection in `gc` (#200)
+- **Pin-budget awareness in `recall__stats`** — reports pinned item count and pinned bytes, and warns when pinned data (which is exempt from eviction) reaches a high fraction of the `store.max_size_mb` cap (#200)
+
+### Fixed
+
+- **Free pages are now reclaimed after automatic deletes** — `evictIfNeeded` and the session-start prune invoke `incremental_vacuum` (previously only manual `recall__forget` did), so routine eviction returns disk to the OS on `auto_vacuum=INCREMENTAL` databases (#200)
+
 ---
 
 ## [1.9.0] — 2026-07-23

--- a/README.md
+++ b/README.md
@@ -232,6 +232,32 @@ mcp-recall profiles update
 
 ---
 
+## Maintenance
+
+mcp-recall keeps a separate SQLite database per project under `~/.local/share/mcp-recall/`. Over time, projects you delete leave their databases behind, and databases accumulate free pages. `mcp-recall gc` reclaims both:
+
+```bash
+# Review what would be reclaimed — dry run, deletes nothing
+mcp-recall gc
+
+# Actually delete orphaned + stale databases
+mcp-recall gc --force
+
+# Also compact the databases you keep (reclaims free pages;
+# rewrites each file, so it can take a moment on a large store)
+mcp-recall gc --force --vacuum
+```
+
+Each database is classified by whether its recorded project path still exists on disk:
+
+- **orphaned** — the project directory is gone; safe to delete.
+- **legacy** — created before path tracking; only a deletion candidate once untouched longer than `--stale-days N` (default 90).
+- **active** / **current** — kept; the current project's database is never deleted.
+
+The active project's database is always protected. When the store grows past `store.gc_reminder_mb` (default 2 GB), session start injects a one-line reminder to run `gc`, and `mcp-recall status` shows the store's size. There's no automatic deletion — reclaiming is always an explicit command.
+
+---
+
 ## Profiles
 
 Profiles teach mcp-recall how to compress output from specific MCPs. Four profiles ship built in (Jira, Gmail, Context7, Docker). **[18 community profiles](https://github.com/sakebomb/mcp-recall-profiles)** cover Grafana, Shopify, Notion, and more.
@@ -294,6 +320,11 @@ stale_item_days = 3
 # used recent item outranks one accessed many times but long ago. Lower =
 # recency matters more; higher = frequency dominates. Pinned items are exempt.
 eviction_half_life_days = 7
+
+# When the on-disk store (all project databases combined) grows past this many
+# megabytes, session start injects a one-line reminder to run `mcp-recall gc`.
+# Set to 0 to disable the reminder. Detection is cheap (no databases are opened).
+gc_reminder_mb = 2048
 
 [retrieve]
 # Max bytes returned by recall__retrieve(mode: "full").

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5152,6 +5152,9 @@ function getProjectKey(cwd) {
   const resolved = resolveProjectPath(cwd);
   return hashPath(resolved);
 }
+function getProjectPath(cwd) {
+  return resolveProjectPath(cwd);
+}
 function resolveProjectPath(cwd) {
   const cached2 = pathCache.get(cwd);
   if (cached2 !== undefined)
@@ -5170,7 +5173,7 @@ function hashPath(path) {
 }
 // src/db/schema.ts
 import { Database } from "bun:sqlite";
-import { join as join2 } from "path";
+import { join as join2, dirname } from "path";
 import { homedir as homedir2 } from "os";
 import { mkdirSync } from "fs";
 var SCHEMA = `
@@ -5224,6 +5227,11 @@ var SCHEMA = `
   CREATE TABLE IF NOT EXISTS sessions (
     date TEXT PRIMARY KEY
   );
+
+  CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
 `;
 var MIGRATIONS = [
   "ALTER TABLE stored_outputs ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
@@ -5247,6 +5255,12 @@ function applyMigrations(db) {
 var instance = null;
 function defaultDbPath(projectKey) {
   return process.env.RECALL_DB_PATH ?? join2(homedir2(), ".local", "share", "mcp-recall", `${projectKey}.db`);
+}
+function dataDir() {
+  const override = process.env.RECALL_DB_PATH;
+  if (override)
+    return dirname(override);
+  return join2(homedir2(), ".local", "share", "mcp-recall");
 }
 function getDb(path) {
   if (instance)
@@ -5296,6 +5310,24 @@ function countAndDelete(db, where, params) {
     db.prepare(`DELETE FROM stored_outputs WHERE ${where}`).run(...params);
   }
   return count;
+}
+var VACUUM_THRESHOLD = 50;
+function reclaimPages(db, deleted) {
+  if (deleted < VACUUM_THRESHOLD)
+    return;
+  try {
+    db.run("PRAGMA incremental_vacuum");
+  } catch (e) {
+    log.warn(`incremental_vacuum failed \u2014 ${e instanceof Error ? e.message : e}`);
+  }
+}
+function setMeta(db, key, value) {
+  db.prepare(`INSERT INTO meta (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`).run(key, value);
+}
+function getMeta(db, key) {
+  const row = db.prepare(`SELECT value FROM meta WHERE key = ?`).get(key);
+  return row?.value ?? null;
 }
 function storeOutput(db, input) {
   const id = generateId();
@@ -5380,11 +5412,14 @@ function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EV
   }
   const placeholders = toEvict.map(() => "?").join(",");
   db.prepare(`DELETE FROM stored_outputs WHERE id IN (${placeholders})`).run(...toEvict);
+  reclaimPages(db, toEvict.length);
   return toEvict.length;
 }
 function pruneExpired(db, project_key, calendar_days) {
   const cutoff = Math.floor(Date.now() / 1000) - calendar_days * 86400;
-  return countAndDelete(db, "created_at < ? AND project_key = ? AND pinned = 0", [cutoff, project_key]);
+  const deleted = countAndDelete(db, "created_at < ? AND project_key = ? AND pinned = 0", [cutoff, project_key]);
+  reclaimPages(db, deleted);
+  return deleted;
 }
 function recordSession(db, date) {
   db.prepare(`INSERT OR IGNORE INTO sessions (date) VALUES (?)`).run(date);
@@ -5638,6 +5673,7 @@ function handleSessionStart(raw) {
   const config = loadConfig();
   const projectKey = getProjectKey(input.cwd);
   const db = getDb(defaultDbPath(projectKey));
+  setMeta(db, "project_path", getProjectPath(input.cwd));
   const today = new Date().toISOString().slice(0, 10);
   recordSession(db, today);
   pruneExpired(db, projectKey, config.store.expire_after_session_days);
@@ -10076,6 +10112,168 @@ Installation: ${BOLD}${label}${RESET}
   console.log("");
 }
 
+// src/gc/index.ts
+import { Database as Database3 } from "bun:sqlite";
+import { readdirSync as readdirSync4, existsSync as existsSync3, statSync as statSync3, rmSync as rmSync2 } from "fs";
+import { join as join8, basename } from "path";
+var DEFAULT_STALE_DAYS = 90;
+function isDeletionCandidate(status) {
+  return status === "orphaned" || status === "legacy-stale";
+}
+function fileSizeSafe(path2) {
+  try {
+    return statSync3(path2).size;
+  } catch {
+    return 0;
+  }
+}
+function dbFootprint(file) {
+  return fileSizeSafe(file) + fileSizeSafe(`${file}-wal`) + fileSizeSafe(`${file}-shm`);
+}
+function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
+  if (!existsSync3(dir))
+    return [];
+  const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
+  const entries = [];
+  for (const name of readdirSync4(dir)) {
+    if (!name.endsWith(".db"))
+      continue;
+    const file = join8(dir, name);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = statSync3(file).mtimeMs;
+    } catch {
+      continue;
+    }
+    const sizeBytes = dbFootprint(file);
+    if (file === currentFile) {
+      entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
+      continue;
+    }
+    let projectPath = null;
+    let items = 0;
+    let readable = true;
+    let db = null;
+    try {
+      db = new Database3(file, { readonly: true });
+      try {
+        projectPath = getMeta(db, "project_path");
+      } catch {
+        projectPath = null;
+      }
+      try {
+        items = db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get().n;
+      } catch {
+        items = 0;
+      }
+    } catch {
+      readable = false;
+    } finally {
+      db?.close();
+    }
+    let status;
+    if (!readable) {
+      status = "unreadable";
+    } else if (projectPath !== null) {
+      status = existsSync3(projectPath) ? "active" : "orphaned";
+    } else {
+      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
+    }
+    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
+  }
+  return entries.sort((a, b) => b.sizeBytes - a.sizeBytes);
+}
+var STATUS_LABEL = {
+  current: "current",
+  active: "active",
+  orphaned: "ORPHANED",
+  "legacy-fresh": "legacy",
+  "legacy-stale": "LEGACY-STALE",
+  unreadable: "unreadable"
+};
+function reportLine(e, nowMs) {
+  const flag = isDeletionCandidate(e.status) ? "\u2717" : " ";
+  const age = formatRelativeTime(nowMs - e.mtimeMs);
+  const where = e.projectPath ?? "(no recorded path)";
+  return `  ${flag} ${STATUS_LABEL[e.status].padEnd(13)} ${formatBytes(e.sizeBytes).padStart(9)}` + `  ${String(e.items).padStart(6)} items  ${age.padEnd(14)}  ${basename(e.file)}
+` + `      ${where}`;
+}
+function vacuumFile(file) {
+  const before = dbFootprint(file);
+  let db = null;
+  try {
+    db = new Database3(file);
+    db.run("PRAGMA busy_timeout=5000");
+    db.run("PRAGMA auto_vacuum=INCREMENTAL");
+    db.run("VACUUM");
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+  return { before, after: dbFootprint(file) };
+}
+function deleteDbFiles(file) {
+  for (const f of [file, `${file}-wal`, `${file}-shm`]) {
+    rmSync2(f, { force: true });
+  }
+}
+function gcCommand(opts = {}) {
+  const dryRun = opts.dryRun ?? true;
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const nowMs = Date.now();
+  const dir = dataDir();
+  const currentFile = defaultDbPath(getProjectKey(process.cwd()));
+  const entries = scanDatabases(dir, currentFile, staleDays, nowMs);
+  if (entries.length === 0) {
+    console.log(`No databases found in ${dir}`);
+    return;
+  }
+  const candidates = entries.filter((e) => isDeletionCandidate(e.status));
+  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
+  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+  console.log(`Project databases in ${dir}:
+`);
+  for (const e of entries)
+    console.log(reportLine(e, nowMs));
+  console.log(`
+${entries.length} databases \xB7 ${formatBytes(totalBytes)} total \xB7 ` + `${candidates.length} reclaimable (${formatBytes(reclaimable)})`);
+  console.log(`  Orphaned = project path deleted \xB7 LEGACY-STALE = no recorded path, ` + `untouched > ${staleDays}d (raise/lower with --stale-days N)`);
+  if (dryRun) {
+    if (candidates.length > 0) {
+      console.log(`
+Dry run \u2014 pass --force to delete the ${candidates.length} marked database(s).`);
+    }
+  } else {
+    let freed = 0;
+    for (const e of candidates) {
+      deleteDbFiles(e.file);
+      freed += e.sizeBytes;
+    }
+    console.log(`
+Deleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
+  }
+  if (opts.vacuum) {
+    const deleted = new Set(dryRun ? [] : candidates.map((e) => e.file));
+    const survivors = entries.filter((e) => e.status !== "current" && e.status !== "unreadable" && !deleted.has(e.file));
+    let reclaimed = 0;
+    let vacuumed = 0;
+    let skipped = 0;
+    for (const e of survivors) {
+      const result = vacuumFile(e.file);
+      if (result) {
+        reclaimed += Math.max(0, result.before - result.after);
+        vacuumed++;
+      } else {
+        skipped++;
+        console.log(`  skipped ${basename(e.file)} \u2014 locked by another session or unreadable`);
+      }
+    }
+    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+    console.log(`Vacuumed ${vacuumed} database(s), reclaimed ${formatBytes(reclaimed)} of free pages.${skipNote}`);
+  }
+}
+
 // src/cli.ts
 async function getVersion() {
   const pkg = await Promise.resolve().then(() => __toESM(require_package(), 1));
@@ -10091,6 +10289,9 @@ Commands:
   install              Register hooks + MCP server in Claude Code
   uninstall            Remove hooks + MCP server
   status               Show current configuration and health
+  gc [--force]         Reclaim disk: list/delete orphaned project DBs
+    --stale-days N     Legacy DBs (no recorded path) older than N days are candidates (default 90)
+    --vacuum           Full-VACUUM surviving DBs to reclaim free pages
   profiles <cmd>       Manage compression profiles
     seed [--all]       Install profiles for detected MCPs (--all for entire catalog)
     list               Show installed profiles
@@ -10137,7 +10338,7 @@ _mcp_recall() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
 
-  local commands="install uninstall status profiles learn completions --help --version"
+  local commands="install uninstall status gc profiles learn completions --help --version"
   local profiles_cmds="list install update remove seed feed check retrain test"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
@@ -10221,6 +10422,7 @@ _mcp_recall() {
         'install:register hooks and MCP server in Claude Code'
         'uninstall:remove hooks and MCP server'
         'status:show current configuration and health'
+        'gc:reclaim disk from orphaned project databases'
         'profiles:manage compression profiles'
         'learn:generate profile suggestions from session data'
         'completions:print shell completion script (bash, zsh, fish)'
@@ -10248,7 +10450,7 @@ function fishCompletion() {
   return `# mcp-recall fish completions
 # Save to: mcp-recall completions fish > ~/.config/fish/completions/mcp-recall.fish
 
-set -l commands install uninstall status profiles learn completions
+set -l commands install uninstall status gc profiles learn completions
 
 # Top-level commands
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
@@ -10257,6 +10459,8 @@ complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
   -a uninstall -d "Remove hooks and MCP server"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
   -a status -d "Show current configuration and health"
+complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
+  -a gc -d "Reclaim disk from orphaned project databases"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
   -a profiles -d "Manage compression profiles"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from $commands" \\
@@ -10355,6 +10559,20 @@ async function main() {
   }
   if (subcommand === "status") {
     await statusCommand();
+    process.exit(0);
+  }
+  if (subcommand === "gc") {
+    const staleIdx = process.argv.indexOf("--stale-days");
+    const staleDays = staleIdx !== -1 && process.argv[staleIdx + 1] ? Number(process.argv[staleIdx + 1]) : undefined;
+    if (staleDays !== undefined && (!Number.isFinite(staleDays) || staleDays < 1)) {
+      console.error("--stale-days must be a positive number");
+      process.exit(1);
+    }
+    gcCommand({
+      dryRun: !process.argv.includes("--force"),
+      vacuum: process.argv.includes("--vacuum"),
+      staleDays
+    });
     process.exit(0);
   }
   const raw = await Bun.stdin.text();

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -10120,6 +10120,9 @@ var DEFAULT_STALE_DAYS = 90;
 function isDeletionCandidate(status) {
   return status === "orphaned" || status === "legacy-stale";
 }
+function vacuumTargets(entries) {
+  return entries.filter((e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable");
+}
 function fileSizeSafe(path2) {
   try {
     return statSync3(path2).size;
@@ -10254,19 +10257,25 @@ Dry run \u2014 pass --force to delete the ${candidates.length} marked database(s
 Deleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
   }
   if (opts.vacuum) {
-    const deleted = new Set(dryRun ? [] : candidates.map((e) => e.file));
-    const survivors = entries.filter((e) => e.status !== "current" && e.status !== "unreadable" && !deleted.has(e.file));
+    const survivors = vacuumTargets(entries);
+    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
+    console.log(`
+Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) \u2014 ` + `rewrites each file, may take a while\u2026`);
     let reclaimed = 0;
     let vacuumed = 0;
     let skipped = 0;
-    for (const e of survivors) {
+    for (let i = 0;i < survivors.length; i++) {
+      const e = survivors[i];
+      process.stdout.write(`  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})\u2026 `);
       const result = vacuumFile(e.file);
       if (result) {
-        reclaimed += Math.max(0, result.before - result.after);
+        const freed = Math.max(0, result.before - result.after);
+        reclaimed += freed;
         vacuumed++;
+        console.log(`reclaimed ${formatBytes(freed)}`);
       } else {
         skipped++;
-        console.log(`  skipped ${basename(e.file)} \u2014 locked by another session or unreadable`);
+        console.log(`skipped \u2014 locked by another session or unreadable`);
       }
     }
     const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5061,7 +5061,8 @@ var RecallConfigSchema = exports_external.object({
     max_size_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
-    eviction_half_life_days: exports_external.number().positive()
+    eviction_half_life_days: exports_external.number().positive(),
+    gc_reminder_mb: exports_external.number().nonnegative()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -5086,7 +5087,8 @@ var DEFAULTS = {
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
-    eviction_half_life_days: 7
+    eviction_half_life_days: 7,
+    gc_reminder_mb: 2048
   },
   retrieve: {
     default_max_bytes: 8192
@@ -5655,7 +5657,199 @@ function toolContext(db, projectKey, args) {
 `);
 }
 
+// src/gc/index.ts
+import { Database as Database2 } from "bun:sqlite";
+import { readdirSync, existsSync, statSync, rmSync } from "fs";
+import { join as join3, basename } from "path";
+var DEFAULT_STALE_DAYS = 90;
+function isDeletionCandidate(status) {
+  return status === "orphaned" || status === "legacy-stale";
+}
+function vacuumTargets(entries) {
+  return entries.filter((e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable");
+}
+function fileSizeSafe(path) {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+function dbFootprint(file) {
+  return fileSizeSafe(file) + fileSizeSafe(`${file}-wal`) + fileSizeSafe(`${file}-shm`);
+}
+function storeFootprint(dir = dataDir()) {
+  if (!existsSync(dir))
+    return { totalBytes: 0, dbCount: 0 };
+  let totalBytes = 0;
+  let dbCount = 0;
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".db"))
+      continue;
+    dbCount++;
+    totalBytes += dbFootprint(join3(dir, name));
+  }
+  return { totalBytes, dbCount };
+}
+function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
+  if (!existsSync(dir))
+    return [];
+  const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
+  const entries = [];
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".db"))
+      continue;
+    const file = join3(dir, name);
+    let mtimeMs = 0;
+    try {
+      mtimeMs = statSync(file).mtimeMs;
+    } catch {
+      continue;
+    }
+    const sizeBytes = dbFootprint(file);
+    if (file === currentFile) {
+      entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
+      continue;
+    }
+    let projectPath = null;
+    let items = 0;
+    let readable = true;
+    let db = null;
+    try {
+      db = new Database2(file, { readonly: true });
+      try {
+        projectPath = getMeta(db, "project_path");
+      } catch {
+        projectPath = null;
+      }
+      try {
+        items = db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get().n;
+      } catch {
+        items = 0;
+      }
+    } catch {
+      readable = false;
+    } finally {
+      db?.close();
+    }
+    let status;
+    if (!readable) {
+      status = "unreadable";
+    } else if (projectPath !== null) {
+      status = existsSync(projectPath) ? "active" : "orphaned";
+    } else {
+      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
+    }
+    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
+  }
+  return entries.sort((a, b) => b.sizeBytes - a.sizeBytes);
+}
+var STATUS_LABEL = {
+  current: "current",
+  active: "active",
+  orphaned: "ORPHANED",
+  "legacy-fresh": "legacy",
+  "legacy-stale": "LEGACY-STALE",
+  unreadable: "unreadable"
+};
+function reportLine(e, nowMs) {
+  const flag = isDeletionCandidate(e.status) ? "\u2717" : " ";
+  const age = formatRelativeTime(nowMs - e.mtimeMs);
+  const where = e.projectPath ?? "(no recorded path)";
+  return `  ${flag} ${STATUS_LABEL[e.status].padEnd(13)} ${formatBytes(e.sizeBytes).padStart(9)}` + `  ${String(e.items).padStart(6)} items  ${age.padEnd(14)}  ${basename(e.file)}
+` + `      ${where}`;
+}
+function vacuumFile(file) {
+  const before = dbFootprint(file);
+  let db = null;
+  try {
+    db = new Database2(file);
+    db.run("PRAGMA busy_timeout=5000");
+    db.run("PRAGMA auto_vacuum=INCREMENTAL");
+    db.run("VACUUM");
+  } catch {
+    return null;
+  } finally {
+    db?.close();
+  }
+  return { before, after: dbFootprint(file) };
+}
+function deleteDbFiles(file) {
+  for (const f of [file, `${file}-wal`, `${file}-shm`]) {
+    rmSync(f, { force: true });
+  }
+}
+function gcCommand(opts = {}) {
+  const dryRun = opts.dryRun ?? true;
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const nowMs = Date.now();
+  const dir = dataDir();
+  const currentFile = defaultDbPath(getProjectKey(process.cwd()));
+  const entries = scanDatabases(dir, currentFile, staleDays, nowMs);
+  if (entries.length === 0) {
+    console.log(`No databases found in ${dir}`);
+    return;
+  }
+  const candidates = entries.filter((e) => isDeletionCandidate(e.status));
+  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
+  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+  console.log(`Project databases in ${dir}:
+`);
+  for (const e of entries)
+    console.log(reportLine(e, nowMs));
+  console.log(`
+${entries.length} databases \xB7 ${formatBytes(totalBytes)} total \xB7 ` + `${candidates.length} reclaimable (${formatBytes(reclaimable)})`);
+  console.log(`  Orphaned = project path deleted \xB7 LEGACY-STALE = no recorded path, ` + `untouched > ${staleDays}d (raise/lower with --stale-days N)`);
+  if (dryRun) {
+    if (candidates.length > 0) {
+      console.log(`
+Dry run \u2014 pass --force to delete the ${candidates.length} marked database(s).`);
+    }
+  } else {
+    let freed = 0;
+    for (const e of candidates) {
+      deleteDbFiles(e.file);
+      freed += e.sizeBytes;
+    }
+    console.log(`
+Deleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
+  }
+  if (opts.vacuum) {
+    const survivors = vacuumTargets(entries);
+    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
+    console.log(`
+Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) \u2014 ` + `rewrites each file, may take a while\u2026`);
+    let reclaimed = 0;
+    let vacuumed = 0;
+    let skipped = 0;
+    for (let i = 0;i < survivors.length; i++) {
+      const e = survivors[i];
+      process.stdout.write(`  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})\u2026 `);
+      const result = vacuumFile(e.file);
+      if (result) {
+        const freed = Math.max(0, result.before - result.after);
+        reclaimed += freed;
+        vacuumed++;
+        console.log(`reclaimed ${formatBytes(freed)}`);
+      } else {
+        skipped++;
+        console.log(`skipped \u2014 locked by another session or unreadable`);
+      }
+    }
+    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+    console.log(`Vacuumed ${vacuumed} database(s), reclaimed ${formatBytes(reclaimed)} of free pages.${skipNote}`);
+  }
+}
+
 // src/hooks/session-start.ts
+function gcReminder(reminderMb) {
+  if (reminderMb <= 0)
+    return "";
+  const { totalBytes, dbCount } = storeFootprint();
+  if (totalBytes < reminderMb * 1024 * 1024)
+    return "";
+  return `\uD83D\uDCA1 recall store is ${formatBytes(totalBytes)} across ${dbCount} project ` + `databases \u2014 run \`mcp-recall gc\` to review and reclaim disk space.`;
+}
 var INJECT_MAX_CHARS = 2000;
 function handleSessionStart(raw) {
   let parsed;
@@ -5677,17 +5871,27 @@ function handleSessionStart(raw) {
   const today = new Date().toISOString().slice(0, 10);
   recordSession(db, today);
   pruneExpired(db, projectKey, config.store.expire_after_session_days);
+  const parts = [];
+  const reminder = gcReminder(config.store.gc_reminder_mb);
+  if (reminder)
+    parts.push(reminder);
   let snapshot = toolContext(db, projectKey, {});
-  if (snapshot === CONTEXT_EMPTY_RESPONSE) {
-    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 nothing to inject`);
-  } else {
+  if (snapshot !== CONTEXT_EMPTY_RESPONSE) {
     if (snapshot.length > INJECT_MAX_CHARS) {
       snapshot = snapshot.slice(0, INJECT_MAX_CHARS) + `
 \u2026 (truncated \u2014 call recall__context for the full view)`;
     }
-    process.stdout.write(snapshot + `
+    parts.push(snapshot);
+  }
+  if (parts.length === 0) {
+    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 nothing to inject`);
+  } else {
+    const out = parts.join(`
+
 `);
-    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 injected ${snapshot.length} chars`);
+    process.stdout.write(out + `
+`);
+    log.debug(`session-start \xB7 project=${projectKey.slice(0, 8)} \xB7 injected ${out.length} chars`);
   }
 }
 
@@ -7511,23 +7715,23 @@ var genericHandler = (_toolName, output) => {
 };
 
 // src/profiles/loader.ts
-import { readdirSync, readFileSync as readFileSync2, statSync } from "fs";
-import { join as join3 } from "path";
+import { readdirSync as readdirSync2, readFileSync as readFileSync2, statSync as statSync2 } from "fs";
+import { join as join4 } from "path";
 import { homedir as homedir3 } from "os";
 function getUserProfilesDir() {
-  return process.env.RECALL_USER_PROFILES_PATH ?? join3(homedir3(), ".config", "mcp-recall", "profiles");
+  return process.env.RECALL_USER_PROFILES_PATH ?? join4(homedir3(), ".config", "mcp-recall", "profiles");
 }
 function getCommunityProfilesDir() {
-  return process.env.RECALL_COMMUNITY_PROFILES_PATH ?? join3(homedir3(), ".local", "share", "mcp-recall", "profiles", "community");
+  return process.env.RECALL_COMMUNITY_PROFILES_PATH ?? join4(homedir3(), ".local", "share", "mcp-recall", "profiles", "community");
 }
 function getBundledProfilesDir() {
   if (process.env.RECALL_BUNDLED_PROFILES_PATH) {
     return process.env.RECALL_BUNDLED_PROFILES_PATH;
   }
-  const devPath = join3(import.meta.dir, "../../profiles");
-  const distPath = join3(import.meta.dir, "../profiles");
+  const devPath = join4(import.meta.dir, "../../profiles");
+  const distPath = join4(import.meta.dir, "../profiles");
   try {
-    statSync(devPath);
+    statSync2(devPath);
     return devPath;
   } catch (e) {
     if (e.code !== "ENOENT")
@@ -7539,7 +7743,7 @@ var fileCache = new Map;
 function loadSpec(filePath) {
   let mtime;
   try {
-    mtime = statSync(filePath).mtimeMs;
+    mtime = statSync2(filePath).mtimeMs;
   } catch {
     fileCache.delete(filePath);
     return null;
@@ -7613,16 +7817,16 @@ function validateSpec(raw, filePath) {
 function scanDir(dir, tier) {
   let entries;
   try {
-    entries = readdirSync(dir);
+    entries = readdirSync2(dir);
   } catch {
     return [];
   }
   const results = [];
   for (const entry of entries) {
-    const full = join3(dir, entry);
+    const full = join4(dir, entry);
     let stat;
     try {
-      stat = statSync(full);
+      stat = statSync2(full);
     } catch {
       continue;
     }
@@ -8340,12 +8544,12 @@ ${"\u2500".repeat(54)}`);
 }
 
 // src/profiles/cmd-local.ts
-import { readFileSync as readFileSync5, readdirSync as readdirSync3, rmSync } from "fs";
-import { join as join5 } from "path";
+import { readFileSync as readFileSync5, readdirSync as readdirSync4, rmSync as rmSync2 } from "fs";
+import { join as join6 } from "path";
 
 // src/profiles/shared.ts
-import { readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, readdirSync as readdirSync2, unlinkSync } from "fs";
-import { join as join4 } from "path";
+import { readFileSync as readFileSync4, writeFileSync as writeFileSync2, mkdirSync as mkdirSync2, readdirSync as readdirSync3, unlinkSync } from "fs";
+import { join as join5 } from "path";
 import { homedir as homedir4, tmpdir } from "os";
 import { createHash as createHash4 } from "crypto";
 var MANIFEST_URL = "https://raw.githubusercontent.com/sakebomb/mcp-recall-profiles/main/manifest.json";
@@ -8367,10 +8571,10 @@ function sanitize(value) {
   return value.replace(/[\x00-\x1F\x7F]|\x9B|\x1B\[[0-9;]*[a-zA-Z]/g, "");
 }
 function communityDir() {
-  return process.env.RECALL_COMMUNITY_PROFILES_PATH ?? join4(homedir4(), ".local", "share", "mcp-recall", "profiles", "community");
+  return process.env.RECALL_COMMUNITY_PROFILES_PATH ?? join5(homedir4(), ".local", "share", "mcp-recall", "profiles", "community");
 }
 function userDir() {
-  return process.env.RECALL_USER_PROFILES_PATH ?? join4(homedir4(), ".config", "mcp-recall", "profiles");
+  return process.env.RECALL_USER_PROFILES_PATH ?? join5(homedir4(), ".config", "mcp-recall", "profiles");
 }
 function manifestShortName(e) {
   return e.short_name ?? e.id.replace(/^mcp__/, "");
@@ -8420,7 +8624,7 @@ async function fetchManifest(skipVerify = false) {
     throw new Error(`manifest fetch failed: ${res.status} ${res.statusText}`);
   const text = await res.text();
   if (!skipVerify) {
-    const tmpPath = join4(tmpdir(), `mcp-recall-manifest-${process.pid}.json`);
+    const tmpPath = join5(tmpdir(), `mcp-recall-manifest-${process.pid}.json`);
     try {
       writeFileSync2(tmpPath, text, "utf8");
       const config = loadConfig();
@@ -8435,9 +8639,9 @@ async function fetchManifest(skipVerify = false) {
   return data.profiles;
 }
 function saveToCommunityDir(profileId, content) {
-  const dir = join4(communityDir(), profileId);
+  const dir = join5(communityDir(), profileId);
   mkdirSync2(dir, { recursive: true });
-  const filePath = join4(dir, "default.toml");
+  const filePath = join5(dir, "default.toml");
   writeFileSync2(filePath, content);
   return filePath;
 }
@@ -8445,12 +8649,12 @@ function installedCommunityMap() {
   const map = new Map;
   let entries;
   try {
-    entries = readdirSync2(communityDir());
+    entries = readdirSync3(communityDir());
   } catch {
     return map;
   }
   for (const entry of entries) {
-    const toml = join4(communityDir(), entry, "default.toml");
+    const toml = join5(communityDir(), entry, "default.toml");
     try {
       const p = parse(readFileSync4(toml, "utf8"));
       const version = p["profile"]["version"];
@@ -8571,7 +8775,7 @@ function cmdRemove(args) {
   }
   const id = target.spec.profile.id;
   assertSafeId(id);
-  rmSync(join5(communityDir(), id), { recursive: true });
+  rmSync2(join6(communityDir(), id), { recursive: true });
   clearProfileCache();
   console.log(`\u2713 Removed ${id}`);
 }
@@ -8581,9 +8785,9 @@ function cmdFeed(args) {
     const dir = userDir();
     const files = [];
     try {
-      for (const entry of readdirSync3(dir)) {
+      for (const entry of readdirSync4(dir)) {
         if (entry.endsWith(".toml"))
-          files.push(join5(dir, entry));
+          files.push(join6(dir, entry));
       }
     } catch {}
     console.log("Usage: mcp-recall profiles feed <path-to-profile.toml>");
@@ -8686,7 +8890,7 @@ ${conflicts.length} conflict(s):
 
 // src/profiles/cmd-catalog.ts
 import { readFileSync as readFileSync6 } from "fs";
-import { join as join6 } from "path";
+import { join as join7 } from "path";
 import { homedir as homedir5 } from "os";
 async function cmdInstall(args) {
   const skipVerify = args.includes("--skip-verify");
@@ -8775,7 +8979,7 @@ ${installCount} profile(s) installed (${alreadyCount} already installed, ${entri
   }
   let serverKeys = [];
   try {
-    const raw = JSON.parse(readFileSync6(join6(homedir5(), ".claude.json"), "utf8"));
+    const raw = JSON.parse(readFileSync6(join7(homedir5(), ".claude.json"), "utf8"));
     const mcpServers = raw["mcpServers"];
     serverKeys = Object.keys(mcpServers ?? {}).filter((k) => k !== "recall");
   } catch {
@@ -9039,7 +9243,7 @@ async function handleProfilesCommand(args) {
 
 // src/learn/index.ts
 import { readFileSync as readFileSync8, writeFileSync as writeFileSync3, mkdirSync as mkdirSync3 } from "fs";
-import { join as join7 } from "path";
+import { join as join8 } from "path";
 import { homedir as homedir6 } from "os";
 
 // src/learn/client.ts
@@ -9465,10 +9669,10 @@ function generateProfile(serverKey, tools) {
 
 // src/learn/index.ts
 function userProfilesDir() {
-  return process.env.RECALL_USER_PROFILES_PATH ?? join7(homedir6(), ".config", "mcp-recall", "profiles");
+  return process.env.RECALL_USER_PROFILES_PATH ?? join8(homedir6(), ".config", "mcp-recall", "profiles");
 }
 function readClaudeJson() {
-  const path = join7(homedir6(), ".claude.json");
+  const path = join8(homedir6(), ".claude.json");
   const raw = JSON.parse(readFileSync8(path, "utf8"));
   return raw["mcpServers"] ?? {};
 }
@@ -9531,9 +9735,9 @@ Learning from ${candidates.length} MCP server(s)\u2026
       console.log(toml);
       continue;
     }
-    const profileDir = join7(outputDir, `mcp__${key.replace(/-/g, "_")}`);
+    const profileDir = join8(outputDir, `mcp__${key.replace(/-/g, "_")}`);
     mkdirSync3(profileDir, { recursive: true });
-    const filePath = join7(profileDir, "default.toml");
+    const filePath = join8(profileDir, "default.toml");
     writeFileSync3(filePath, toml);
     console.log(`     \u2192 ${filePath}`);
     written++;
@@ -9554,9 +9758,9 @@ Next steps:`);
 }
 
 // src/import/index.ts
-import { readFileSync as readFileSync9, statSync as statSync2, existsSync } from "fs";
+import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync2 } from "fs";
 import { resolve } from "path";
-import { Database as Database2 } from "bun:sqlite";
+import { Database as Database3 } from "bun:sqlite";
 var LARGE_FILE_BYTES = 50 * 1024 * 1024;
 var EMPTY_EXPORT_SENTINEL = "[recall: no items to export]";
 var StoredOutputSchema = exports_external.object({
@@ -9576,12 +9780,12 @@ var StoredOutputSchema = exports_external.object({
 });
 var ExportSchema = exports_external.array(StoredOutputSchema);
 function dryRunCount(dbPath, items, overwrite) {
-  if (dbPath === ":memory:" || !existsSync(dbPath)) {
+  if (dbPath === ":memory:" || !existsSync2(dbPath)) {
     return { imported: items.length, skipped: 0, overwritten: 0 };
   }
   let db = null;
   try {
-    db = new Database2(dbPath, { readonly: true });
+    db = new Database3(dbPath, { readonly: true });
     const hasTable = db.prepare(`SELECT name FROM sqlite_master WHERE type='table' AND name='stored_outputs' LIMIT 1`).get();
     if (!hasTable)
       return { imported: items.length, skipped: 0, overwritten: 0 };
@@ -9645,7 +9849,7 @@ async function handleImportCommand(args) {
   let raw;
   if (filePath) {
     try {
-      const size = statSync2(filePath).size;
+      const size = statSync3(filePath).size;
       if (size > LARGE_FILE_BYTES) {
         console.error(`Warning: file is ${Math.round(size / 1024 / 1024)} MB \u2014 this may take a while.`);
       }
@@ -9713,7 +9917,7 @@ Next steps:`);
 }
 
 // src/install/index.ts
-import { existsSync as existsSync2 } from "fs";
+import { existsSync as existsSync3 } from "fs";
 import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
@@ -9885,7 +10089,7 @@ async function installCommand(opts = {}) {
     claudeMdPath = defaultClaudeMdPath()
   } = opts;
   const paths = detectPaths();
-  if (!existsSync2(paths.serverJs) || !existsSync2(paths.cliJs)) {
+  if (!existsSync3(paths.serverJs) || !existsSync3(paths.cliJs)) {
     console.error(`${RED}\u2717 Build artifacts not found.${RESET}`);
     console.error(`  Expected: ${DIM}${paths.serverJs}${RESET}`);
     console.error(`  Run ${BOLD}bun run build${RESET} first.`);
@@ -10070,8 +10274,8 @@ async function statusCommand(opts = {}) {
     claudeMdContent = await readFile(claudeMdPath, "utf8");
   } catch {}
   const claudeMdOk = isClaudeMdInjected(claudeMdContent);
-  const serverExists = existsSync2(recallPaths.serverJs);
-  const cliExists = existsSync2(recallPaths.cliJs);
+  const serverExists = existsSync3(recallPaths.serverJs);
+  const cliExists = existsSync3(recallPaths.cliJs);
   const fullyInstalled = serverRegistered && ssRegistered && ptuRegistered && claudeMdOk && serverExists && cliExists;
   const label = fullyInstalled ? `${GREEN}installed${RESET}` : serverRegistered || ssRegistered || ptuRegistered ? `${YELLOW}partial / stale${RESET}` : `${RED}not installed${RESET}`;
   console.log(`
@@ -10110,177 +10314,15 @@ Installation: ${BOLD}${label}${RESET}
     console.log(`  ${GREEN}\u2713${RESET} Profiles: ${profiles.length} installed (${summary})`);
   }
   console.log("");
-}
-
-// src/gc/index.ts
-import { Database as Database3 } from "bun:sqlite";
-import { readdirSync as readdirSync4, existsSync as existsSync3, statSync as statSync3, rmSync as rmSync2 } from "fs";
-import { join as join8, basename } from "path";
-var DEFAULT_STALE_DAYS = 90;
-function isDeletionCandidate(status) {
-  return status === "orphaned" || status === "legacy-stale";
-}
-function vacuumTargets(entries) {
-  return entries.filter((e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable");
-}
-function fileSizeSafe(path2) {
-  try {
-    return statSync3(path2).size;
-  } catch {
-    return 0;
+  const { totalBytes, dbCount } = storeFootprint();
+  const reminderMb = loadConfig().store.gc_reminder_mb;
+  const large = reminderMb > 0 && totalBytes >= reminderMb * 1024 * 1024;
+  const storeIcon = large ? `${YELLOW}!${RESET}` : `${GREEN}\u2713${RESET}`;
+  console.log(`  ${storeIcon} Store: ${formatBytes(totalBytes)} across ${dbCount} project database${dbCount === 1 ? "" : "s"}`);
+  if (large) {
+    console.log(`    \u2192 Reclaim space: ${BOLD}mcp-recall gc${RESET} (review, then re-run with ${BOLD}--force${RESET})`);
   }
-}
-function dbFootprint(file) {
-  return fileSizeSafe(file) + fileSizeSafe(`${file}-wal`) + fileSizeSafe(`${file}-shm`);
-}
-function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
-  if (!existsSync3(dir))
-    return [];
-  const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
-  const entries = [];
-  for (const name of readdirSync4(dir)) {
-    if (!name.endsWith(".db"))
-      continue;
-    const file = join8(dir, name);
-    let mtimeMs = 0;
-    try {
-      mtimeMs = statSync3(file).mtimeMs;
-    } catch {
-      continue;
-    }
-    const sizeBytes = dbFootprint(file);
-    if (file === currentFile) {
-      entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
-      continue;
-    }
-    let projectPath = null;
-    let items = 0;
-    let readable = true;
-    let db = null;
-    try {
-      db = new Database3(file, { readonly: true });
-      try {
-        projectPath = getMeta(db, "project_path");
-      } catch {
-        projectPath = null;
-      }
-      try {
-        items = db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get().n;
-      } catch {
-        items = 0;
-      }
-    } catch {
-      readable = false;
-    } finally {
-      db?.close();
-    }
-    let status;
-    if (!readable) {
-      status = "unreadable";
-    } else if (projectPath !== null) {
-      status = existsSync3(projectPath) ? "active" : "orphaned";
-    } else {
-      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
-    }
-    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
-  }
-  return entries.sort((a, b) => b.sizeBytes - a.sizeBytes);
-}
-var STATUS_LABEL = {
-  current: "current",
-  active: "active",
-  orphaned: "ORPHANED",
-  "legacy-fresh": "legacy",
-  "legacy-stale": "LEGACY-STALE",
-  unreadable: "unreadable"
-};
-function reportLine(e, nowMs) {
-  const flag = isDeletionCandidate(e.status) ? "\u2717" : " ";
-  const age = formatRelativeTime(nowMs - e.mtimeMs);
-  const where = e.projectPath ?? "(no recorded path)";
-  return `  ${flag} ${STATUS_LABEL[e.status].padEnd(13)} ${formatBytes(e.sizeBytes).padStart(9)}` + `  ${String(e.items).padStart(6)} items  ${age.padEnd(14)}  ${basename(e.file)}
-` + `      ${where}`;
-}
-function vacuumFile(file) {
-  const before = dbFootprint(file);
-  let db = null;
-  try {
-    db = new Database3(file);
-    db.run("PRAGMA busy_timeout=5000");
-    db.run("PRAGMA auto_vacuum=INCREMENTAL");
-    db.run("VACUUM");
-  } catch {
-    return null;
-  } finally {
-    db?.close();
-  }
-  return { before, after: dbFootprint(file) };
-}
-function deleteDbFiles(file) {
-  for (const f of [file, `${file}-wal`, `${file}-shm`]) {
-    rmSync2(f, { force: true });
-  }
-}
-function gcCommand(opts = {}) {
-  const dryRun = opts.dryRun ?? true;
-  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
-  const nowMs = Date.now();
-  const dir = dataDir();
-  const currentFile = defaultDbPath(getProjectKey(process.cwd()));
-  const entries = scanDatabases(dir, currentFile, staleDays, nowMs);
-  if (entries.length === 0) {
-    console.log(`No databases found in ${dir}`);
-    return;
-  }
-  const candidates = entries.filter((e) => isDeletionCandidate(e.status));
-  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
-  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
-  console.log(`Project databases in ${dir}:
-`);
-  for (const e of entries)
-    console.log(reportLine(e, nowMs));
-  console.log(`
-${entries.length} databases \xB7 ${formatBytes(totalBytes)} total \xB7 ` + `${candidates.length} reclaimable (${formatBytes(reclaimable)})`);
-  console.log(`  Orphaned = project path deleted \xB7 LEGACY-STALE = no recorded path, ` + `untouched > ${staleDays}d (raise/lower with --stale-days N)`);
-  if (dryRun) {
-    if (candidates.length > 0) {
-      console.log(`
-Dry run \u2014 pass --force to delete the ${candidates.length} marked database(s).`);
-    }
-  } else {
-    let freed = 0;
-    for (const e of candidates) {
-      deleteDbFiles(e.file);
-      freed += e.sizeBytes;
-    }
-    console.log(`
-Deleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
-  }
-  if (opts.vacuum) {
-    const survivors = vacuumTargets(entries);
-    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
-    console.log(`
-Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) \u2014 ` + `rewrites each file, may take a while\u2026`);
-    let reclaimed = 0;
-    let vacuumed = 0;
-    let skipped = 0;
-    for (let i = 0;i < survivors.length; i++) {
-      const e = survivors[i];
-      process.stdout.write(`  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})\u2026 `);
-      const result = vacuumFile(e.file);
-      if (result) {
-        const freed = Math.max(0, result.before - result.after);
-        reclaimed += freed;
-        vacuumed++;
-        console.log(`reclaimed ${formatBytes(freed)}`);
-      } else {
-        skipped++;
-        console.log(`skipped \u2014 locked by another session or unreadable`);
-      }
-    }
-    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
-    console.log(`Vacuumed ${vacuumed} database(s), reclaimed ${formatBytes(reclaimed)} of free pages.${skipNote}`);
-  }
+  console.log("");
 }
 
 // src/cli.ts

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5660,14 +5660,24 @@ function toolContext(db, projectKey, args) {
 // src/gc/index.ts
 import { Database as Database2 } from "bun:sqlite";
 import { readdirSync, existsSync, statSync, rmSync } from "fs";
-import { join as join3, basename } from "path";
+import { join as join3, basename, dirname as dirname2, resolve } from "path";
 var DEFAULT_STALE_DAYS = 90;
+var STATUS_POLICY = {
+  current: { deletable: false, vacuumable: false },
+  active: { deletable: false, vacuumable: true },
+  orphaned: { deletable: true, vacuumable: false },
+  unverifiable: { deletable: false, vacuumable: false },
+  "legacy-fresh": { deletable: false, vacuumable: true },
+  "legacy-stale": { deletable: true, vacuumable: false },
+  unreadable: { deletable: false, vacuumable: false }
+};
 function isDeletionCandidate(status) {
-  return status === "orphaned" || status === "legacy-stale";
+  return STATUS_POLICY[status].deletable;
 }
 function vacuumTargets(entries) {
-  return entries.filter((e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable");
+  return entries.filter((e) => STATUS_POLICY[e.status].vacuumable);
 }
+var sumBytes = (entries) => entries.reduce((sum, e) => sum + e.sizeBytes, 0);
 function fileSizeSafe(path) {
   try {
     return statSync(path).size;
@@ -5691,10 +5701,49 @@ function storeFootprint(dir = dataDir()) {
   }
   return { totalBytes, dbCount };
 }
+function gcReminderText(footprint, reminderMb) {
+  if (reminderMb <= 0)
+    return "";
+  if (footprint.totalBytes < reminderMb * 1024 * 1024)
+    return "";
+  return `\uD83D\uDCA1 recall store is ${formatBytes(footprint.totalBytes)} across ${footprint.dbCount} ` + `project databases \u2014 run \`mcp-recall gc\` to review and reclaim disk space.`;
+}
+function probeDb(file) {
+  let db = null;
+  try {
+    db = new Database2(file, { readonly: true });
+    const isRecallDb = db.prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='stored_outputs'`).get();
+    if (!isRecallDb)
+      return { readable: false, projectPath: null, items: 0 };
+    let projectPath = null;
+    try {
+      projectPath = getMeta(db, "project_path");
+    } catch {
+      projectPath = null;
+    }
+    const items = db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get().n;
+    return { readable: true, projectPath, items };
+  } catch {
+    return { readable: false, projectPath: null, items: 0 };
+  } finally {
+    db?.close();
+  }
+}
+function classify(probe, mtimeMs, staleCutoffMs) {
+  if (!probe.readable)
+    return "unreadable";
+  if (probe.projectPath !== null) {
+    if (existsSync(probe.projectPath))
+      return "active";
+    return existsSync(dirname2(probe.projectPath)) ? "orphaned" : "unverifiable";
+  }
+  return mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
+}
 function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
   if (!existsSync(dir))
     return [];
   const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
+  const currentResolved = resolve(currentFile);
   const entries = [];
   for (const name of readdirSync(dir)) {
     if (!name.endsWith(".db"))
@@ -5707,40 +5756,13 @@ function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
       continue;
     }
     const sizeBytes = dbFootprint(file);
-    if (file === currentFile) {
+    if (resolve(file) === currentResolved) {
       entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
       continue;
     }
-    let projectPath = null;
-    let items = 0;
-    let readable = true;
-    let db = null;
-    try {
-      db = new Database2(file, { readonly: true });
-      try {
-        projectPath = getMeta(db, "project_path");
-      } catch {
-        projectPath = null;
-      }
-      try {
-        items = db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get().n;
-      } catch {
-        items = 0;
-      }
-    } catch {
-      readable = false;
-    } finally {
-      db?.close();
-    }
-    let status;
-    if (!readable) {
-      status = "unreadable";
-    } else if (projectPath !== null) {
-      status = existsSync(projectPath) ? "active" : "orphaned";
-    } else {
-      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
-    }
-    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
+    const probe = probeDb(file);
+    const status = classify(probe, mtimeMs, staleCutoffMs);
+    entries.push({ file, status, projectPath: probe.projectPath, sizeBytes, mtimeMs, items: probe.items });
   }
   return entries.sort((a, b) => b.sizeBytes - a.sizeBytes);
 }
@@ -5748,6 +5770,7 @@ var STATUS_LABEL = {
   current: "current",
   active: "active",
   orphaned: "ORPHANED",
+  unverifiable: "unverifiable",
   "legacy-fresh": "legacy",
   "legacy-stale": "LEGACY-STALE",
   unreadable: "unreadable"
@@ -5767,17 +5790,31 @@ function vacuumFile(file) {
     db.run("PRAGMA busy_timeout=5000");
     db.run("PRAGMA auto_vacuum=INCREMENTAL");
     db.run("VACUUM");
-  } catch {
-    return null;
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    log.warn(`vacuum failed for ${basename(file)} \u2014 ${message}`);
+    return { error: message };
   } finally {
     db?.close();
   }
   return { before, after: dbFootprint(file) };
 }
+function vacuumSkipReason(error) {
+  if (/lock|busy/i.test(error))
+    return "locked by another session";
+  if (/disk|full|space/i.test(error))
+    return "disk full";
+  return "unreadable or errored (see RECALL_DEBUG logs)";
+}
 function deleteDbFiles(file) {
   for (const f of [file, `${file}-wal`, `${file}-shm`]) {
     rmSync(f, { force: true });
   }
+}
+function executeDeletions(candidates) {
+  for (const e of candidates)
+    deleteDbFiles(e.file);
+  return sumBytes(candidates);
 }
 function gcCommand(opts = {}) {
   const dryRun = opts.dryRun ?? true;
@@ -5791,34 +5828,27 @@ function gcCommand(opts = {}) {
     return;
   }
   const candidates = entries.filter((e) => isDeletionCandidate(e.status));
-  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
-  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
   console.log(`Project databases in ${dir}:
 `);
   for (const e of entries)
     console.log(reportLine(e, nowMs));
   console.log(`
-${entries.length} databases \xB7 ${formatBytes(totalBytes)} total \xB7 ` + `${candidates.length} reclaimable (${formatBytes(reclaimable)})`);
-  console.log(`  Orphaned = project path deleted \xB7 LEGACY-STALE = no recorded path, ` + `untouched > ${staleDays}d (raise/lower with --stale-days N)`);
+${entries.length} databases \xB7 ${formatBytes(sumBytes(entries))} total \xB7 ` + `${candidates.length} reclaimable (${formatBytes(sumBytes(candidates))})`);
+  console.log(`  ORPHANED = project path deleted \xB7 LEGACY-STALE = no recorded path, untouched > ${staleDays}d ` + `(--stale-days N) \xB7 unverifiable/unreadable are never deleted`);
   if (dryRun) {
     if (candidates.length > 0) {
       console.log(`
 Dry run \u2014 pass --force to delete the ${candidates.length} marked database(s).`);
     }
   } else {
-    let freed = 0;
-    for (const e of candidates) {
-      deleteDbFiles(e.file);
-      freed += e.sizeBytes;
-    }
+    const freed = executeDeletions(candidates);
     console.log(`
 Deleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
   }
   if (opts.vacuum) {
     const survivors = vacuumTargets(entries);
-    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
     console.log(`
-Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) \u2014 ` + `rewrites each file, may take a while\u2026`);
+Vacuuming ${survivors.length} database(s) to keep (${formatBytes(sumBytes(survivors))}) \u2014 ` + `rewrites each file, may take a while\u2026`);
     let reclaimed = 0;
     let vacuumed = 0;
     let skipped = 0;
@@ -5826,14 +5856,14 @@ Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}
       const e = survivors[i];
       process.stdout.write(`  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})\u2026 `);
       const result = vacuumFile(e.file);
-      if (result) {
+      if ("after" in result) {
         const freed = Math.max(0, result.before - result.after);
         reclaimed += freed;
         vacuumed++;
         console.log(`reclaimed ${formatBytes(freed)}`);
       } else {
         skipped++;
-        console.log(`skipped \u2014 locked by another session or unreadable`);
+        console.log(`skipped \u2014 ${vacuumSkipReason(result.error)}`);
       }
     }
     const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
@@ -5842,14 +5872,6 @@ Vacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}
 }
 
 // src/hooks/session-start.ts
-function gcReminder(reminderMb) {
-  if (reminderMb <= 0)
-    return "";
-  const { totalBytes, dbCount } = storeFootprint();
-  if (totalBytes < reminderMb * 1024 * 1024)
-    return "";
-  return `\uD83D\uDCA1 recall store is ${formatBytes(totalBytes)} across ${dbCount} project ` + `databases \u2014 run \`mcp-recall gc\` to review and reclaim disk space.`;
-}
 var INJECT_MAX_CHARS = 2000;
 function handleSessionStart(raw) {
   let parsed;
@@ -5872,7 +5894,7 @@ function handleSessionStart(raw) {
   recordSession(db, today);
   pruneExpired(db, projectKey, config.store.expire_after_session_days);
   const parts = [];
-  const reminder = gcReminder(config.store.gc_reminder_mb);
+  const reminder = gcReminderText(storeFootprint(), config.store.gc_reminder_mb);
   if (reminder)
     parts.push(reminder);
   let snapshot = toolContext(db, projectKey, {});
@@ -8666,9 +8688,9 @@ function installedCommunityMap() {
 async function promptNumber(msg, min, max) {
   for (let attempt = 0;attempt < 3; attempt++) {
     process.stdout.write(msg);
-    const line = await new Promise((resolve) => {
+    const line = await new Promise((resolve2) => {
       process.stdin.setEncoding("utf8");
-      process.stdin.once("data", (d) => resolve(String(d).trim()));
+      process.stdin.once("data", (d) => resolve2(String(d).trim()));
     });
     const n = parseInt(line);
     if (!isNaN(n) && n >= min && n <= max)
@@ -9255,7 +9277,7 @@ class LineReader {
     this.reader = stream.getReader();
   }
   async readLine(timeoutMs) {
-    const timer = new Promise((resolve) => setTimeout(() => resolve(null), timeoutMs));
+    const timer = new Promise((resolve2) => setTimeout(() => resolve2(null), timeoutMs));
     const read = this._nextLine();
     return Promise.race([read, timer]);
   }
@@ -9512,8 +9534,8 @@ async function tryLegacySse(url, timeoutMs) {
         return req.then(() => {
           return;
         });
-      return new Promise((resolve, reject) => {
-        pending.set(body.id, { resolve, reject });
+      return new Promise((resolve2, reject) => {
+        pending.set(body.id, { resolve: resolve2, reject });
         req.catch(reject);
       });
     };
@@ -9759,7 +9781,7 @@ Next steps:`);
 
 // src/import/index.ts
 import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync2 } from "fs";
-import { resolve } from "path";
+import { resolve as resolve2 } from "path";
 import { Database as Database3 } from "bun:sqlite";
 var LARGE_FILE_BYTES = 50 * 1024 * 1024;
 var EMPTY_EXPORT_SENTINEL = "[recall: no items to export]";
@@ -9845,7 +9867,7 @@ async function handleImportCommand(args) {
   const keepProjectKey = args.includes("--keep-project-key");
   const dryRun = args.includes("--dry-run");
   const rawPath = args.find((a) => !a.startsWith("--"));
-  const filePath = rawPath ? resolve(rawPath) : null;
+  const filePath = rawPath ? resolve2(rawPath) : null;
   let raw;
   if (filePath) {
     try {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -20998,7 +20998,8 @@ var RecallConfigSchema = exports_external.object({
     max_size_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
-    eviction_half_life_days: exports_external.number().positive()
+    eviction_half_life_days: exports_external.number().positive(),
+    gc_reminder_mb: exports_external.number().nonnegative()
   }),
   retrieve: exports_external.object({
     default_max_bytes: exports_external.number().positive()
@@ -21023,7 +21024,8 @@ var DEFAULTS = {
     max_size_mb: 500,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
-    eviction_half_life_days: 7
+    eviction_half_life_days: 7,
+    gc_reminder_mb: 2048
   },
   retrieve: {
     default_max_bytes: 8192

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19562,7 +19562,7 @@ function hashPath(path) {
 }
 // src/db/schema.ts
 import { Database } from "bun:sqlite";
-import { join } from "path";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { mkdirSync } from "fs";
 var SCHEMA = `
@@ -19615,6 +19615,11 @@ var SCHEMA = `
 
   CREATE TABLE IF NOT EXISTS sessions (
     date TEXT PRIMARY KEY
+  );
+
+  CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
   );
 `;
 var MIGRATIONS = [
@@ -19731,6 +19736,15 @@ function countAndDelete(db, where, params) {
   return count;
 }
 var VACUUM_THRESHOLD = 50;
+function reclaimPages(db, deleted) {
+  if (deleted < VACUUM_THRESHOLD)
+    return;
+  try {
+    db.run("PRAGMA incremental_vacuum");
+  } catch (e) {
+    log.warn(`incremental_vacuum failed \u2014 ${e instanceof Error ? e.message : e}`);
+  }
+}
 function storeOutput(db, input) {
   const id = generateId();
   const summary_size = Buffer.byteLength(input.summary, "utf8");
@@ -19870,13 +19884,7 @@ function forgetOutputs(db, project_key, options) {
     const cutoff = Math.floor(Date.now() / 1000) - options.older_than_days * 86400;
     deleted = countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
   }
-  if (deleted >= VACUUM_THRESHOLD) {
-    try {
-      db.run("PRAGMA incremental_vacuum");
-    } catch (e) {
-      log.warn(`incremental_vacuum failed \u2014 ${e instanceof Error ? e.message : e}`);
-    }
-  }
+  reclaimPages(db, deleted);
   return deleted;
 }
 function getSessionDays(db) {
@@ -19888,7 +19896,9 @@ function getStats(db, project_key) {
     SELECT
       COUNT(*) as total_items,
       COALESCE(SUM(original_size), 0) as total_original_bytes,
-      COALESCE(SUM(summary_size), 0) as total_summary_bytes
+      COALESCE(SUM(summary_size), 0) as total_summary_bytes,
+      COALESCE(SUM(pinned), 0) as pinned_items,
+      COALESCE(SUM(CASE WHEN pinned = 1 THEN original_size ELSE 0 END), 0) as pinned_bytes
     FROM stored_outputs
     WHERE project_key = ?
   `).get(project_key);
@@ -21097,6 +21107,7 @@ function formatRelativeTime(ms) {
 
 // src/tools.ts
 var CONTEXT_EMPTY_RESPONSE = "[recall: no context available yet \u2014 use recall tools to build up your context store]";
+var PIN_BUDGET_WARN_PCT = 80;
 var SEARCH_EXCERPT_LEN = 120;
 var NOTE_EXCERPT_LEN = 200;
 var CONTEXT_EXCERPT_LEN = 100;
@@ -21389,6 +21400,15 @@ function toolStats(db, projectKey, args = {}) {
     `  ~Tokens saved:     ~${tokensSaved.toLocaleString()}`,
     `  Session days:      ${sessionDays.length}`
   ];
+  if (stats.pinned_items > 0) {
+    const maxSizeMb = loadConfig().store.max_size_mb;
+    const maxBytes = maxSizeMb * 1024 * 1024;
+    const capPct = maxBytes > 0 ? stats.pinned_bytes / maxBytes * 100 : 0;
+    lines.push(`  Pinned:            ${stats.pinned_items} item${stats.pinned_items === 1 ? "" : "s"}` + ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of cap)`);
+    if (capPct >= PIN_BUDGET_WARN_PCT) {
+      lines.push(`  \u26A0 Pinned data is ${capPct.toFixed(0)}% of the ${maxSizeMb} MB cap and is exempt` + ` from eviction \u2014 unpin or raise store.max_size_mb to reclaim space.`);
+    }
+  }
   const breakdown = getToolBreakdown(db, projectKey);
   if (breakdown.length > 0) {
     lines.push("", "By tool (sorted by original size):");

--- a/src/cli.ts
+++ b/src/cli.ts
@@ -9,6 +9,7 @@
  *   install         — register hooks + MCP server in Claude Code
  *   uninstall       — remove hooks + MCP server
  *   status          — show configuration and health
+ *   gc              — reclaim disk from orphaned project databases
  *   profiles        — manage compression profiles
  *   learn           — generate profile suggestions from session data
  *   completions     — print shell completion script for bash, zsh, or fish
@@ -22,6 +23,7 @@ import { handleProfilesCommand } from "./profiles/commands";
 import { handleLearnCommand } from "./learn/index";
 import { handleImportCommand } from "./import/index";
 import { installCommand, uninstallCommand, statusCommand } from "./install/index";
+import { gcCommand } from "./gc/index";
 import { log } from "./log";
 
 export async function getVersion(): Promise<string> {
@@ -39,6 +41,9 @@ Commands:
   install              Register hooks + MCP server in Claude Code
   uninstall            Remove hooks + MCP server
   status               Show current configuration and health
+  gc [--force]         Reclaim disk: list/delete orphaned project DBs
+    --stale-days N     Legacy DBs (no recorded path) older than N days are candidates (default 90)
+    --vacuum           Full-VACUUM surviving DBs to reclaim free pages
   profiles <cmd>       Manage compression profiles
     seed [--all]       Install profiles for detected MCPs (--all for entire catalog)
     list               Show installed profiles
@@ -87,7 +92,7 @@ _mcp_recall() {
   COMPREPLY=()
   cur="\${COMP_WORDS[COMP_CWORD]}"
 
-  local commands="install uninstall status profiles learn completions --help --version"
+  local commands="install uninstall status gc profiles learn completions --help --version"
   local profiles_cmds="list install update remove seed feed check retrain test"
 
   if [[ \${COMP_CWORD} -eq 1 ]]; then
@@ -172,6 +177,7 @@ _mcp_recall() {
         'install:register hooks and MCP server in Claude Code'
         'uninstall:remove hooks and MCP server'
         'status:show current configuration and health'
+        'gc:reclaim disk from orphaned project databases'
         'profiles:manage compression profiles'
         'learn:generate profile suggestions from session data'
         'completions:print shell completion script (bash, zsh, fish)'
@@ -200,7 +206,7 @@ function fishCompletion(): string {
   return `# mcp-recall fish completions
 # Save to: mcp-recall completions fish > ~/.config/fish/completions/mcp-recall.fish
 
-set -l commands install uninstall status profiles learn completions
+set -l commands install uninstall status gc profiles learn completions
 
 # Top-level commands
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
@@ -209,6 +215,8 @@ complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
   -a uninstall -d "Remove hooks and MCP server"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
   -a status -d "Show current configuration and health"
+complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
+  -a gc -d "Reclaim disk from orphaned project databases"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
   -a profiles -d "Manage compression profiles"
 complete -c mcp-recall -f -n "not __fish_seen_subcommand_from \$commands" \\
@@ -321,6 +329,24 @@ async function main(): Promise<void> {
 
   if (subcommand === "status") {
     await statusCommand();
+    process.exit(0);
+  }
+
+  if (subcommand === "gc") {
+    const staleIdx = process.argv.indexOf("--stale-days");
+    const staleDays =
+      staleIdx !== -1 && process.argv[staleIdx + 1]
+        ? Number(process.argv[staleIdx + 1])
+        : undefined;
+    if (staleDays !== undefined && (!Number.isFinite(staleDays) || staleDays < 1)) {
+      console.error("--stale-days must be a positive number");
+      process.exit(1);
+    }
+    gcCommand({
+      dryRun: !process.argv.includes("--force"),
+      vacuum: process.argv.includes("--vacuum"),
+      staleDays,
+    });
     process.exit(0);
   }
 

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,6 +13,7 @@ const RecallConfigSchema = z.object({
     pin_recommendation_threshold: z.number().int().positive(),
     stale_item_days: z.number().int().positive(),
     eviction_half_life_days: z.number().positive(),
+    gc_reminder_mb: z.number().nonnegative(),
   }),
   retrieve: z.object({
     default_max_bytes: z.number().positive(),
@@ -42,6 +43,7 @@ const DEFAULTS: RecallConfig = {
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
     eviction_half_life_days: 7,
+    gc_reminder_mb: 2048,
   },
   retrieve: {
     default_max_bytes: 8192,

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -18,13 +18,17 @@ export function getStats(db: Database, project_key: string): Stats {
     SELECT
       COUNT(*) as total_items,
       COALESCE(SUM(original_size), 0) as total_original_bytes,
-      COALESCE(SUM(summary_size), 0) as total_summary_bytes
+      COALESCE(SUM(summary_size), 0) as total_summary_bytes,
+      COALESCE(SUM(pinned), 0) as pinned_items,
+      COALESCE(SUM(CASE WHEN pinned = 1 THEN original_size ELSE 0 END), 0) as pinned_bytes
     FROM stored_outputs
     WHERE project_key = ?
   `).get(project_key) as {
     total_items: number;
     total_original_bytes: number;
     total_summary_bytes: number;
+    pinned_items: number;
+    pinned_bytes: number;
   };
 
   const compression_ratio =

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -33,6 +33,37 @@ function countAndDelete(db: Database, where: string, params: SQLQueryBindings[])
 const VACUUM_THRESHOLD = 50;
 
 /**
+ * Returns free pages to the OS after a bulk delete, when enough rows were removed
+ * to be worth the work. A no-op on databases created without
+ * `auto_vacuum=INCREMENTAL` (e.g. legacy stores) — those must be reclaimed with a
+ * full `VACUUM`, which `mcp-recall gc --vacuum` performs. Never throws.
+ */
+export function reclaimPages(db: Database, deleted: number): void {
+  if (deleted < VACUUM_THRESHOLD) return;
+  try {
+    db.run("PRAGMA incremental_vacuum");
+  } catch (e) {
+    log.warn(`incremental_vacuum failed — ${e instanceof Error ? e.message : e}`);
+  }
+}
+
+/** Upserts a key/value pair into the per-project `meta` table. */
+export function setMeta(db: Database, key: string, value: string): void {
+  db.prepare(
+    `INSERT INTO meta (key, value) VALUES (?, ?)
+     ON CONFLICT(key) DO UPDATE SET value = excluded.value`
+  ).run(key, value);
+}
+
+/** Reads a value from the `meta` table, or `null` if the key is absent. */
+export function getMeta(db: Database, key: string): string | null {
+  const row = db.prepare(`SELECT value FROM meta WHERE key = ?`).get(key) as
+    | { value: string }
+    | undefined;
+  return row?.value ?? null;
+}
+
+/**
  * Persists a compressed tool output and populates the FTS index and chunk table.
  * Returns the fully-hydrated row including the generated `id`.
  */
@@ -225,6 +256,8 @@ export function evictIfNeeded(
     ...(toEvict as unknown as SQLQueryBindings[])
   );
 
+  reclaimPages(db, toEvict.length);
+
   return toEvict.length;
 }
 
@@ -411,15 +444,7 @@ export function forgetOutputs(
     deleted = countAndDelete(db, `created_at < ? AND project_key = ? ${pinGuard}`, [cutoff, project_key]);
   }
 
-  if (deleted >= VACUUM_THRESHOLD) {
-    try {
-      // Non-blocking incremental reclamation; no-op on databases that were
-      // created without auto_vacuum=INCREMENTAL.
-      db.run("PRAGMA incremental_vacuum");
-    } catch (e) {
-      log.warn(`incremental_vacuum failed — ${e instanceof Error ? e.message : e}`);
-    }
-  }
+  reclaimPages(db, deleted);
 
   return deleted;
 }
@@ -435,7 +460,9 @@ export function pruneExpired(
   calendar_days: number
 ): number {
   const cutoff = Math.floor(Date.now() / 1000) - calendar_days * 86400;
-  return countAndDelete(db, "created_at < ? AND project_key = ? AND pinned = 0", [cutoff, project_key]);
+  const deleted = countAndDelete(db, "created_at < ? AND project_key = ? AND pinned = 0", [cutoff, project_key]);
+  reclaimPages(db, deleted);
+  return deleted;
 }
 
 /** Records a session date (YYYY-MM-DD) in the sessions table. No-op if already present. */

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -61,7 +61,9 @@ const SCHEMA = `
   );
 `;
 
-// Columns added after initial schema — applied once, idempotent via try/catch
+// Schema changes applied after initial creation, each idempotent: columns rely on
+// the duplicate-column catch below (SQLite has no ADD COLUMN IF NOT EXISTS),
+// indexes use IF NOT EXISTS directly.
 const MIGRATIONS = [
   "ALTER TABLE stored_outputs ADD COLUMN pinned INTEGER NOT NULL DEFAULT 0",
   "ALTER TABLE stored_outputs ADD COLUMN access_count INTEGER NOT NULL DEFAULT 0",

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -1,5 +1,5 @@
 import { Database } from "bun:sqlite";
-import { join } from "path";
+import { join, dirname } from "path";
 import { homedir } from "os";
 import { mkdirSync } from "fs";
 
@@ -54,6 +54,11 @@ const SCHEMA = `
   CREATE TABLE IF NOT EXISTS sessions (
     date TEXT PRIMARY KEY
   );
+
+  CREATE TABLE IF NOT EXISTS meta (
+    key TEXT PRIMARY KEY,
+    value TEXT NOT NULL
+  );
 `;
 
 // Columns added after initial schema — applied once, idempotent via try/catch
@@ -92,6 +97,17 @@ export function defaultDbPath(projectKey: string): string {
     process.env.RECALL_DB_PATH ??
     join(homedir(), ".local", "share", "mcp-recall", `${projectKey}.db`)
   );
+}
+
+/**
+ * Returns the directory that holds per-project databases.
+ * When `RECALL_DB_PATH` overrides to a single file, returns its parent directory
+ * so callers that scan the store (e.g. `gc`) operate on the right location.
+ */
+export function dataDir(): string {
+  const override = process.env.RECALL_DB_PATH;
+  if (override) return dirname(override);
+  return join(homedir(), ".local", "share", "mcp-recall");
 }
 
 /**

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -61,6 +61,10 @@ export interface Stats {
   total_original_bytes: number;
   total_summary_bytes: number;
   compression_ratio: number;
+  /** Number of pinned items (exempt from eviction). */
+  pinned_items: number;
+  /** Sum of `original_size` across pinned items — bytes eviction cannot reclaim. */
+  pinned_bytes: number;
 }
 
 /** Options for the session-orientation context snapshot. */

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -78,6 +78,29 @@ function dbFootprint(file: string): number {
   return fileSizeSafe(file) + fileSizeSafe(`${file}-wal`) + fileSizeSafe(`${file}-shm`);
 }
 
+export interface StoreFootprint {
+  totalBytes: number;
+  dbCount: number;
+}
+
+/**
+ * Cheap total size + count of the DB store — `stat` only, no database opens, so it
+ * is safe to call on every session start. Used to decide whether to nudge the user
+ * to run `gc`. Orphan classification (which requires opening each DB) is deferred to
+ * the `gc` command itself.
+ */
+export function storeFootprint(dir: string = dataDir()): StoreFootprint {
+  if (!existsSync(dir)) return { totalBytes: 0, dbCount: 0 };
+  let totalBytes = 0;
+  let dbCount = 0;
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".db")) continue;
+    dbCount++;
+    totalBytes += dbFootprint(join(dir, name));
+  }
+  return { totalBytes, dbCount };
+}
+
 /**
  * Inspects every `*.db` in `dir` and classifies it. Pure aside from reads:
  * no file is modified or deleted. `currentFile` is the active project's DB path

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -1,0 +1,250 @@
+/**
+ * `mcp-recall gc` — reclaim disk from the per-project database store.
+ *
+ * Two independent problems this addresses:
+ *   1. Orphaned DBs: when a project is deleted, its DB is never reopened, so the
+ *      session-start prune never runs against it and it lingers forever. `gc`
+ *      classifies each DB by whether its recorded `project_path` still exists.
+ *   2. Free-page bloat: incremental_vacuum only reclaims on databases created with
+ *      auto_vacuum=INCREMENTAL. `gc --vacuum` runs a full VACUUM on survivors,
+ *      which reclaims free pages AND upgrades legacy auto_vacuum=NONE DBs.
+ *
+ * Default is a dry run — nothing is deleted without `--force`.
+ */
+
+import { Database } from "bun:sqlite";
+import { readdirSync, existsSync, statSync, rmSync } from "fs";
+import { join, basename } from "path";
+import { dataDir, defaultDbPath } from "../db/schema";
+import { getMeta } from "../db/queries";
+import { getProjectKey } from "../project-key";
+import { formatBytes, formatRelativeTime } from "../format";
+
+const DEFAULT_STALE_DAYS = 90;
+
+export interface GcOptions {
+  /** When false, actually delete candidates. Default true (report only). */
+  dryRun?: boolean;
+  /** Legacy (no recorded path) DBs untouched for longer than this are candidates. */
+  staleDays?: number;
+  /** Run a full VACUUM on surviving DBs to reclaim free pages. */
+  vacuum?: boolean;
+}
+
+export type DbStatus =
+  | "current" // the active project's DB — never touched
+  | "active" // recorded path still exists on disk
+  | "orphaned" // recorded path is gone — safe to remove
+  | "legacy-fresh" // no recorded path, recently modified — kept
+  | "legacy-stale" // no recorded path, untouched past the stale window — candidate
+  | "unreadable"; // could not be opened — reported, never deleted
+
+export interface DbEntry {
+  file: string; // absolute path to the .db file
+  status: DbStatus;
+  projectPath: string | null; // recorded project_path, if any
+  sizeBytes: number; // .db + -wal + -shm
+  mtimeMs: number;
+  items: number; // stored_outputs row count (0 if unavailable)
+}
+
+/** True for statuses that `gc --force` will delete. */
+export function isDeletionCandidate(status: DbStatus): boolean {
+  return status === "orphaned" || status === "legacy-stale";
+}
+
+function fileSizeSafe(path: string): number {
+  try {
+    return statSync(path).size;
+  } catch {
+    return 0;
+  }
+}
+
+/** Total on-disk footprint of a DB, including its WAL and shared-memory sidecars. */
+function dbFootprint(file: string): number {
+  return fileSizeSafe(file) + fileSizeSafe(`${file}-wal`) + fileSizeSafe(`${file}-shm`);
+}
+
+/**
+ * Inspects every `*.db` in `dir` and classifies it. Pure aside from reads:
+ * no file is modified or deleted. `currentFile` is the active project's DB path
+ * (always classified "current"); `nowMs` is injectable for deterministic tests.
+ */
+export function scanDatabases(
+  dir: string,
+  currentFile: string,
+  staleDays: number,
+  nowMs: number = Date.now()
+): DbEntry[] {
+  if (!existsSync(dir)) return [];
+
+  const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
+  const entries: DbEntry[] = [];
+
+  for (const name of readdirSync(dir)) {
+    if (!name.endsWith(".db")) continue;
+    const file = join(dir, name);
+
+    let mtimeMs = 0;
+    try {
+      mtimeMs = statSync(file).mtimeMs;
+    } catch {
+      continue; // vanished between readdir and stat
+    }
+    const sizeBytes = dbFootprint(file);
+
+    if (file === currentFile) {
+      entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
+      continue;
+    }
+
+    let projectPath: string | null = null;
+    let items = 0;
+    let readable = true;
+    let db: Database | null = null;
+    try {
+      db = new Database(file, { readonly: true });
+      try {
+        projectPath = getMeta(db, "project_path");
+      } catch {
+        projectPath = null; // legacy DB without a `meta` table
+      }
+      try {
+        items = (db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get() as { n: number }).n;
+      } catch {
+        items = 0;
+      }
+    } catch {
+      readable = false;
+    } finally {
+      db?.close();
+    }
+
+    let status: DbStatus;
+    if (!readable) {
+      status = "unreadable";
+    } else if (projectPath !== null) {
+      status = existsSync(projectPath) ? "active" : "orphaned";
+    } else {
+      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
+    }
+
+    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
+  }
+
+  // Largest first — the biggest reclaimable wins surface at the top.
+  return entries.sort((a, b) => b.sizeBytes - a.sizeBytes);
+}
+
+const STATUS_LABEL: Record<DbStatus, string> = {
+  current: "current",
+  active: "active",
+  orphaned: "ORPHANED",
+  "legacy-fresh": "legacy",
+  "legacy-stale": "LEGACY-STALE",
+  unreadable: "unreadable",
+};
+
+function reportLine(e: DbEntry, nowMs: number): string {
+  const flag = isDeletionCandidate(e.status) ? "✗" : " ";
+  const age = formatRelativeTime(nowMs - e.mtimeMs);
+  const where = e.projectPath ?? "(no recorded path)";
+  return (
+    `  ${flag} ${STATUS_LABEL[e.status].padEnd(13)} ${formatBytes(e.sizeBytes).padStart(9)}` +
+    `  ${String(e.items).padStart(6)} items  ${age.padEnd(14)}  ${basename(e.file)}\n` +
+    `      ${where}`
+  );
+}
+
+/** Full VACUUM: reclaims free pages and upgrades legacy DBs to incremental auto-vacuum. */
+function vacuumFile(file: string): { before: number; after: number } | null {
+  const before = dbFootprint(file);
+  let db: Database | null = null;
+  try {
+    db = new Database(file);
+    db.run("PRAGMA busy_timeout=5000");
+    db.run("PRAGMA auto_vacuum=INCREMENTAL");
+    db.run("VACUUM");
+  } catch {
+    return null; // locked or corrupt — skip, never fatal
+  } finally {
+    db?.close();
+  }
+  return { before, after: dbFootprint(file) };
+}
+
+function deleteDbFiles(file: string): void {
+  for (const f of [file, `${file}-wal`, `${file}-shm`]) {
+    rmSync(f, { force: true });
+  }
+}
+
+/** Entry point for the `gc` CLI subcommand. Prints a report and, unless dry-run, reclaims. */
+export function gcCommand(opts: GcOptions = {}): void {
+  const dryRun = opts.dryRun ?? true;
+  const staleDays = opts.staleDays ?? DEFAULT_STALE_DAYS;
+  const nowMs = Date.now();
+  const dir = dataDir();
+  const currentFile = defaultDbPath(getProjectKey(process.cwd()));
+
+  const entries = scanDatabases(dir, currentFile, staleDays, nowMs);
+  if (entries.length === 0) {
+    console.log(`No databases found in ${dir}`);
+    return;
+  }
+
+  const candidates = entries.filter((e) => isDeletionCandidate(e.status));
+  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
+  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
+
+  console.log(`Project databases in ${dir}:\n`);
+  for (const e of entries) console.log(reportLine(e, nowMs));
+  console.log(
+    `\n${entries.length} databases · ${formatBytes(totalBytes)} total · ` +
+      `${candidates.length} reclaimable (${formatBytes(reclaimable)})`
+  );
+  console.log(
+    `  Orphaned = project path deleted · LEGACY-STALE = no recorded path, ` +
+      `untouched > ${staleDays}d (raise/lower with --stale-days N)`
+  );
+
+  if (dryRun) {
+    if (candidates.length > 0) {
+      console.log(`\nDry run — pass --force to delete the ${candidates.length} marked database(s).`);
+    }
+  } else {
+    let freed = 0;
+    for (const e of candidates) {
+      deleteDbFiles(e.file);
+      freed += e.sizeBytes;
+    }
+    console.log(`\nDeleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
+  }
+
+  if (opts.vacuum) {
+    // Vacuum survivors only: never the current (live-locked) DB, and skip anything
+    // already deleted above.
+    const deleted = new Set(dryRun ? [] : candidates.map((e) => e.file));
+    const survivors = entries.filter(
+      (e) => e.status !== "current" && e.status !== "unreadable" && !deleted.has(e.file)
+    );
+    let reclaimed = 0;
+    let vacuumed = 0;
+    let skipped = 0;
+    for (const e of survivors) {
+      const result = vacuumFile(e.file);
+      if (result) {
+        reclaimed += Math.max(0, result.before - result.after);
+        vacuumed++;
+      } else {
+        skipped++;
+        console.log(`  skipped ${basename(e.file)} — locked by another session or unreadable`);
+      }
+    }
+    const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";
+    console.log(
+      `Vacuumed ${vacuumed} database(s), reclaimed ${formatBytes(reclaimed)} of free pages.${skipNote}`
+    );
+  }
+}

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -53,6 +53,18 @@ export function isDeletionCandidate(status: DbStatus): boolean {
   return status === "orphaned" || status === "legacy-stale";
 }
 
+/**
+ * Databases `--vacuum` should rewrite: the ones being kept. Excludes deletion
+ * candidates (pointless to rewrite a DB slated for removal — and in a dry run
+ * would otherwise VACUUM the entire store), the live-locked current DB, and
+ * anything unreadable.
+ */
+export function vacuumTargets(entries: DbEntry[]): DbEntry[] {
+  return entries.filter(
+    (e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable"
+  );
+}
+
 function fileSizeSafe(path: string): number {
   try {
     return statSync(path).size;
@@ -223,23 +235,33 @@ export function gcCommand(opts: GcOptions = {}): void {
   }
 
   if (opts.vacuum) {
-    // Vacuum survivors only: never the current (live-locked) DB, and skip anything
-    // already deleted above.
-    const deleted = new Set(dryRun ? [] : candidates.map((e) => e.file));
-    const survivors = entries.filter(
-      (e) => e.status !== "current" && e.status !== "unreadable" && !deleted.has(e.file)
+    // Vacuum the databases we are KEEPING only. Deletion candidates are excluded
+    // regardless of dry-run — rewriting a DB that is slated for removal is pure
+    // waste (and, in a dry run, would otherwise VACUUM the entire store). The
+    // current (live-locked) and unreadable DBs are also skipped.
+    const survivors = vacuumTargets(entries);
+    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
+    console.log(
+      `\nVacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) — ` +
+        `rewrites each file, may take a while…`
     );
     let reclaimed = 0;
     let vacuumed = 0;
     let skipped = 0;
-    for (const e of survivors) {
+    for (let i = 0; i < survivors.length; i++) {
+      const e = survivors[i]!;
+      process.stdout.write(
+        `  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})… `
+      );
       const result = vacuumFile(e.file);
       if (result) {
-        reclaimed += Math.max(0, result.before - result.after);
+        const freed = Math.max(0, result.before - result.after);
+        reclaimed += freed;
         vacuumed++;
+        console.log(`reclaimed ${formatBytes(freed)}`);
       } else {
         skipped++;
-        console.log(`  skipped ${basename(e.file)} — locked by another session or unreadable`);
+        console.log(`skipped — locked by another session or unreadable`);
       }
     }
     const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -9,16 +9,21 @@
  *      auto_vacuum=INCREMENTAL. `gc --vacuum` runs a full VACUUM on survivors,
  *      which reclaims free pages AND upgrades legacy auto_vacuum=NONE DBs.
  *
- * Default is a dry run — nothing is deleted without `--force`.
+ * Default is a dry run — nothing is deleted without `--force`. Deletion is
+ * conservative: only DBs whose project was *definitively* removed (the recorded
+ * path is gone but its parent still exists) or pathless DBs untouched past the
+ * stale window are candidates. A path missing because its whole volume is
+ * unmounted, a non-mcp-recall `.db`, or a corrupt DB is never a candidate.
  */
 
 import { Database } from "bun:sqlite";
 import { readdirSync, existsSync, statSync, rmSync } from "fs";
-import { join, basename } from "path";
+import { join, basename, dirname, resolve } from "path";
 import { dataDir, defaultDbPath } from "../db/schema";
 import { getMeta } from "../db/queries";
 import { getProjectKey } from "../project-key";
 import { formatBytes, formatRelativeTime } from "../format";
+import { log } from "../log";
 
 const DEFAULT_STALE_DAYS = 90;
 
@@ -34,10 +39,27 @@ export interface GcOptions {
 export type DbStatus =
   | "current" // the active project's DB — never touched
   | "active" // recorded path still exists on disk
-  | "orphaned" // recorded path is gone — safe to remove
+  | "orphaned" // recorded path gone but its parent exists — project deleted, safe to remove
+  | "unverifiable" // recorded path AND its parent gone — likely an unmounted volume; never deleted
   | "legacy-fresh" // no recorded path, recently modified — kept
   | "legacy-stale" // no recorded path, untouched past the stale window — candidate
-  | "unreadable"; // could not be opened — reported, never deleted
+  | "unreadable"; // not an mcp-recall DB, or could not be read — reported, never deleted
+
+/**
+ * Per-status policy. As a `Record<DbStatus, …>` this is exhaustive: adding a new
+ * `DbStatus` variant without a policy is a compile error — so no status can be
+ * silently treated as deletable or vacuumable. This is the single source of truth
+ * for both decisions.
+ */
+const STATUS_POLICY: Record<DbStatus, { deletable: boolean; vacuumable: boolean }> = {
+  current: { deletable: false, vacuumable: false },
+  active: { deletable: false, vacuumable: true },
+  orphaned: { deletable: true, vacuumable: false },
+  unverifiable: { deletable: false, vacuumable: false },
+  "legacy-fresh": { deletable: false, vacuumable: true },
+  "legacy-stale": { deletable: true, vacuumable: false },
+  unreadable: { deletable: false, vacuumable: false },
+};
 
 export interface DbEntry {
   file: string; // absolute path to the .db file
@@ -50,20 +72,20 @@ export interface DbEntry {
 
 /** True for statuses that `gc --force` will delete. */
 export function isDeletionCandidate(status: DbStatus): boolean {
-  return status === "orphaned" || status === "legacy-stale";
+  return STATUS_POLICY[status].deletable;
 }
 
 /**
  * Databases `--vacuum` should rewrite: the ones being kept. Excludes deletion
  * candidates (pointless to rewrite a DB slated for removal — and in a dry run
  * would otherwise VACUUM the entire store), the live-locked current DB, and
- * anything unreadable.
+ * anything unverifiable/unreadable.
  */
 export function vacuumTargets(entries: DbEntry[]): DbEntry[] {
-  return entries.filter(
-    (e) => !isDeletionCandidate(e.status) && e.status !== "current" && e.status !== "unreadable"
-  );
+  return entries.filter((e) => STATUS_POLICY[e.status].vacuumable);
 }
+
+const sumBytes = (entries: DbEntry[]): number => entries.reduce((sum, e) => sum + e.sizeBytes, 0);
 
 function fileSizeSafe(path: string): number {
   try {
@@ -102,6 +124,75 @@ export function storeFootprint(dir: string = dataDir()): StoreFootprint {
 }
 
 /**
+ * The one-line session-start reminder to run `gc`, or "" when the store is under
+ * the threshold or reminders are disabled (`reminderMb <= 0`). Pure — the caller
+ * supplies the footprint (from the cheap `storeFootprint`).
+ */
+export function gcReminderText(footprint: StoreFootprint, reminderMb: number): string {
+  if (reminderMb <= 0) return "";
+  if (footprint.totalBytes < reminderMb * 1024 * 1024) return "";
+  return (
+    `💡 recall store is ${formatBytes(footprint.totalBytes)} across ${footprint.dbCount} ` +
+    `project databases — run \`mcp-recall gc\` to review and reclaim disk space.`
+  );
+}
+
+/** Reads a DB's classification inputs. `null` recordedPath = no meta / legacy. */
+interface DbProbe {
+  readable: boolean; // opened AND is an mcp-recall DB we could read
+  projectPath: string | null;
+  items: number;
+}
+
+/**
+ * Opens a DB read-only and reads what classification needs. A file that is not an
+ * mcp-recall database (no `stored_outputs` table) or that errors on read (corrupt)
+ * is reported `readable: false` so it is never treated as a deletion candidate.
+ */
+function probeDb(file: string): DbProbe {
+  let db: Database | null = null;
+  try {
+    db = new Database(file, { readonly: true });
+    const isRecallDb = db
+      .prepare(`SELECT 1 FROM sqlite_master WHERE type='table' AND name='stored_outputs'`)
+      .get();
+    if (!isRecallDb) return { readable: false, projectPath: null, items: 0 };
+
+    let projectPath: string | null = null;
+    try {
+      projectPath = getMeta(db, "project_path");
+    } catch {
+      projectPath = null; // legacy DB without a `meta` table — legitimate
+    }
+    // Outside the meta catch: a throw here means real corruption, not just a
+    // missing table, so it propagates to the outer catch → unreadable.
+    const items = (db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get() as { n: number }).n;
+    return { readable: true, projectPath, items };
+  } catch {
+    return { readable: false, projectPath: null, items: 0 };
+  } finally {
+    db?.close();
+  }
+}
+
+/** Classifies one DB. Split out for exhaustive, testable status logic. */
+function classify(
+  probe: DbProbe,
+  mtimeMs: number,
+  staleCutoffMs: number
+): DbStatus {
+  if (!probe.readable) return "unreadable";
+  if (probe.projectPath !== null) {
+    if (existsSync(probe.projectPath)) return "active";
+    // Path gone: only call it orphaned if the PARENT still exists (the project
+    // dir was really deleted). If the parent is also gone, the volume is likely
+    // just unmounted — never delete on that basis.
+    return existsSync(dirname(probe.projectPath)) ? "orphaned" : "unverifiable";
+  }
+  return mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
+}
+
+/**
  * Inspects every `*.db` in `dir` and classifies it. Pure aside from reads:
  * no file is modified or deleted. `currentFile` is the active project's DB path
  * (always classified "current"); `nowMs` is injectable for deterministic tests.
@@ -115,6 +206,9 @@ export function scanDatabases(
   if (!existsSync(dir)) return [];
 
   const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
+  // Resolve both sides so a non-normalized RECALL_DB_PATH (e.g. a "/./" segment)
+  // still matches the scanned, join-normalized path — protecting the live DB.
+  const currentResolved = resolve(currentFile);
   const entries: DbEntry[] = [];
 
   for (const name of readdirSync(dir)) {
@@ -129,43 +223,14 @@ export function scanDatabases(
     }
     const sizeBytes = dbFootprint(file);
 
-    if (file === currentFile) {
+    if (resolve(file) === currentResolved) {
       entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
       continue;
     }
 
-    let projectPath: string | null = null;
-    let items = 0;
-    let readable = true;
-    let db: Database | null = null;
-    try {
-      db = new Database(file, { readonly: true });
-      try {
-        projectPath = getMeta(db, "project_path");
-      } catch {
-        projectPath = null; // legacy DB without a `meta` table
-      }
-      try {
-        items = (db.prepare(`SELECT COUNT(*) AS n FROM stored_outputs`).get() as { n: number }).n;
-      } catch {
-        items = 0;
-      }
-    } catch {
-      readable = false;
-    } finally {
-      db?.close();
-    }
-
-    let status: DbStatus;
-    if (!readable) {
-      status = "unreadable";
-    } else if (projectPath !== null) {
-      status = existsSync(projectPath) ? "active" : "orphaned";
-    } else {
-      status = mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";
-    }
-
-    entries.push({ file, status, projectPath, sizeBytes, mtimeMs, items });
+    const probe = probeDb(file);
+    const status = classify(probe, mtimeMs, staleCutoffMs);
+    entries.push({ file, status, projectPath: probe.projectPath, sizeBytes, mtimeMs, items: probe.items });
   }
 
   // Largest first — the biggest reclaimable wins surface at the top.
@@ -176,6 +241,7 @@ const STATUS_LABEL: Record<DbStatus, string> = {
   current: "current",
   active: "active",
   orphaned: "ORPHANED",
+  unverifiable: "unverifiable",
   "legacy-fresh": "legacy",
   "legacy-stale": "LEGACY-STALE",
   unreadable: "unreadable",
@@ -192,8 +258,10 @@ function reportLine(e: DbEntry, nowMs: number): string {
   );
 }
 
+export type VacuumResult = { before: number; after: number } | { error: string };
+
 /** Full VACUUM: reclaims free pages and upgrades legacy DBs to incremental auto-vacuum. */
-function vacuumFile(file: string): { before: number; after: number } | null {
+export function vacuumFile(file: string): VacuumResult {
   const before = dbFootprint(file);
   let db: Database | null = null;
   try {
@@ -201,18 +269,35 @@ function vacuumFile(file: string): { before: number; after: number } | null {
     db.run("PRAGMA busy_timeout=5000");
     db.run("PRAGMA auto_vacuum=INCREMENTAL");
     db.run("VACUUM");
-  } catch {
-    return null; // locked or corrupt — skip, never fatal
+  } catch (e) {
+    const message = e instanceof Error ? e.message : String(e);
+    // VACUUM is atomic — a failure leaves the DB intact. Log the real cause; the
+    // caller derives a user-facing reason from it.
+    log.warn(`vacuum failed for ${basename(file)} — ${message}`);
+    return { error: message };
   } finally {
     db?.close();
   }
   return { before, after: dbFootprint(file) };
 }
 
+/** Best-effort human-readable cause for a skipped vacuum, from the raw error. */
+function vacuumSkipReason(error: string): string {
+  if (/lock|busy/i.test(error)) return "locked by another session";
+  if (/disk|full|space/i.test(error)) return "disk full";
+  return "unreadable or errored (see RECALL_DEBUG logs)";
+}
+
 function deleteDbFiles(file: string): void {
   for (const f of [file, `${file}-wal`, `${file}-shm`]) {
     rmSync(f, { force: true });
   }
+}
+
+/** Deletes each candidate's `.db` + WAL/SHM sidecars. Returns bytes freed. */
+export function executeDeletions(candidates: DbEntry[]): number {
+  for (const e of candidates) deleteDbFiles(e.file);
+  return sumBytes(candidates);
 }
 
 /** Entry point for the `gc` CLI subcommand. Prints a report and, unless dry-run, reclaims. */
@@ -230,18 +315,16 @@ export function gcCommand(opts: GcOptions = {}): void {
   }
 
   const candidates = entries.filter((e) => isDeletionCandidate(e.status));
-  const reclaimable = candidates.reduce((sum, e) => sum + e.sizeBytes, 0);
-  const totalBytes = entries.reduce((sum, e) => sum + e.sizeBytes, 0);
 
   console.log(`Project databases in ${dir}:\n`);
   for (const e of entries) console.log(reportLine(e, nowMs));
   console.log(
-    `\n${entries.length} databases · ${formatBytes(totalBytes)} total · ` +
-      `${candidates.length} reclaimable (${formatBytes(reclaimable)})`
+    `\n${entries.length} databases · ${formatBytes(sumBytes(entries))} total · ` +
+      `${candidates.length} reclaimable (${formatBytes(sumBytes(candidates))})`
   );
   console.log(
-    `  Orphaned = project path deleted · LEGACY-STALE = no recorded path, ` +
-      `untouched > ${staleDays}d (raise/lower with --stale-days N)`
+    `  ORPHANED = project path deleted · LEGACY-STALE = no recorded path, untouched > ${staleDays}d ` +
+      `(--stale-days N) · unverifiable/unreadable are never deleted`
   );
 
   if (dryRun) {
@@ -249,23 +332,17 @@ export function gcCommand(opts: GcOptions = {}): void {
       console.log(`\nDry run — pass --force to delete the ${candidates.length} marked database(s).`);
     }
   } else {
-    let freed = 0;
-    for (const e of candidates) {
-      deleteDbFiles(e.file);
-      freed += e.sizeBytes;
-    }
+    const freed = executeDeletions(candidates);
     console.log(`\nDeleted ${candidates.length} database(s), freed ${formatBytes(freed)}.`);
   }
 
   if (opts.vacuum) {
-    // Vacuum the databases we are KEEPING only. Deletion candidates are excluded
-    // regardless of dry-run — rewriting a DB that is slated for removal is pure
-    // waste (and, in a dry run, would otherwise VACUUM the entire store). The
-    // current (live-locked) and unreadable DBs are also skipped.
+    // Vacuum the databases we are KEEPING only (see vacuumTargets). Acts regardless
+    // of dry-run: --vacuum is an explicit reclaim action, orthogonal to --force,
+    // and VACUUM is non-destructive to data.
     const survivors = vacuumTargets(entries);
-    const totalToVacuum = survivors.reduce((sum, e) => sum + e.sizeBytes, 0);
     console.log(
-      `\nVacuuming ${survivors.length} database(s) to keep (${formatBytes(totalToVacuum)}) — ` +
+      `\nVacuuming ${survivors.length} database(s) to keep (${formatBytes(sumBytes(survivors))}) — ` +
         `rewrites each file, may take a while…`
     );
     let reclaimed = 0;
@@ -277,14 +354,14 @@ export function gcCommand(opts: GcOptions = {}): void {
         `  [${i + 1}/${survivors.length}] ${basename(e.file)} (${formatBytes(e.sizeBytes)})… `
       );
       const result = vacuumFile(e.file);
-      if (result) {
+      if ("after" in result) {
         const freed = Math.max(0, result.before - result.after);
         reclaimed += freed;
         vacuumed++;
         console.log(`reclaimed ${formatBytes(freed)}`);
       } else {
         skipped++;
-        console.log(`skipped — locked by another session or unreadable`);
+        console.log(`skipped — ${vacuumSkipReason(result.error)}`);
       }
     }
     const skipNote = skipped > 0 ? ` (${skipped} skipped)` : "";

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,6 +1,6 @@
 import { loadConfig } from "../config";
-import { getProjectKey } from "../project-key";
-import { getDb, defaultDbPath, recordSession, pruneExpired } from "../db/index";
+import { getProjectKey, getProjectPath } from "../project-key";
+import { getDb, defaultDbPath, recordSession, pruneExpired, setMeta } from "../db/index";
 import { toolContext, CONTEXT_EMPTY_RESPONSE } from "../tools";
 import { log } from "../log";
 
@@ -29,6 +29,10 @@ export function handleSessionStart(raw: string): void {
   const config = loadConfig();
   const projectKey = getProjectKey(input.cwd);
   const db = getDb(defaultDbPath(projectKey));
+
+  // Record the resolved project path so `mcp-recall gc` can tell whether this
+  // project still exists on disk (orphan detection is path-existence based).
+  setMeta(db, "project_path", getProjectPath(input.cwd));
 
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
   recordSession(db, today);

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -2,7 +2,24 @@ import { loadConfig } from "../config";
 import { getProjectKey, getProjectPath } from "../project-key";
 import { getDb, defaultDbPath, recordSession, pruneExpired, setMeta } from "../db/index";
 import { toolContext, CONTEXT_EMPTY_RESPONSE } from "../tools";
+import { storeFootprint } from "../gc/index";
+import { formatBytes } from "../format";
 import { log } from "../log";
+
+/**
+ * Returns a one-line reminder to run `mcp-recall gc` when the store's on-disk
+ * footprint exceeds the configured threshold, or "" when it doesn't (or the
+ * reminder is disabled with `gc_reminder_mb = 0`). Cheap: stats files, no DB opens.
+ */
+function gcReminder(reminderMb: number): string {
+  if (reminderMb <= 0) return "";
+  const { totalBytes, dbCount } = storeFootprint();
+  if (totalBytes < reminderMb * 1024 * 1024) return "";
+  return (
+    `💡 recall store is ${formatBytes(totalBytes)} across ${dbCount} project ` +
+    `databases — run \`mcp-recall gc\` to review and reclaim disk space.`
+  );
+}
 
 interface SessionStartInput {
   session_id: string;
@@ -40,16 +57,26 @@ export function handleSessionStart(raw: string): void {
 
   // Inject a compact context snapshot into Claude's initial context via stdout.
   // Claude Code adds SessionStart hook stdout as context before the first message.
+  // A store-maintenance reminder (if any) leads, so it survives snapshot truncation.
+  const parts: string[] = [];
+  const reminder = gcReminder(config.store.gc_reminder_mb);
+  if (reminder) parts.push(reminder);
+
   let snapshot = toolContext(db, projectKey, {});
-  if (snapshot === CONTEXT_EMPTY_RESPONSE) {
-    log.debug(`session-start · project=${projectKey.slice(0, 8)} · nothing to inject`);
-  } else {
+  if (snapshot !== CONTEXT_EMPTY_RESPONSE) {
     if (snapshot.length > INJECT_MAX_CHARS) {
       snapshot =
         snapshot.slice(0, INJECT_MAX_CHARS) +
         "\n… (truncated — call recall__context for the full view)";
     }
-    process.stdout.write(snapshot + "\n");
-    log.debug(`session-start · project=${projectKey.slice(0, 8)} · injected ${snapshot.length} chars`);
+    parts.push(snapshot);
+  }
+
+  if (parts.length === 0) {
+    log.debug(`session-start · project=${projectKey.slice(0, 8)} · nothing to inject`);
+  } else {
+    const out = parts.join("\n\n");
+    process.stdout.write(out + "\n");
+    log.debug(`session-start · project=${projectKey.slice(0, 8)} · injected ${out.length} chars`);
   }
 }

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -2,24 +2,8 @@ import { loadConfig } from "../config";
 import { getProjectKey, getProjectPath } from "../project-key";
 import { getDb, defaultDbPath, recordSession, pruneExpired, setMeta } from "../db/index";
 import { toolContext, CONTEXT_EMPTY_RESPONSE } from "../tools";
-import { storeFootprint } from "../gc/index";
-import { formatBytes } from "../format";
+import { storeFootprint, gcReminderText } from "../gc/index";
 import { log } from "../log";
-
-/**
- * Returns a one-line reminder to run `mcp-recall gc` when the store's on-disk
- * footprint exceeds the configured threshold, or "" when it doesn't (or the
- * reminder is disabled with `gc_reminder_mb = 0`). Cheap: stats files, no DB opens.
- */
-function gcReminder(reminderMb: number): string {
-  if (reminderMb <= 0) return "";
-  const { totalBytes, dbCount } = storeFootprint();
-  if (totalBytes < reminderMb * 1024 * 1024) return "";
-  return (
-    `💡 recall store is ${formatBytes(totalBytes)} across ${dbCount} project ` +
-    `databases — run \`mcp-recall gc\` to review and reclaim disk space.`
-  );
-}
 
 interface SessionStartInput {
   session_id: string;
@@ -59,7 +43,7 @@ export function handleSessionStart(raw: string): void {
   // Claude Code adds SessionStart hook stdout as context before the first message.
   // A store-maintenance reminder (if any) leads, so it survives snapshot truncation.
   const parts: string[] = [];
-  const reminder = gcReminder(config.store.gc_reminder_mb);
+  const reminder = gcReminderText(storeFootprint(), config.store.gc_reminder_mb);
   if (reminder) parts.push(reminder);
 
   let snapshot = toolContext(db, projectKey, {});

--- a/src/install/index.ts
+++ b/src/install/index.ts
@@ -14,6 +14,9 @@ import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
 import { loadProfiles } from "../profiles/loader";
+import { storeFootprint } from "../gc/index";
+import { loadConfig } from "../config";
+import { formatBytes } from "../format";
 
 // ── Utilities ────────────────────────────────────────────────────────────────
 
@@ -520,6 +523,19 @@ export async function statusCommand(opts: StatusOptions = {}): Promise<void> {
     }, {});
     const summary = Object.entries(counts).map(([t, n]) => `${n} ${t}`).join(", ");
     console.log(`  ${GREEN}✓${RESET} Profiles: ${profiles.length} installed (${summary})`);
+  }
+
+  // Store footprint — nudge toward `gc` when the on-disk store is large.
+  console.log("");
+  const { totalBytes, dbCount } = storeFootprint();
+  const reminderMb = loadConfig().store.gc_reminder_mb;
+  const large = reminderMb > 0 && totalBytes >= reminderMb * 1024 * 1024;
+  const storeIcon = large ? `${YELLOW}!${RESET}` : `${GREEN}✓${RESET}`;
+  console.log(
+    `  ${storeIcon} Store: ${formatBytes(totalBytes)} across ${dbCount} project database${dbCount === 1 ? "" : "s"}`
+  );
+  if (large) {
+    console.log(`    → Reclaim space: ${BOLD}mcp-recall gc${RESET} (review, then re-run with ${BOLD}--force${RESET})`);
   }
 
   console.log("");

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,6 +34,7 @@ import { formatBytes, formatRelativeTime } from "./format";
 // Display constants
 // ---------------------------------------------------------------------------
 
+const PIN_BUDGET_WARN_PCT = 80;  // warn in recall__stats when pinned bytes reach this % of max_size_mb
 const SEARCH_EXCERPT_LEN  = 120; // chars shown per result in recall__search
 const NOTE_EXCERPT_LEN    = 200; // chars shown in recall__note store confirmation
 const CONTEXT_EXCERPT_LEN = 100; // chars shown per item in recall__context
@@ -539,6 +540,24 @@ export function toolStats(
     `  ~Tokens saved:     ~${tokensSaved.toLocaleString()}`,
     `  Session days:      ${sessionDays.length}`,
   ];
+
+  // Pin-budget awareness: pinned items are exempt from eviction, so a store that
+  // is mostly pinned can silently defeat the max_size_mb cap. Surface it.
+  if (stats.pinned_items > 0) {
+    const maxSizeMb = loadConfig().store.max_size_mb;
+    const maxBytes = maxSizeMb * 1024 * 1024;
+    const capPct = maxBytes > 0 ? (stats.pinned_bytes / maxBytes) * 100 : 0;
+    lines.push(
+      `  Pinned:            ${stats.pinned_items} item${stats.pinned_items === 1 ? "" : "s"}` +
+        ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of cap)`
+    );
+    if (capPct >= PIN_BUDGET_WARN_PCT) {
+      lines.push(
+        `  ⚠ Pinned data is ${capPct.toFixed(0)}% of the ${maxSizeMb} MB cap and is exempt` +
+          ` from eviction — unpin or raise store.max_size_mb to reclaim space.`
+      );
+    }
+  }
 
   // Per-tool breakdown
   const breakdown = getToolBreakdown(db, projectKey);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -28,6 +28,7 @@ describe("loadConfig", () => {
     expect(config.store.pin_recommendation_threshold).toBe(5);
     expect(config.store.stale_item_days).toBe(3);
     expect(config.store.eviction_half_life_days).toBe(7);
+    expect(config.store.gc_reminder_mb).toBe(2048);
     expect(config.retrieve.default_max_bytes).toBe(8192);
     expect(config.denylist.additional).toEqual([]);
     expect(config.denylist.override_defaults).toEqual([]);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -15,6 +15,8 @@ import {
   listOutputs,
   forgetOutputs,
   getStats,
+  setMeta,
+  getMeta,
   pruneExpired,
   recordSession,
   getSessionDays,
@@ -332,6 +334,43 @@ describe("db", () => {
       storeOutput(db, makeInput({ project_key: "otherproject567", original_size: 9999 }));
       const stats = getStats(db, PROJECT_KEY);
       expect(stats.total_items).toBe(0);
+    });
+
+    it("reports pinned item count and pinned bytes", () => {
+      const a = storeOutput(db, makeInput({ original_size: 1000 }));
+      storeOutput(db, makeInput({ original_size: 2000 }));
+      pinOutput(db, a.id, PROJECT_KEY, true);
+      const stats = getStats(db, PROJECT_KEY);
+      expect(stats.pinned_items).toBe(1);
+      expect(stats.pinned_bytes).toBe(1000);
+    });
+
+    it("reports zero pinned bytes when nothing is pinned", () => {
+      storeOutput(db, makeInput({ original_size: 500 }));
+      const stats = getStats(db, PROJECT_KEY);
+      expect(stats.pinned_items).toBe(0);
+      expect(stats.pinned_bytes).toBe(0);
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // meta table
+  // -------------------------------------------------------------------------
+
+  describe("setMeta / getMeta", () => {
+    it("returns null for an unset key", () => {
+      expect(getMeta(db, "project_path")).toBeNull();
+    });
+
+    it("stores and reads back a value", () => {
+      setMeta(db, "project_path", "/home/u/proj");
+      expect(getMeta(db, "project_path")).toBe("/home/u/proj");
+    });
+
+    it("upserts an existing key rather than duplicating it", () => {
+      setMeta(db, "project_path", "/old");
+      setMeta(db, "project_path", "/new");
+      expect(getMeta(db, "project_path")).toBe("/new");
     });
   });
 

--- a/tests/denylist.test.ts
+++ b/tests/denylist.test.ts
@@ -10,6 +10,7 @@ const baseConfig: RecallConfig = {
     pin_recommendation_threshold: 3,
     stale_item_days: 3,
     eviction_half_life_days: 7,
+    gc_reminder_mb: 2048,
   },
   retrieve: { default_max_bytes: 8192 },
   denylist: { additional: [], override_defaults: [], allowlist: [] },

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -4,7 +4,13 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { initSchema, setMeta, storeOutput, forgetOutputs } from "../src/db/index";
-import { scanDatabases, isDeletionCandidate, vacuumTargets, type DbEntry } from "../src/gc/index";
+import {
+  scanDatabases,
+  isDeletionCandidate,
+  vacuumTargets,
+  storeFootprint,
+  type DbEntry,
+} from "../src/gc/index";
 
 const DAY_MS = 86400 * 1000;
 
@@ -139,6 +145,28 @@ describe("gc vacuumTargets", () => {
 
   it("returns nothing when every database is a deletion candidate", () => {
     expect(vacuumTargets([entry("orphaned"), entry("legacy-stale")])).toEqual([]);
+  });
+});
+
+describe("gc storeFootprint", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recall-fp-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("returns zero for a nonexistent directory", () => {
+    expect(storeFootprint(join(workDir, "nope"))).toEqual({ totalBytes: 0, dbCount: 0 });
+  });
+
+  it("counts .db files and sums their size (ignoring non-.db files)", () => {
+    makeDb("a", null, 5);
+    makeDb("b", null, 5);
+    writeFileSync(join(workDir, "readme.txt"), "x");
+    const fp = storeFootprint(workDir);
+    expect(fp.dbCount).toBe(2);
+    expect(fp.totalBytes).toBeGreaterThan(0);
   });
 });
 

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -1,0 +1,152 @@
+import { describe, it, expect, beforeEach, afterEach } from "bun:test";
+import { Database } from "bun:sqlite";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { tmpdir } from "os";
+import { join } from "path";
+import { initSchema, setMeta, storeOutput, forgetOutputs } from "../src/db/index";
+import { scanDatabases, isDeletionCandidate } from "../src/gc/index";
+
+const DAY_MS = 86400 * 1000;
+
+let workDir: string; // holds the .db store
+let projectsDir: string; // holds fake project directories
+
+function makeDb(name: string, projectPath: string | null, items = 0): string {
+  const file = join(workDir, `${name}.db`);
+  const db = new Database(file);
+  initSchema(db);
+  if (projectPath !== null) setMeta(db, "project_path", projectPath);
+  for (let i = 0; i < items; i++) {
+    db.prepare(
+      `INSERT INTO stored_outputs
+        (id, project_key, session_id, tool_name, summary, full_content, original_size, summary_size, created_at)
+       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?)`
+    ).run(`id_${name}_${i}`, name, "2026-01-01", "t", "s", "c", 10, 2, 1000);
+  }
+  db.close();
+  return file;
+}
+
+/** A DB with no `meta` table at all — mimics stores created before meta existed. */
+function makeLegacyDb(name: string): string {
+  const file = join(workDir, `${name}.db`);
+  const db = new Database(file);
+  db.run(`CREATE TABLE stored_outputs (id TEXT PRIMARY KEY, original_size INTEGER)`);
+  db.close();
+  return file;
+}
+
+describe("gc scanDatabases", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recall-gc-"));
+    projectsDir = mkdtempSync(join(tmpdir(), "recall-proj-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+    rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  it("returns empty for a nonexistent directory", () => {
+    expect(scanDatabases(join(workDir, "nope"), "/x.db", 90)).toEqual([]);
+  });
+
+  it("classifies a DB whose recorded path exists as active", () => {
+    const existing = join(projectsDir, "live");
+    mkdirSync(existing);
+    makeDb("live", existing);
+    const [entry] = scanDatabases(workDir, "/current.db", 90);
+    expect(entry!.status).toBe("active");
+    expect(isDeletionCandidate(entry!.status)).toBe(false);
+  });
+
+  it("classifies a DB whose recorded path is gone as orphaned (deletion candidate)", () => {
+    makeDb("dead", join(projectsDir, "deleted-project"));
+    const [entry] = scanDatabases(workDir, "/current.db", 90);
+    expect(entry!.status).toBe("orphaned");
+    expect(isDeletionCandidate(entry!.status)).toBe(true);
+  });
+
+  it("never flags the current project's DB, even when its path is gone", () => {
+    const file = makeDb("mine", join(projectsDir, "also-deleted"));
+    const [entry] = scanDatabases(workDir, file, 90);
+    expect(entry!.status).toBe("current");
+    expect(isDeletionCandidate(entry!.status)).toBe(false);
+  });
+
+  it("treats a pathless DB as legacy-stale only once past the stale window", () => {
+    makeDb("old", null, 3);
+    // now = well past the stale window relative to the just-created file
+    const stale = scanDatabases(workDir, "/current.db", 90, Date.now() + 200 * DAY_MS);
+    expect(stale[0]!.status).toBe("legacy-stale");
+    expect(isDeletionCandidate(stale[0]!.status)).toBe(true);
+
+    const fresh = scanDatabases(workDir, "/current.db", 90, Date.now());
+    expect(fresh[0]!.status).toBe("legacy-fresh");
+    expect(isDeletionCandidate(fresh[0]!.status)).toBe(false);
+  });
+
+  it("handles a DB with no meta table (legacy) without throwing", () => {
+    makeLegacyDb("ancient");
+    const [entry] = scanDatabases(workDir, "/current.db", 90, Date.now() + 200 * DAY_MS);
+    expect(entry!.projectPath).toBeNull();
+    expect(entry!.status).toBe("legacy-stale");
+  });
+
+  it("reports item counts and sorts largest first", () => {
+    const a = join(projectsDir, "a");
+    const b = join(projectsDir, "b");
+    mkdirSync(a);
+    mkdirSync(b);
+    makeDb("small", a, 1);
+    makeDb("big", b, 200);
+    const entries = scanDatabases(workDir, "/current.db", 90);
+    expect(entries).toHaveLength(2);
+    expect(entries[0]!.sizeBytes).toBeGreaterThanOrEqual(entries[1]!.sizeBytes);
+    const big = entries.find((e) => e.file.endsWith("big.db"))!;
+    expect(big.items).toBe(200);
+  });
+
+  it("ignores non-.db files in the store directory", () => {
+    makeDb("real", join(projectsDir, "x"));
+    writeFileSync(join(workDir, "notes.txt"), "hi");
+    const entries = scanDatabases(workDir, "/current.db", 90);
+    expect(entries).toHaveLength(1);
+  });
+});
+
+describe("incremental_vacuum reclamation (on-disk)", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recall-vac-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("returns free pages to the file after a bulk delete on an INCREMENTAL db", () => {
+    const file = join(workDir, "store.db");
+    const db = new Database(file);
+    db.run("PRAGMA auto_vacuum=INCREMENTAL"); // must precede table creation
+    initSchema(db);
+
+    const big = "z".repeat(4096);
+    for (let i = 0; i < 80; i++) {
+      storeOutput(db, {
+        project_key: "p",
+        session_id: "2026-01-01",
+        tool_name: "mcp__tool",
+        summary: "s",
+        full_content: big,
+        original_size: big.length,
+      });
+    }
+    const before = (db.query("PRAGMA page_count").get() as { page_count: number }).page_count;
+
+    // forgetOutputs deletes >= VACUUM_THRESHOLD rows and calls reclaimPages internally.
+    const deleted = forgetOutputs(db, "p", { all: true, force: true });
+    expect(deleted).toBe(80);
+
+    const after = (db.query("PRAGMA page_count").get() as { page_count: number }).page_count;
+    expect(after).toBeLessThan(before);
+    db.close();
+  });
+});

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -4,7 +4,7 @@ import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { initSchema, setMeta, storeOutput, forgetOutputs } from "../src/db/index";
-import { scanDatabases, isDeletionCandidate } from "../src/gc/index";
+import { scanDatabases, isDeletionCandidate, vacuumTargets, type DbEntry } from "../src/gc/index";
 
 const DAY_MS = 86400 * 1000;
 
@@ -111,6 +111,34 @@ describe("gc scanDatabases", () => {
     writeFileSync(join(workDir, "notes.txt"), "hi");
     const entries = scanDatabases(workDir, "/current.db", 90);
     expect(entries).toHaveLength(1);
+  });
+});
+
+describe("gc vacuumTargets", () => {
+  const entry = (status: DbEntry["status"]): DbEntry => ({
+    file: `/x/${status}.db`,
+    status,
+    projectPath: null,
+    sizeBytes: 100,
+    mtimeMs: 0,
+    items: 0,
+  });
+
+  it("vacuums only kept databases — never deletion candidates, current, or unreadable", () => {
+    const all: DbEntry[] = [
+      entry("active"),
+      entry("legacy-fresh"),
+      entry("orphaned"), // deletion candidate — must be excluded (was the 5GB bug)
+      entry("legacy-stale"), // deletion candidate — must be excluded
+      entry("current"), // live-locked
+      entry("unreadable"),
+    ];
+    const targets = vacuumTargets(all).map((e) => e.status);
+    expect(targets).toEqual(["active", "legacy-fresh"]);
+  });
+
+  it("returns nothing when every database is a deletion candidate", () => {
+    expect(vacuumTargets([entry("orphaned"), entry("legacy-stale")])).toEqual([]);
   });
 });
 

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -1,6 +1,6 @@
 import { describe, it, expect, beforeEach, afterEach } from "bun:test";
 import { Database } from "bun:sqlite";
-import { mkdtempSync, rmSync, mkdirSync, writeFileSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, writeFileSync, existsSync } from "fs";
 import { tmpdir } from "os";
 import { join } from "path";
 import { initSchema, setMeta, storeOutput, forgetOutputs } from "../src/db/index";
@@ -9,6 +9,9 @@ import {
   isDeletionCandidate,
   vacuumTargets,
   storeFootprint,
+  executeDeletions,
+  vacuumFile,
+  gcReminderText,
   type DbEntry,
 } from "../src/gc/index";
 
@@ -38,6 +41,15 @@ function makeLegacyDb(name: string): string {
   const file = join(workDir, `${name}.db`);
   const db = new Database(file);
   db.run(`CREATE TABLE stored_outputs (id TEXT PRIMARY KEY, original_size INTEGER)`);
+  db.close();
+  return file;
+}
+
+/** A valid SQLite file that is NOT an mcp-recall DB (no `stored_outputs` table). */
+function makeForeignDb(name: string): string {
+  const file = join(workDir, `${name}.db`);
+  const db = new Database(file);
+  db.run(`CREATE TABLE something_else (x INTEGER)`);
   db.close();
   return file;
 }
@@ -76,6 +88,30 @@ describe("gc scanDatabases", () => {
     const file = makeDb("mine", join(projectsDir, "also-deleted"));
     const [entry] = scanDatabases(workDir, file, 90);
     expect(entry!.status).toBe("current");
+    expect(isDeletionCandidate(entry!.status)).toBe(false);
+  });
+
+  it("matches the current DB even when currentFile is a non-normalized path", () => {
+    const file = makeDb("mine", null);
+    // e.g. a RECALL_DB_PATH override with a "/./" segment — resolve() must still match.
+    const nonNormalized = join(workDir, ".", "mine.db");
+    const [entry] = scanDatabases(workDir, nonNormalized, 90);
+    expect(entry!.file).toBe(file);
+    expect(entry!.status).toBe("current");
+  });
+
+  it("classifies a path gone whose PARENT is also gone as unverifiable (never deleted)", () => {
+    // Mimics a live project on an unmounted volume: whole path tree absent.
+    makeDb("unmounted", "/no/such/mount/point/project");
+    const [entry] = scanDatabases(workDir, "/current.db", 90);
+    expect(entry!.status).toBe("unverifiable");
+    expect(isDeletionCandidate(entry!.status)).toBe(false);
+  });
+
+  it("classifies a non-mcp-recall .db as unreadable (never deleted)", () => {
+    makeForeignDb("stranger");
+    const [entry] = scanDatabases(workDir, "/current.db", 90, Date.now() + 200 * DAY_MS);
+    expect(entry!.status).toBe("unreadable");
     expect(isDeletionCandidate(entry!.status)).toBe(false);
   });
 
@@ -137,6 +173,7 @@ describe("gc vacuumTargets", () => {
       entry("orphaned"), // deletion candidate — must be excluded (was the 5GB bug)
       entry("legacy-stale"), // deletion candidate — must be excluded
       entry("current"), // live-locked
+      entry("unverifiable"), // path unverifiable — must be excluded
       entry("unreadable"),
     ];
     const targets = vacuumTargets(all).map((e) => e.status);
@@ -204,5 +241,99 @@ describe("incremental_vacuum reclamation (on-disk)", () => {
     const after = (db.query("PRAGMA page_count").get() as { page_count: number }).page_count;
     expect(after).toBeLessThan(before);
     db.close();
+  });
+});
+
+describe("gc executeDeletions (destructive path)", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recall-del-"));
+    projectsDir = mkdtempSync(join(tmpdir(), "recall-delproj-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+    rmSync(projectsDir, { recursive: true, force: true });
+  });
+
+  it("deletes only deletion candidates, including their -wal/-shm sidecars, and never a live DB", () => {
+    // orphaned: recorded path gone but parent (projectsDir) exists → candidate
+    const orphanFile = makeDb("orphan", join(projectsDir, "gone"));
+    writeFileSync(`${orphanFile}-wal`, "wal");
+    writeFileSync(`${orphanFile}-shm`, "shm");
+    // active: recorded path exists → must be preserved
+    const liveDir = join(projectsDir, "live");
+    mkdirSync(liveDir);
+    const activeFile = makeDb("active", liveDir);
+
+    const entries = scanDatabases(workDir, "/current.db", 90);
+    const candidates = entries.filter((e) => isDeletionCandidate(e.status));
+    expect(candidates.map((e) => e.file)).toEqual([orphanFile]);
+
+    const freed = executeDeletions(candidates);
+    expect(freed).toBeGreaterThan(0);
+    expect(existsSync(orphanFile)).toBe(false);
+    expect(existsSync(`${orphanFile}-wal`)).toBe(false);
+    expect(existsSync(`${orphanFile}-shm`)).toBe(false);
+    expect(existsSync(activeFile)).toBe(true); // non-candidate untouched
+  });
+});
+
+describe("gc vacuumFile (full VACUUM)", () => {
+  beforeEach(() => {
+    workDir = mkdtempSync(join(tmpdir(), "recall-vf-"));
+  });
+  afterEach(() => {
+    rmSync(workDir, { recursive: true, force: true });
+  });
+
+  it("reclaims free pages and upgrades a legacy auto_vacuum=NONE DB to INCREMENTAL", () => {
+    const file = join(workDir, "legacy.db");
+    const db = new Database(file); // default auto_vacuum = NONE (0)
+    initSchema(db);
+    expect((db.query("PRAGMA auto_vacuum").get() as { auto_vacuum: number }).auto_vacuum).toBe(0);
+
+    const big = "z".repeat(4096);
+    for (let i = 0; i < 120; i++) {
+      storeOutput(db, {
+        project_key: "p",
+        session_id: "2026-01-01",
+        tool_name: "t",
+        summary: "s",
+        full_content: big,
+        original_size: big.length,
+      });
+    }
+    // Raw delete (no reclaimPages) — on a NONE database the pages become freelist.
+    db.prepare("DELETE FROM stored_outputs").run();
+    const freelistBefore = (db.query("PRAGMA freelist_count").get() as { freelist_count: number }).freelist_count;
+    expect(freelistBefore).toBeGreaterThan(0);
+    db.close();
+
+    const result = vacuumFile(file);
+    expect("after" in result).toBe(true);
+    if ("after" in result) expect(result.after).toBeLessThanOrEqual(result.before);
+
+    const check = new Database(file, { readonly: true });
+    // 2 = INCREMENTAL — the legacy DB was upgraded.
+    expect((check.query("PRAGMA auto_vacuum").get() as { auto_vacuum: number }).auto_vacuum).toBe(2);
+    expect((check.query("PRAGMA freelist_count").get() as { freelist_count: number }).freelist_count).toBe(0);
+    check.close();
+  });
+});
+
+describe("gc gcReminderText", () => {
+  const GB = 1024 * 1024 * 1024;
+
+  it("returns empty when reminders are disabled (reminderMb <= 0)", () => {
+    expect(gcReminderText({ totalBytes: 10 * GB, dbCount: 50 }, 0)).toBe("");
+  });
+
+  it("returns empty when under the threshold", () => {
+    expect(gcReminderText({ totalBytes: 100 * 1024 * 1024, dbCount: 3 }, 2048)).toBe("");
+  });
+
+  it("returns a reminder naming size and count when over the threshold", () => {
+    const msg = gcReminderText({ totalBytes: 3 * GB, dbCount: 40 }, 2048);
+    expect(msg).toContain("mcp-recall gc");
+    expect(msg).toContain("40");
   });
 });


### PR DESCRIPTION
Closes #200.

## Summary

Surfaced by a dogfooding pass on the live install (5.1GB across 77 project DBs; core value prop healthy at 88–97% context savings, but three DB-lifecycle gaps let disk grow without bound):

- **`mcp-recall gc`** — classifies every project DB (active / orphaned / legacy / current) via a recorded `project_path` in a new per-DB `meta` table, reports reclaimable bytes, and deletes orphaned + stale-legacy DBs on `--force` (dry-run by default). `--vacuum` full-VACUUMs survivors (reclaims free pages + upgrades legacy `auto_vacuum=NONE` DBs). The active project's DB is **never** a deletion candidate.
- **Free-page reclamation on automatic deletes** — extracted `reclaimPages()` and wired it into `evictIfNeeded` and the session-start prune (previously only manual `recall__forget` reclaimed).
- **Pin-budget awareness** — `recall__stats` reports pinned items/bytes and warns when pinned data (exempt from eviction) reaches ≥80% of the `store.max_size_mb` cap.

## Live dogfood

`gc --stale-days 30` against the real 5.15GB store correctly flagged **62 DBs / 4.39GB reclaimable**, protected the current DB, and stayed a dry run. No data touched.

## Review

A `typescript-reviewer` pass returned APPROVE (no CRITICAL/blocking issues) and verified: current-DB protection, exact path-existence orphan check, `finally` handle cleanup, dry-run default, non-fatal VACUUM failures. Non-blocking nits applied: hoisted a duplicate `loadConfig()` call; `--vacuum` now reports skipped (locked) DBs.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 747 pass, 0 fail (added `tests/gc.test.ts`: classification for all statuses, current-DB protection, legacy-no-meta handling, on-disk `incremental_vacuum` reclamation; extended db tests for `meta` + pinned stats)
- [x] `bun run build` (dist rebuilt; bundle-freshness green)
- [x] Live `gc` dry-run validated against real store
- [ ] Reviewer/CI green on PR