### PR TITLE
docs: record the 1.10.0/1.10.1 releases and the packaging gap

### DIFF
--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -46,13 +46,31 @@ could otherwise mint a repo-valid attestation for arbitrary content), and a `git
 rebase-retry. VERIFIED: live manifest exits 0, signed by `manifest.yml@refs/heads/main`;
 `profiles available` clean in both `warn` and `error` mode.
 
+## ~~Release 1.10.0 + 1.10.1~~ ✓ DONE (2026-07-28)
+
+**v1.10.0** (tag `f0c8f33`) then **v1.10.1** (tag `c704dbc`), both live on npm with SLSA
+provenance; `latest` = 1.10.1. Closed #204.
+
+1.10.1 exists because post-publish verification of 1.10.0 found the npm CLI had **never**
+worked through a `.bin` symlink (#216): `bin/recall` used `dirname "$0"`, which doesn't
+follow symlinks, so `npx mcp-recall install` — the README's primary onboarding — failed with
+`Module not found .../node_modules/.bin/../src/cli.ts`. Pre-existing in 1.9.0 too, so it was
+broken for two releases. A green suite plus a direct `bin/recall` call both looked fine;
+nothing ran the *packaged* artifact. See [[verify-the-packaged-artifact]].
+
+Two permanent guards added: `publish.yml` fails closed if the release tag and `package.json`
+disagree (fired correctly on both releases), and a `Packaged CLI` CI job packs the tarball,
+installs it, and runs the CLI through `.bin` + `npx` + `install --dry-run`.
+
+---
+
 ## Up Next — filed 2026-07-27
 
 | # | Title | Labels | Notes |
 |---|-------|--------|-------|
 | ~~[#202](https://github.com/sakebomb/mcp-recall/issues/202)~~ | ~~Pin the signer identity when verifying the manifest~~ | security, P1, S | ✓ **DONE** — merged PR [#206](https://github.com/sakebomb/mcp-recall/pull/206), main @ `4be445d`. GOTCHAS worth keeping: (1) `--signer-workflow` is a **prefix-anchored, unterminated** match — `…/workflows/man` passes, and it stops short of `@refs/heads/<ref>`, so it does *not* pin the branch. Use `--cert-identity` (exact SAN). (2) `--signer-workflow` also needs `<owner>/<repo>/<path>`; a bare path is rejected outright. (3) An old `gh` exits non-zero exactly like a bad signature — now detected and reported as a skip, see #208. |
 | ~~[#203](https://github.com/sakebomb/mcp-recall/issues/203)~~ | ~~Stop profile tests shelling out to real `gh attestation verify`~~ | test, P2, S | ✓ **DONE** — merged PR [#210](https://github.com/sakebomb/mcp-recall/pull/210), main @ `66bd14f`. File 25s → 51ms; suite 34s → 7s. GOTCHAS: (1) `expect(spy).not.toHaveBeenCalled()` placed *after* `spy.mockRestore()` passes unconditionally — mockRestore clears the call record; count into a local. (2) A test that calls `loadConfig()` without pinning `RECALL_CONFIG_PATH` reads the *runner's* real config — use `writeConfig(mode)`. |
-| [#204](https://github.com/sakebomb/mcp-recall/issues/204) | Release v1.10.0 | chore, P2, S | **Prep merged via PR [#211](https://github.com/sakebomb/mcp-recall/pull/211)** — changelog cut, all three manifests at 1.10.0, dist rebuilt. **Still to do: tag → `gh release create` → verify npm.** Gotchas: bundle embeds the version so a version-only commit needs `bun run build` + committed dist; 1.9.0's publish first failed on a stale `NPM_TOKEN` (rotate from 1Password, then `gh run rerun <id> --failed`). `publish.yml` now fails closed if the tag and `package.json` disagree. |
+| ~~[#204](https://github.com/sakebomb/mcp-recall/issues/204)~~ | ~~Release v1.10.0~~ | chore, P2, S | ✓ **DONE** — released 1.10.0 *and* 1.10.1. Prep was PR [#211](https://github.com/sakebomb/mcp-recall/pull/211) — changelog cut, all three manifests at 1.10.0, dist rebuilt. **Still to do: tag → `gh release create` → verify npm.** Gotchas: bundle embeds the version so a version-only commit needs `bun run build` + committed dist; 1.9.0's publish first failed on a stale `NPM_TOKEN` (rotate from 1Password, then `gh run rerun <id> --failed`). `publish.yml` now fails closed if the tag and `package.json` disagree. |
 | [#205](https://github.com/sakebomb/mcp-recall/issues/205) | Bound pinned data so `max_size_mb` isn't silently voided | enhancement, P2, M, needs-info | **Blocked on a design call**, not capacity: 4 options (separate pin budget / pins evictable / refuse writes / warn only). Lean is a separate `max_pinned_mb`. |
 | ~~[#207](https://github.com/sakebomb/mcp-recall/issues/207)~~ | ~~`gc scanDatabases` test flakes on its 5s timeout~~ | test, P2, S | ✓ **DONE** — merged PR [#209](https://github.com/sakebomb/mcp-recall/pull/209), main @ `3eea1b8`. Measured: 200 implicit transactions = **4119ms** vs **22ms** batched — 18% headroom under a 5s timeout, hence load-sensitive. File 12.83s → 5.15s. Three loops, not one: grepping `.prepare(` missed loops calling `storeOutput` (its transaction is one layer down). |
 | [#208](https://github.com/sakebomb/mcp-recall/issues/208) | `verify_signature = "error"` still proceeds unverified when `gh` is unavailable | security, P2, S, needs-info | **Blocked on a design call.** `error` strengthens *failure* handling, not *availability*. Pre-existing since #134; #206 documented it rather than changing it. Options: new `require` mode / redefine `error` (breaking) / keep. Lean is redefining `error`. |


### PR DESCRIPTION
Doc-only. Records both releases in `tasks/todo.md`, why 1.10.1 was needed (#216 — the npm CLI never worked through a `.bin` symlink, broken since 1.9.0), and the two permanent guards added: the publish-time tag/version check and the `Packaged CLI` CI job.

## Test plan
- [x] No code changed — `tasks/todo.md` only