### PR TITLE
fix: never orphan-delete a DB whose recorded project path is relative

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5660,7 +5660,7 @@ function toolContext(db, projectKey, args) {
 // src/gc/index.ts
 import { Database as Database2 } from "bun:sqlite";
 import { readdirSync, existsSync, statSync, rmSync } from "fs";
-import { join as join3, basename, dirname as dirname2, resolve } from "path";
+import { join as join3, basename, dirname as dirname2, resolve, isAbsolute } from "path";
 var DEFAULT_STALE_DAYS = 90;
 var STATUS_POLICY = {
   current: { deletable: false, vacuumable: false },
@@ -5735,6 +5735,8 @@ function classify(probe, mtimeMs, staleCutoffMs) {
   if (probe.projectPath !== null) {
     if (existsSync(probe.projectPath))
       return "active";
+    if (!isAbsolute(probe.projectPath))
+      return "unverifiable";
     return existsSync(dirname2(probe.projectPath)) ? "orphaned" : "unverifiable";
   }
   return mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5733,10 +5733,10 @@ function classify(probe, mtimeMs, staleCutoffMs) {
   if (!probe.readable)
     return "unreadable";
   if (probe.projectPath !== null) {
-    if (existsSync(probe.projectPath))
-      return "active";
     if (!isAbsolute(probe.projectPath))
       return "unverifiable";
+    if (existsSync(probe.projectPath))
+      return "active";
     return existsSync(dirname2(probe.projectPath)) ? "orphaned" : "unverifiable";
   }
   return mtimeMs < staleCutoffMs ? "legacy-stale" : "legacy-fresh";

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -41,7 +41,7 @@ export type DbStatus =
   | "current" // the active project's DB — never touched
   | "active" // recorded path still exists on disk
   | "orphaned" // recorded path gone but its parent exists — project deleted, safe to remove
-  | "unverifiable" // recorded path AND its parent gone — likely an unmounted volume; never deleted
+  | "unverifiable" // can't be reasoned about: path AND parent gone (likely an unmounted volume), or a relative path with no knowable root; never deleted
   | "legacy-fresh" // no recorded path, recently modified — kept
   | "legacy-stale" // no recorded path, untouched past the stale window — candidate
   | "unreadable"; // not an mcp-recall DB, or could not be read — reported, never deleted
@@ -184,13 +184,13 @@ function classify(
 ): DbStatus {
   if (!probe.readable) return "unreadable";
   if (probe.projectPath !== null) {
-    if (existsSync(probe.projectPath)) return "active";
-    // The orphan test below reasons about the recorded path's PARENT, which is
-    // only meaningful for an absolute path. `dirname` of "" or of a bare name is
-    // ".", which always exists, so a relative path would read as "parent survived,
-    // project deleted" and be destroyed. We cannot tell where a relative path was
-    // rooted, so it is exactly the can't-verify case.
+    // Checked before any existsSync: a relative path is resolved against the cwd
+    // gc happens to run from, so it would otherwise classify differently per
+    // invocation — and "." or a bare name would read as "parent survived, project
+    // deleted" (dirname is ".", which always exists) and be destroyed. We cannot
+    // know where a relative path was rooted, so it is the can't-verify case.
     if (!isAbsolute(probe.projectPath)) return "unverifiable";
+    if (existsSync(probe.projectPath)) return "active";
     // Path gone: only call it orphaned if the PARENT still exists (the project
     // dir was really deleted). If the parent is also gone, the volume is likely
     // just unmounted — never delete on that basis.

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -13,12 +13,13 @@
  * conservative: only DBs whose project was *definitively* removed (the recorded
  * path is gone but its parent still exists) or pathless DBs untouched past the
  * stale window are candidates. A path missing because its whole volume is
- * unmounted, a non-mcp-recall `.db`, or a corrupt DB is never a candidate.
+ * unmounted, a recorded path we cannot reason about (relative, so un-rootable), a
+ * non-mcp-recall `.db`, or a corrupt DB is never a candidate.
  */
 
 import { Database } from "bun:sqlite";
 import { readdirSync, existsSync, statSync, rmSync } from "fs";
-import { join, basename, dirname, resolve } from "path";
+import { join, basename, dirname, resolve, isAbsolute } from "path";
 import { dataDir, defaultDbPath } from "../db/schema";
 import { getMeta } from "../db/queries";
 import { getProjectKey } from "../project-key";
@@ -184,6 +185,12 @@ function classify(
   if (!probe.readable) return "unreadable";
   if (probe.projectPath !== null) {
     if (existsSync(probe.projectPath)) return "active";
+    // The orphan test below reasons about the recorded path's PARENT, which is
+    // only meaningful for an absolute path. `dirname` of "" or of a bare name is
+    // ".", which always exists, so a relative path would read as "parent survived,
+    // project deleted" and be destroyed. We cannot tell where a relative path was
+    // rooted, so it is exactly the can't-verify case.
+    if (!isAbsolute(probe.projectPath)) return "unverifiable";
     // Path gone: only call it orphaned if the PARENT still exists (the project
     // dir was really deleted). If the parent is also gone, the volume is likely
     // just unmounted — never delete on that basis.

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -114,6 +114,21 @@ describe("gc scanDatabases", () => {
     expect(isDeletionCandidate(entry!.status)).toBe(false);
   });
 
+  // `dirname("")` and `dirname("bare-name")` are both ".", which always exists, so
+  // the parent-survived orphan test would read these as "project deleted" and
+  // destroy the DB. A relative path cannot be rooted, so it is un-verifiable.
+  it.each([
+    ["an empty recorded path", ""],
+    ["a bare relative name", "myproject"],
+    ["a relative path with segments", "some/relative/path"],
+  ])("classifies %s as unverifiable (never deleted)", (_label, recorded) => {
+    makeDb("relpath", recorded);
+    const [entry] = scanDatabases(workDir, "/current.db", 90);
+    expect(entry!.projectPath).toBe(recorded);
+    expect(entry!.status).toBe("unverifiable");
+    expect(isDeletionCandidate(entry!.status)).toBe(false);
+  });
+
   it("classifies a non-mcp-recall .db as unreadable (never deleted)", () => {
     makeForeignDb("stranger");
     const [entry] = scanDatabases(workDir, "/current.db", 90, Date.now() + 200 * DAY_MS);

--- a/tests/gc.test.ts
+++ b/tests/gc.test.ts
@@ -121,6 +121,9 @@ describe("gc scanDatabases", () => {
     ["an empty recorded path", ""],
     ["a bare relative name", "myproject"],
     ["a relative path with segments", "some/relative/path"],
+    // Exists relative to whatever cwd gc runs from. Must not become "active":
+    // a DB's status cannot depend on the directory the command was invoked in.
+    ["a relative path that resolves against cwd", "."],
   ])("classifies %s as unverifiable (never deleted)", (_label, recorded) => {
     makeDb("relpath", recorded);
     const [entry] = scanDatabases(workDir, "/current.db", 90);


### PR DESCRIPTION
Found during a pre-tag review of the 1.10.0 release surface. **Data-loss path in `gc --force`**, which is new in this release — worth landing before the tag.

## The defect

`gc`'s orphan test reasons about the recorded `project_path`'s **parent**: path gone but parent present ⇒ the project directory was really deleted ⇒ the DB is a deletion candidate (`src/gc/index.ts`, `classify`).

That inference only holds for an **absolute** path. `dirname("")` and `dirname("bare-name")` are both `"."`, which always exists — so the parent-survived test succeeds spuriously:

| recorded `project_path` | `existsSync` | `dirname` | parent exists | classified |
|---|---|---|---|---|
| `""` | false | `"."` | **true** | **ORPHANED → deleted** |
| `"myproject"` | false | `"."` | **true** | **ORPHANED → deleted** |
| `"some/rel/path"` | false | `"some/rel"` | false | unverifiable (already safe) |
| `"/no/such/abs"` | false | `"/no/such"` | false | unverifiable |

## Reachability

Not theoretical, though it needs a malformed payload:

1. `src/hooks/session-start.ts:36` records `getProjectPath(input.cwd)`.
2. `resolveProjectPath` (`src/project-key.ts:36-38`) returns `input.cwd` **verbatim** when `git rev-parse --show-toplevel` fails.
3. `input.cwd` is a bare cast — `session-start.ts:28` validates only that the payload is a non-array object, never that `cwd` is a non-empty absolute string.

So a SessionStart payload carrying `cwd: ""` stores `project_path: ""`, and the next `gc --force` deletes that project's database. Normal Claude Code operation sends an absolute `cwd`, so this isn't firing in practice — but the consequence is silent loss of a project's stored context, and `--force` is a brand-new destructive command.

## Fix

Treat a non-absolute recorded path as `unverifiable` — which is what it is. We cannot know where a relative path was rooted, so we cannot conclude the project is gone. That's the module's stated contract: only delete what was *definitively* removed.

## Verified against a store containing every dangerous shape

Built a fake store and ran the real `scanDatabases` / `isDeletionCandidate` / `executeDeletions`:

```
before fix:  would delete: emptypath.db, orphaned.db, legacy.db
after fix:   would delete: orphaned.db, legacy.db
```

`emptypath.db` moves ORPHANED → `unverifiable`; genuine orphans and legacy-stale DBs are still collected, so the feature still does its job. Everything that must survive still does — the current DB, a foreign SQLite file, a corrupt file, an empty file, a **directory** named `*.db`, and a symlink's out-of-store target.

**Mutation-tested:** removing the `isAbsolute` guard turns 2 of the 3 new cases red. The third (`some/relative/path`) stays green because it was already `unverifiable` — it documents existing behaviour rather than guarding the fix, and I'd rather say so than imply three guards.

## Also verified while reviewing (no changes needed)

- **The 1.9.0 → 1.10.0 upgrade path.** `meta` ships in `SCHEMA` rather than `MIGRATIONS`, so I checked it rather than assuming. Built a database with v1.9.0's actual `initSchema` from a worktree at the tag, then opened it with 1.10.0: `meta` is created, `setMeta`/`getMeta` round-trip, and pre-existing rows are intact. `initSchema` runs `SCHEMA` unconditionally with `IF NOT EXISTS`, and `getDb` calls it on every open.
- `setMeta`/`getMeta` are parameterized; `reclaimPages` never throws and is threshold-gated.
- Pin-budget stats guard division by zero (`maxBytes > 0 ? … : 0`) and `COALESCE` the sums.
- `dataDir()` returns `dirname(RECALL_DB_PATH)` when overridden, so `gc` scans that whole directory — bounded by the `stored_outputs` check, which is what makes a foreign `.db` there safe.

## Test plan

- [x] `bun test` — 772 tests, 0 fail
- [x] `bun run typecheck` clean
- [x] Adversarial store: only the intended candidates are deleted; six must-survive shapes survive
- [x] Mutation-tested the new guard
- [x] Real v1.9.0 → v1.10.0 upgrade exercised against a database built by the tagged code

## Follow-up, not in this PR

`cwd` should be validated at the hook boundary rather than relying on this downstream guard — `post-tool-use.ts` has the same unvalidated cast. Filing separately; tightening hook input validation is a behaviour change that doesn't belong in a pre-tag fix.