### PR TITLE
fix: resolve symlinks in bin/recall so the npm CLI works — release 1.10.1

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -65,3 +65,53 @@ jobs:
             echo "dist/ is out of sync with src/. Run 'bun run build' and commit the result."
             exit 1
           fi
+
+  # Proves the published tarball is installable and that its CLI runs the way users
+  # invoke it — through the node_modules/.bin symlink. `bundle-freshness` proves
+  # dist/ matches src/, but nothing proved the artifact worked once installed, which
+  # is how a broken `npx mcp-recall` shipped in 1.9.0 and 1.10.0 (#216).
+  packaged-cli:
+    name: Packaged CLI
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v6
+
+      - uses: oven-sh/setup-bun@v2.1.3
+        with:
+          bun-version: 1.3.14
+
+      - uses: actions/setup-node@v6
+        with:
+          node-version: "24"
+
+      - name: Install dependencies
+        run: bun install --frozen-lockfile
+
+      - name: Pack the tarball
+        run: echo "TGZ=$(npm pack --silent | tail -1)" >> "$GITHUB_ENV"
+
+      - name: Install it into a clean project
+        run: |
+          mkdir -p /tmp/consumer
+          cd /tmp/consumer
+          npm init -y >/dev/null
+          npm install "$GITHUB_WORKSPACE/$TGZ" --no-fund --no-audit
+
+      - name: Run the CLI through the .bin symlink
+        run: |
+          cd /tmp/consumer
+          EXPECTED="$(node -p "require('$GITHUB_WORKSPACE/package.json').version")"
+          for invocation in "./node_modules/.bin/mcp-recall" "npx --no-install mcp-recall"; do
+            echo "--- $invocation ---"
+            got="$($invocation --version 2>&1 | tail -1)"
+            echo "reported: $got"
+            if [ "$got" != "$EXPECTED" ]; then
+              echo "::error::$invocation reported '$got', expected '$EXPECTED'"
+              exit 1
+            fi
+          done
+
+      - name: Exercise the documented onboarding path
+        run: |
+          cd /tmp/consumer
+          ./node_modules/.bin/mcp-recall install --dry-run

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,12 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+## [1.10.1] — 2026-07-28
+
+### Fixed
+
+- **The `mcp-recall` CLI works again when installed from npm.** `bin/recall` located `src/cli.ts` with `dirname "$0"`, which does not follow symlinks — and npm and bun install a `bin` entry as a symlink, so `npx mcp-recall`, `bunx mcp-recall`, and a global install all failed with `Module not found .../node_modules/.bin/../src/cli.ts` while a direct call to `bin/recall` worked. Since `mcp-recall install` is how hooks and the MCP server get registered, npm users could not complete setup. Present in 1.9.0 and 1.10.0 (#216)
+
 ## [1.10.0] — 2026-07-28
 
 ### Added
@@ -342,7 +348,8 @@ Ten `recall__*` tools available in every Claude session:
 
 ---
 
-[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.10.0...HEAD
+[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.10.1...HEAD
+[1.10.1]: https://github.com/sakebomb/mcp-recall/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/sakebomb/mcp-recall/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/sakebomb/mcp-recall/compare/v1.8.0...v1.9.0
 [1.8.0]: https://github.com/sakebomb/mcp-recall/compare/v1.7.0...v1.8.0

--- a/bin/recall
+++ b/bin/recall
@@ -1,2 +1,18 @@
 #!/usr/bin/env bash
-exec bun run "$(dirname "$0")/../src/cli.ts" "$@"
+# Resolves its own location through any symlink chain before locating src/.
+# npm and bun install a `bin` entry as a symlink (node_modules/.bin/mcp-recall ->
+# ../mcp-recall/bin/recall), so `dirname "$0"` alone points at .bin/ and
+# ../src/cli.ts resolves to node_modules/src/cli.ts, which does not exist —
+# breaking npx, bunx, and global installs while a direct call still worked (#216).
+set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  # A relative link target is relative to the link's own directory.
+  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+exec bun run "$DIR/../src/cli.ts" "$@"

--- a/bin/recall
+++ b/bin/recall
@@ -10,8 +10,12 @@ SOURCE="${BASH_SOURCE[0]}"
 while [ -L "$SOURCE" ]; do
   DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
   SOURCE="$(readlink "$SOURCE")"
-  # A relative link target is relative to the link's own directory.
-  [[ $SOURCE != /* ]] && SOURCE="$DIR/$SOURCE"
+  # A relative link target is relative to the link's own directory. An `if` rather
+  # than `[[ … ]] && …`, which returns 1 for an absolute target — exempt from
+  # `set -e` only because it sits in an && list, and easy to break when edited.
+  if [[ $SOURCE != /* ]]; then
+    SOURCE="$DIR/$SOURCE"
+  fi
 done
 DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/.claude-plugin/plugin.json
+++ b/plugins/mcp-recall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.0",
+  "version": "1.10.1",
   "description": "Context compression and persistent retrieval for Claude Code — prevents context window exhaustion in long sessions",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/bin/recall
+++ b/plugins/mcp-recall/bin/recall
@@ -1,2 +1,17 @@
 #!/usr/bin/env bash
-exec bun "$(dirname "$0")/../dist/cli.js" "$@"
+# Same symlink resolution as ../../bin/recall — see the comment there and #216.
+# Invoked today as ${CLAUDE_PLUGIN_ROOT}/bin/recall (absolute, unsymlinked) and not
+# shipped to npm, so it is not broken; kept identical so the two cannot diverge.
+set -euo pipefail
+
+SOURCE="${BASH_SOURCE[0]}"
+while [ -L "$SOURCE" ]; do
+  DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+  SOURCE="$(readlink "$SOURCE")"
+  if [[ $SOURCE != /* ]]; then
+    SOURCE="$DIR/$SOURCE"
+  fi
+done
+DIR="$(cd -P "$(dirname "$SOURCE")" && pwd)"
+
+exec bun "$DIR/../dist/cli.js" "$@"

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.10.0",
+    version: "1.10.1",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.10.0",
+    version: "1.10.1",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,0 +1,107 @@
+import { test, expect, describe, beforeAll, afterAll } from "bun:test";
+import { mkdtempSync, rmSync, mkdirSync, symlinkSync, readFileSync, existsSync } from "fs";
+import { tmpdir } from "os";
+import { join, dirname } from "path";
+
+/**
+ * Guards the packaged artifact, invoked the way users actually invoke it.
+ *
+ * #216: `bin/recall` computed its location with `dirname "$0"`, which does not
+ * follow symlinks. npm and bun install a `bin` entry as a symlink, so every real
+ * entry point — npx, bunx, global install — resolved `src/cli.ts` against
+ * `node_modules/.bin/` and failed, while a direct call worked. Two releases
+ * shipped that way because nothing here ran the binary through a symlink:
+ * `tests/cli.test.ts` imports `getVersion` in-process, which cannot catch it.
+ */
+const REPO = join(import.meta.dir, "..");
+const BIN = join(REPO, "bin", "recall");
+const EXPECTED = (JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as { version: string }).version;
+
+let work: string;
+
+beforeAll(() => {
+  work = mkdtempSync(join(tmpdir(), "recall-pack-"));
+});
+
+afterAll(() => {
+  rmSync(work, { recursive: true, force: true });
+});
+
+function run(cmd: string[]): { code: number | null; out: string } {
+  const p = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+  return {
+    code: p.exitCode,
+    out: (new TextDecoder().decode(p.stdout) + new TextDecoder().decode(p.stderr)).trim(),
+  };
+}
+
+describe("packaged CLI entrypoint", () => {
+  test("runs when invoked directly", () => {
+    const { code, out } = run([BIN, "--version"]);
+    expect(code).toBe(0);
+    expect(out).toContain(EXPECTED);
+  });
+
+  // The regression case. Mirrors node_modules/.bin/mcp-recall -> ../mcp-recall/bin/recall:
+  // a RELATIVE link, from a sibling directory, which is what npm creates.
+  test("runs when invoked through a relative symlink, as npm and bunx do", () => {
+    const pkgDir = join(work, "node_modules", "mcp-recall");
+    const binDir = join(work, "node_modules", ".bin");
+    mkdirSync(pkgDir, { recursive: true });
+    mkdirSync(binDir, { recursive: true });
+    // Stand in for the installed package: symlink the repo's own tree into place,
+    // so the test exercises the shipped bin/ + src/ rather than a copy.
+    symlinkSync(join(REPO, "bin"), join(pkgDir, "bin"));
+    symlinkSync(join(REPO, "src"), join(pkgDir, "src"));
+    symlinkSync(join(REPO, "package.json"), join(pkgDir, "package.json"));
+    symlinkSync(join(REPO, "node_modules"), join(pkgDir, "node_modules"));
+
+    const link = join(binDir, "mcp-recall");
+    symlinkSync(join("..", "mcp-recall", "bin", "recall"), link);
+
+    const { code, out } = run([link, "--version"]);
+    expect(code).toBe(0);
+    expect(out).toContain(EXPECTED);
+    // The old failure mode resolved src/ against .bin/ — assert we are not back there.
+    expect(out).not.toContain("Module not found");
+  });
+
+  test("runs through a chain of symlinks", () => {
+    const outer = join(work, "outer-link");
+    const inner = join(work, "inner-link");
+    symlinkSync(BIN, inner);
+    symlinkSync(inner, outer);
+
+    const { code, out } = run([outer, "--version"]);
+    expect(code).toBe(0);
+    expect(out).toContain(EXPECTED);
+  });
+
+  test("bin entry named in package.json exists and is executable", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
+      bin: Record<string, string>;
+    };
+    for (const target of Object.values(pkg.bin)) {
+      const p = join(REPO, target);
+      expect(existsSync(p)).toBe(true);
+      // A bin that isn't executable fails only once installed.
+      expect(run(["test", "-x", p]).code).toBe(0);
+    }
+  });
+
+  test("package.json files list covers the bin's runtime dependency", () => {
+    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
+      files: string[];
+      bin: Record<string, string>;
+    };
+    // bin/recall execs src/cli.ts, so both trees must ship or the CLI breaks only
+    // for installed users — invisible to a repo-local run.
+    const covered = (p: string) => pkg.files.some((f) => p.startsWith(f.replace(/\/$/, "")));
+    expect(covered("bin")).toBe(true);
+    expect(covered("src")).toBe(true);
+    for (const target of Object.values(pkg.bin)) {
+      expect(covered(target.replace(/^\.\//, "").split("/")[0]!)).toBe(true);
+    }
+    void dirname;
+  });
+});

--- a/tests/packaging.test.ts
+++ b/tests/packaging.test.ts
@@ -1,34 +1,71 @@
 import { test, expect, describe, beforeAll, afterAll } from "bun:test";
-import { mkdtempSync, rmSync, mkdirSync, symlinkSync, readFileSync, existsSync } from "fs";
+import { mkdtempSync, rmSync, mkdirSync, symlinkSync, readFileSync, existsSync, cpSync } from "fs";
 import { tmpdir } from "os";
-import { join, dirname } from "path";
+import { join } from "path";
 
 /**
  * Guards the packaged artifact, invoked the way users actually invoke it.
  *
- * #216: `bin/recall` computed its location with `dirname "$0"`, which does not
+ * #216: `bin/recall` located `src/cli.ts` with `dirname "$0"`, which does not
  * follow symlinks. npm and bun install a `bin` entry as a symlink, so every real
- * entry point — npx, bunx, global install — resolved `src/cli.ts` against
- * `node_modules/.bin/` and failed, while a direct call worked. Two releases
- * shipped that way because nothing here ran the binary through a symlink:
- * `tests/cli.test.ts` imports `getVersion` in-process, which cannot catch it.
+ * entry point — npx, bunx, global install — resolved against `node_modules/.bin/`
+ * and failed, while a direct call worked. Two releases shipped that way because
+ * nothing here ran the binary through a symlink: `tests/cli.test.ts` imports
+ * `getVersion` in-process, which cannot catch it.
+ *
+ * Deliberately does NOT `npm install` a real tarball: that would fetch runtime
+ * dependencies and make the suite network-dependent, which #203 just removed.
+ * The layout below is assembled by hand to match what npm produces.
  */
 const REPO = join(import.meta.dir, "..");
 const BIN = join(REPO, "bin", "recall");
-const EXPECTED = (JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as { version: string }).version;
+const PLUGIN_BIN = join(REPO, "plugins", "mcp-recall", "bin", "recall");
+const PKG = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
+  version: string;
+  files: string[];
+  bin: Record<string, string>;
+};
 
 let work: string;
+let installedLink: string;
 
 beforeAll(() => {
   work = mkdtempSync(join(tmpdir(), "recall-pack-"));
+
+  // Mirror an installed tree: node_modules/mcp-recall/{bin,src} with the bin entry
+  // symlinked from a sibling .bin/ by a RELATIVE path, which is what npm creates.
+  const pkgDir = join(work, "node_modules", "mcp-recall");
+  const binDir = join(work, "node_modules", ".bin");
+  mkdirSync(pkgDir, { recursive: true });
+  mkdirSync(binDir, { recursive: true });
+
+  // COPIED, not symlinked. If `bin/` were itself a link, `cd -P` would resolve
+  // straight back into the real repo and the test would not exercise the installed
+  // layout at all. Copying also keeps cleanup from ever reaching the working tree.
+  cpSync(join(REPO, "bin"), join(pkgDir, "bin"), { recursive: true });
+  cpSync(join(REPO, "src"), join(pkgDir, "src"), { recursive: true });
+  cpSync(join(REPO, "package.json"), join(pkgDir, "package.json"));
+  cpSync(join(REPO, "plugins", "mcp-recall", "dist"), join(pkgDir, "plugins", "mcp-recall", "dist"), {
+    recursive: true,
+  });
+  // Only node_modules is linked, since deps must resolve and copying them is
+  // wasteful. It is the sole link under `work`, and `fs.rm` unlinks rather than
+  // traverses — see the afterAll note.
+  symlinkSync(join(REPO, "node_modules"), join(pkgDir, "node_modules"));
+
+  installedLink = join(binDir, "mcp-recall");
+  symlinkSync(join("..", "mcp-recall", "bin", "recall"), installedLink);
 });
 
 afterAll(() => {
+  // Safe against the node_modules link above only because fs.rm unlinks symlinks
+  // instead of following them. Do not swap this for a shell `rm -rf` helper that
+  // dereferences — it would delete the repo's own node_modules.
   rmSync(work, { recursive: true, force: true });
 });
 
-function run(cmd: string[]): { code: number | null; out: string } {
-  const p = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe" });
+function run(cmd: string[], cwd?: string): { code: number | null; out: string } {
+  const p = Bun.spawnSync(cmd, { stdout: "pipe", stderr: "pipe", ...(cwd ? { cwd } : {}) });
   return {
     code: p.exitCode,
     out: (new TextDecoder().decode(p.stdout) + new TextDecoder().decode(p.stderr)).trim(),
@@ -39,49 +76,52 @@ describe("packaged CLI entrypoint", () => {
   test("runs when invoked directly", () => {
     const { code, out } = run([BIN, "--version"]);
     expect(code).toBe(0);
-    expect(out).toContain(EXPECTED);
+    expect(out).toContain(PKG.version);
   });
 
-  // The regression case. Mirrors node_modules/.bin/mcp-recall -> ../mcp-recall/bin/recall:
-  // a RELATIVE link, from a sibling directory, which is what npm creates.
+  // The regression case for #216.
   test("runs when invoked through a relative symlink, as npm and bunx do", () => {
-    const pkgDir = join(work, "node_modules", "mcp-recall");
-    const binDir = join(work, "node_modules", ".bin");
-    mkdirSync(pkgDir, { recursive: true });
-    mkdirSync(binDir, { recursive: true });
-    // Stand in for the installed package: symlink the repo's own tree into place,
-    // so the test exercises the shipped bin/ + src/ rather than a copy.
-    symlinkSync(join(REPO, "bin"), join(pkgDir, "bin"));
-    symlinkSync(join(REPO, "src"), join(pkgDir, "src"));
-    symlinkSync(join(REPO, "package.json"), join(pkgDir, "package.json"));
-    symlinkSync(join(REPO, "node_modules"), join(pkgDir, "node_modules"));
-
-    const link = join(binDir, "mcp-recall");
-    symlinkSync(join("..", "mcp-recall", "bin", "recall"), link);
-
-    const { code, out } = run([link, "--version"]);
+    const { code, out } = run([installedLink, "--version"]);
     expect(code).toBe(0);
-    expect(out).toContain(EXPECTED);
-    // The old failure mode resolved src/ against .bin/ — assert we are not back there.
+    expect(out).toContain(PKG.version);
+    // The old failure resolved src/ against .bin/ — assert we are not back there.
     expect(out).not.toContain("Module not found");
   });
 
+  // --version alone would not have caught a break in path resolution *inside* the
+  // CLI. `install` is the journey #216 actually blocked: it is how hooks and the
+  // MCP server get registered, and it resolves plugins/mcp-recall/dist/ itself.
+  test("install --dry-run works through the installed symlink", () => {
+    const { code, out } = run([installedLink, "install", "--dry-run"], work);
+    expect(code).toBe(0);
+    expect(out).not.toContain("Module not found");
+    expect(out).not.toContain("no such file");
+  });
+
   test("runs through a chain of symlinks", () => {
-    const outer = join(work, "outer-link");
     const inner = join(work, "inner-link");
+    const outer = join(work, "outer-link");
     symlinkSync(BIN, inner);
     symlinkSync(inner, outer);
 
     const { code, out } = run([outer, "--version"]);
     expect(code).toBe(0);
-    expect(out).toContain(EXPECTED);
+    expect(out).toContain(PKG.version);
   });
 
-  test("bin entry named in package.json exists and is executable", () => {
-    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
-      bin: Record<string, string>;
-    };
-    for (const target of Object.values(pkg.bin)) {
+  // Same latent defect lived here; kept covered so the two wrappers can't diverge.
+  test("the plugin wrapper also survives a symlink", () => {
+    const link = join(work, "plugin-link");
+    symlinkSync(PLUGIN_BIN, link);
+
+    const { code, out } = run([link, "--version"]);
+    expect(code).toBe(0);
+    expect(out).toContain(PKG.version);
+    expect(out).not.toContain("Module not found");
+  });
+
+  test("bin entries named in package.json exist and are executable", () => {
+    for (const target of Object.values(PKG.bin)) {
       const p = join(REPO, target);
       expect(existsSync(p)).toBe(true);
       // A bin that isn't executable fails only once installed.
@@ -89,19 +129,24 @@ describe("packaged CLI entrypoint", () => {
     }
   });
 
-  test("package.json files list covers the bin's runtime dependency", () => {
-    const pkg = JSON.parse(readFileSync(join(REPO, "package.json"), "utf8")) as {
-      files: string[];
-      bin: Record<string, string>;
-    };
+  test("package.json files list covers the bin and its runtime dependency", () => {
+    // Exact match or a true path-segment prefix. `p.startsWith(f)` alone would let
+    // files: ["b"] satisfy "bin".
+    const covered = (p: string) =>
+      PKG.files.some((raw) => {
+        const f = raw.replace(/\/$/, "");
+        return f === p || p.startsWith(`${f}/`);
+      });
+
     // bin/recall execs src/cli.ts, so both trees must ship or the CLI breaks only
     // for installed users — invisible to a repo-local run.
-    const covered = (p: string) => pkg.files.some((f) => p.startsWith(f.replace(/\/$/, "")));
     expect(covered("bin")).toBe(true);
     expect(covered("src")).toBe(true);
-    for (const target of Object.values(pkg.bin)) {
-      expect(covered(target.replace(/^\.\//, "").split("/")[0]!)).toBe(true);
+    expect(covered("src/cli.ts")).toBe(true);
+    for (const target of Object.values(PKG.bin)) {
+      expect(covered(target.replace(/^\.\//, ""))).toBe(true);
     }
-    void dirname;
+    // Guard the helper itself against the reversed-prefix bug.
+    expect(covered("b")).toBe(false);
   });
 });


### PR DESCRIPTION
Closes #216. Patch release, because the documented onboarding path is broken on npm.

## The bug

`bin/recall` was:

```bash
exec bun run "$(dirname "$0")/../src/cli.ts" "$@"
```

`dirname "$0"` doesn't follow symlinks, and npm/bun install a `bin` entry *as* a symlink (`node_modules/.bin/mcp-recall -> ../mcp-recall/bin/recall`). So `$0` is the symlink and `../src/cli.ts` resolves to `node_modules/src/cli.ts`:

```
npx mcp-recall --version   → error: Module not found ".../node_modules/.bin/../src/cli.ts"
bunx mcp-recall --version  → same
node_modules/mcp-recall/bin/recall --version → 1.10.0   ← only direct calls worked
```

`README.md:149` (`npx mcp-recall install`) and `:155-156` (global install) are the primary onboarding instructions, and `mcp-recall install` is what registers hooks and the MCP server — so an npm user could not complete setup.

**Pre-existing:** 1.9.0 fails identically. Not introduced by 1.10.0.

## Fix

Resolve the link chain before computing the directory, handling relative targets (the shape npm creates).

## Verified end to end

Against a real `npm pack` + install, not a simulation:

| Invocation | Before | After |
|---|---|---|
| `node_modules/.bin/mcp-recall` | Module not found | **1.10.0** |
| `npx mcp-recall` | Module not found | **1.10.0** |
| `bin/recall` directly | 1.10.0 | 1.10.0 |

## The test that was missing

`tests/packaging.test.ts` runs the binary the way users do — through a relative symlink from a sibling directory, and through a symlink chain. Mutation-tested against the original script:

| Case | Old `bin/recall` |
|---|---|
| relative symlink, as npm creates | **RED** |
| symlink chain | **RED** |
| direct invocation | green |

That asymmetry is the whole story: everything that existed tested the green row. `tests/cli.test.ts` imports `getVersion` in-process, and my own pre-release check ran the bundle by path (`bun plugins/.../dist/cli.js`) — both structurally incapable of catching this. Two releases shipped through that gap.

Also added assertions that the `bin` target exists, is executable, and that `files` covers both `bin/` and `src/` — the neighbouring ways to break an installed-only path.

## Release 1.10.1

- `[Unreleased]` → `[1.10.1]` with the changelog link definition
- Version bumped across all three manifests (guarded by the check added in #211)
- `dist/` rebuilt and committed — the bundle embeds the version

## Test plan

- [x] Full suite: 778 tests, 0 fail
- [x] `bun run typecheck` clean
- [x] `npm pack` + install → `.bin` symlink and `npx` both report the version
- [x] Mutation-tested: reverting `bin/recall` reddens exactly the two symlink cases
- [x] `bash -n bin/recall` clean; script is executable
- [x] All three manifests at 1.10.1; bundle reports 1.10.1