### PR TITLE
fix: absolutise the recorded project path at its source

### DIFF
--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -108,6 +108,9 @@ var require_package = __commonJS((exports, module) => {
   };
 });
 
+// src/hooks/session-start.ts
+import { existsSync as existsSync2 } from "fs";
+
 // node_modules/smol-toml/dist/error.js
 /*!
  * Copyright (c) Squirrel Chat et al., All rights reserved.
@@ -5167,7 +5170,7 @@ function resolveProjectPath(cwd) {
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : resolve(cwd);
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : typeof cwd === "string" && cwd ? resolve(cwd) : process.cwd();
   pathCache.set(cwd, resolved);
   return resolved;
 }
@@ -5892,7 +5895,12 @@ function handleSessionStart(raw) {
   const config = loadConfig();
   const projectKey = getProjectKey(input.cwd);
   const db = getDb(defaultDbPath(projectKey));
-  setMeta(db, "project_path", getProjectPath(input.cwd));
+  const projectPath = getProjectPath(input.cwd);
+  if (existsSync2(projectPath)) {
+    setMeta(db, "project_path", projectPath);
+  } else {
+    log.debug(`session-start \xB7 resolved project path does not exist, not recording: ${projectPath}`);
+  }
   const today = new Date().toISOString().slice(0, 10);
   recordSession(db, today);
   pruneExpired(db, projectKey, config.store.expire_after_session_days);
@@ -9801,7 +9809,7 @@ Next steps:`);
 }
 
 // src/import/index.ts
-import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync2 } from "fs";
+import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync3 } from "fs";
 import { resolve as resolve3 } from "path";
 import { Database as Database3 } from "bun:sqlite";
 var LARGE_FILE_BYTES = 50 * 1024 * 1024;
@@ -9823,7 +9831,7 @@ var StoredOutputSchema = exports_external.object({
 });
 var ExportSchema = exports_external.array(StoredOutputSchema);
 function dryRunCount(dbPath, items, overwrite) {
-  if (dbPath === ":memory:" || !existsSync2(dbPath)) {
+  if (dbPath === ":memory:" || !existsSync3(dbPath)) {
     return { imported: items.length, skipped: 0, overwritten: 0 };
   }
   let db = null;
@@ -9960,7 +9968,7 @@ Next steps:`);
 }
 
 // src/install/index.ts
-import { existsSync as existsSync3 } from "fs";
+import { existsSync as existsSync4 } from "fs";
 import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
@@ -10132,7 +10140,7 @@ async function installCommand(opts = {}) {
     claudeMdPath = defaultClaudeMdPath()
   } = opts;
   const paths = detectPaths();
-  if (!existsSync3(paths.serverJs) || !existsSync3(paths.cliJs)) {
+  if (!existsSync4(paths.serverJs) || !existsSync4(paths.cliJs)) {
     console.error(`${RED}\u2717 Build artifacts not found.${RESET}`);
     console.error(`  Expected: ${DIM}${paths.serverJs}${RESET}`);
     console.error(`  Run ${BOLD}bun run build${RESET} first.`);
@@ -10317,8 +10325,8 @@ async function statusCommand(opts = {}) {
     claudeMdContent = await readFile(claudeMdPath, "utf8");
   } catch {}
   const claudeMdOk = isClaudeMdInjected(claudeMdContent);
-  const serverExists = existsSync3(recallPaths.serverJs);
-  const cliExists = existsSync3(recallPaths.cliJs);
+  const serverExists = existsSync4(recallPaths.serverJs);
+  const cliExists = existsSync4(recallPaths.cliJs);
   const fullyInstalled = serverRegistered && ssRegistered && ptuRegistered && claudeMdOk && serverExists && cliExists;
   const label = fullyInstalled ? `${GREEN}installed${RESET}` : serverRegistered || ssRegistered || ptuRegistered ? `${YELLOW}partial / stale${RESET}` : `${RED}not installed${RESET}`;
   console.log(`

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -109,7 +109,7 @@ var require_package = __commonJS((exports, module) => {
 });
 
 // src/hooks/session-start.ts
-import { existsSync as existsSync2 } from "fs";
+import { statSync as statSync2 } from "fs";
 
 // node_modules/smol-toml/dist/error.js
 /*!
@@ -5879,6 +5879,13 @@ Vacuuming ${survivors.length} database(s) to keep (${formatBytes(sumBytes(surviv
 
 // src/hooks/session-start.ts
 var INJECT_MAX_CHARS = 2000;
+function isExistingDir(path) {
+  try {
+    return statSync2(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
 function handleSessionStart(raw) {
   let parsed;
   try {
@@ -5896,10 +5903,10 @@ function handleSessionStart(raw) {
   const projectKey = getProjectKey(input.cwd);
   const db = getDb(defaultDbPath(projectKey));
   const projectPath = getProjectPath(input.cwd);
-  if (existsSync2(projectPath)) {
+  if (isExistingDir(projectPath)) {
     setMeta(db, "project_path", projectPath);
   } else {
-    log.debug(`session-start \xB7 resolved project path does not exist, not recording: ${projectPath}`);
+    log.debug(`session-start \xB7 resolved project path is not a directory, leaving meta as-is: ${projectPath}`);
   }
   const today = new Date().toISOString().slice(0, 10);
   recordSession(db, today);
@@ -7748,7 +7755,7 @@ var genericHandler = (_toolName, output) => {
 };
 
 // src/profiles/loader.ts
-import { readdirSync as readdirSync2, readFileSync as readFileSync2, statSync as statSync2 } from "fs";
+import { readdirSync as readdirSync2, readFileSync as readFileSync2, statSync as statSync3 } from "fs";
 import { join as join4 } from "path";
 import { homedir as homedir3 } from "os";
 function getUserProfilesDir() {
@@ -7764,7 +7771,7 @@ function getBundledProfilesDir() {
   const devPath = join4(import.meta.dir, "../../profiles");
   const distPath = join4(import.meta.dir, "../profiles");
   try {
-    statSync2(devPath);
+    statSync3(devPath);
     return devPath;
   } catch (e) {
     if (e.code !== "ENOENT")
@@ -7776,7 +7783,7 @@ var fileCache = new Map;
 function loadSpec(filePath) {
   let mtime;
   try {
-    mtime = statSync2(filePath).mtimeMs;
+    mtime = statSync3(filePath).mtimeMs;
   } catch {
     fileCache.delete(filePath);
     return null;
@@ -7859,7 +7866,7 @@ function scanDir(dir, tier) {
     const full = join4(dir, entry);
     let stat;
     try {
-      stat = statSync2(full);
+      stat = statSync3(full);
     } catch {
       continue;
     }
@@ -9809,7 +9816,7 @@ Next steps:`);
 }
 
 // src/import/index.ts
-import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync3 } from "fs";
+import { readFileSync as readFileSync9, statSync as statSync4, existsSync as existsSync2 } from "fs";
 import { resolve as resolve3 } from "path";
 import { Database as Database3 } from "bun:sqlite";
 var LARGE_FILE_BYTES = 50 * 1024 * 1024;
@@ -9831,7 +9838,7 @@ var StoredOutputSchema = exports_external.object({
 });
 var ExportSchema = exports_external.array(StoredOutputSchema);
 function dryRunCount(dbPath, items, overwrite) {
-  if (dbPath === ":memory:" || !existsSync3(dbPath)) {
+  if (dbPath === ":memory:" || !existsSync2(dbPath)) {
     return { imported: items.length, skipped: 0, overwritten: 0 };
   }
   let db = null;
@@ -9900,7 +9907,7 @@ async function handleImportCommand(args) {
   let raw;
   if (filePath) {
     try {
-      const size = statSync3(filePath).size;
+      const size = statSync4(filePath).size;
       if (size > LARGE_FILE_BYTES) {
         console.error(`Warning: file is ${Math.round(size / 1024 / 1024)} MB \u2014 this may take a while.`);
       }
@@ -9968,7 +9975,7 @@ Next steps:`);
 }
 
 // src/install/index.ts
-import { existsSync as existsSync4 } from "fs";
+import { existsSync as existsSync3 } from "fs";
 import { mkdir, rename, readFile } from "fs/promises";
 import path from "path";
 import os from "os";
@@ -10140,7 +10147,7 @@ async function installCommand(opts = {}) {
     claudeMdPath = defaultClaudeMdPath()
   } = opts;
   const paths = detectPaths();
-  if (!existsSync4(paths.serverJs) || !existsSync4(paths.cliJs)) {
+  if (!existsSync3(paths.serverJs) || !existsSync3(paths.cliJs)) {
     console.error(`${RED}\u2717 Build artifacts not found.${RESET}`);
     console.error(`  Expected: ${DIM}${paths.serverJs}${RESET}`);
     console.error(`  Run ${BOLD}bun run build${RESET} first.`);
@@ -10325,8 +10332,8 @@ async function statusCommand(opts = {}) {
     claudeMdContent = await readFile(claudeMdPath, "utf8");
   } catch {}
   const claudeMdOk = isClaudeMdInjected(claudeMdContent);
-  const serverExists = existsSync4(recallPaths.serverJs);
-  const cliExists = existsSync4(recallPaths.cliJs);
+  const serverExists = existsSync3(recallPaths.serverJs);
+  const cliExists = existsSync3(recallPaths.cliJs);
   const fullyInstalled = serverRegistered && ssRegistered && ptuRegistered && claudeMdOk && serverExists && cliExists;
   const label = fullyInstalled ? `${GREEN}installed${RESET}` : serverRegistered || ssRegistered || ptuRegistered ? `${YELLOW}partial / stale${RESET}` : `${RED}not installed${RESET}`;
   console.log(`

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5149,6 +5149,7 @@ function loadConfig() {
 // src/project-key.ts
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
+import { resolve } from "path";
 var pathCache = new Map;
 function getProjectKey(cwd) {
   const resolved = resolveProjectPath(cwd);
@@ -5166,7 +5167,7 @@ function resolveProjectPath(cwd) {
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : cwd;
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : resolve(cwd);
   pathCache.set(cwd, resolved);
   return resolved;
 }
@@ -5660,7 +5661,7 @@ function toolContext(db, projectKey, args) {
 // src/gc/index.ts
 import { Database as Database2 } from "bun:sqlite";
 import { readdirSync, existsSync, statSync, rmSync } from "fs";
-import { join as join3, basename, dirname as dirname2, resolve, isAbsolute } from "path";
+import { join as join3, basename, dirname as dirname2, resolve as resolve2, isAbsolute } from "path";
 var DEFAULT_STALE_DAYS = 90;
 var STATUS_POLICY = {
   current: { deletable: false, vacuumable: false },
@@ -5745,7 +5746,7 @@ function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
   if (!existsSync(dir))
     return [];
   const staleCutoffMs = nowMs - staleDays * 86400 * 1000;
-  const currentResolved = resolve(currentFile);
+  const currentResolved = resolve2(currentFile);
   const entries = [];
   for (const name of readdirSync(dir)) {
     if (!name.endsWith(".db"))
@@ -5758,7 +5759,7 @@ function scanDatabases(dir, currentFile, staleDays, nowMs = Date.now()) {
       continue;
     }
     const sizeBytes = dbFootprint(file);
-    if (resolve(file) === currentResolved) {
+    if (resolve2(file) === currentResolved) {
       entries.push({ file, status: "current", projectPath: null, sizeBytes, mtimeMs, items: 0 });
       continue;
     }
@@ -8708,9 +8709,9 @@ function installedCommunityMap() {
 async function promptNumber(msg, min, max) {
   for (let attempt = 0;attempt < 3; attempt++) {
     process.stdout.write(msg);
-    const line = await new Promise((resolve2) => {
+    const line = await new Promise((resolve3) => {
       process.stdin.setEncoding("utf8");
-      process.stdin.once("data", (d) => resolve2(String(d).trim()));
+      process.stdin.once("data", (d) => resolve3(String(d).trim()));
     });
     const n = parseInt(line);
     if (!isNaN(n) && n >= min && n <= max)
@@ -9297,7 +9298,7 @@ class LineReader {
     this.reader = stream.getReader();
   }
   async readLine(timeoutMs) {
-    const timer = new Promise((resolve2) => setTimeout(() => resolve2(null), timeoutMs));
+    const timer = new Promise((resolve3) => setTimeout(() => resolve3(null), timeoutMs));
     const read = this._nextLine();
     return Promise.race([read, timer]);
   }
@@ -9554,8 +9555,8 @@ async function tryLegacySse(url, timeoutMs) {
         return req.then(() => {
           return;
         });
-      return new Promise((resolve2, reject) => {
-        pending.set(body.id, { resolve: resolve2, reject });
+      return new Promise((resolve3, reject) => {
+        pending.set(body.id, { resolve: resolve3, reject });
         req.catch(reject);
       });
     };
@@ -9801,7 +9802,7 @@ Next steps:`);
 
 // src/import/index.ts
 import { readFileSync as readFileSync9, statSync as statSync3, existsSync as existsSync2 } from "fs";
-import { resolve as resolve2 } from "path";
+import { resolve as resolve3 } from "path";
 import { Database as Database3 } from "bun:sqlite";
 var LARGE_FILE_BYTES = 50 * 1024 * 1024;
 var EMPTY_EXPORT_SENTINEL = "[recall: no items to export]";
@@ -9887,7 +9888,7 @@ async function handleImportCommand(args) {
   const keepProjectKey = args.includes("--keep-project-key");
   const dryRun = args.includes("--dry-run");
   const rawPath = args.find((a) => !a.startsWith("--"));
-  const filePath = rawPath ? resolve2(rawPath) : null;
+  const filePath = rawPath ? resolve3(rawPath) : null;
   let raw;
   if (filePath) {
     try {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19539,6 +19539,7 @@ class StdioServerTransport {
 // src/project-key.ts
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
+import { resolve } from "path";
 var pathCache = new Map;
 function getProjectKey(cwd) {
   const resolved = resolveProjectPath(cwd);
@@ -19553,7 +19554,7 @@ function resolveProjectPath(cwd) {
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : cwd;
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : resolve(cwd);
   pathCache.set(cwd, resolved);
   return resolved;
 }

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19554,7 +19554,7 @@ function resolveProjectPath(cwd) {
     encoding: "utf8",
     stdio: ["pipe", "pipe", "pipe"]
   });
-  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : resolve(cwd);
+  const resolved = result.status === 0 && result.stdout ? result.stdout.trim() : typeof cwd === "string" && cwd ? resolve(cwd) : process.cwd();
   pathCache.set(cwd, resolved);
   return resolved;
 }

--- a/src/gc/index.ts
+++ b/src/gc/index.ts
@@ -184,6 +184,8 @@ function classify(
 ): DbStatus {
   if (!probe.readable) return "unreadable";
   if (probe.projectPath !== null) {
+    // Still required, not dead code: session-start absolutises the path it records
+    // (#213), but databases written by 1.10.0 and earlier can hold a relative one.
     // Checked before any existsSync: a relative path is resolved against the cwd
     // gc happens to run from, so it would otherwise classify differently per
     // invocation — and "." or a bare name would read as "parent survived, project

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,4 +1,4 @@
-import { existsSync } from "fs";
+import { statSync } from "fs";
 import { loadConfig } from "../config";
 import { getProjectKey, getProjectPath } from "../project-key";
 import { getDb, defaultDbPath, recordSession, pruneExpired, setMeta } from "../db/index";
@@ -14,6 +14,15 @@ interface SessionStartInput {
 
 /** Maximum characters written to stdout for the context snapshot injection. */
 const INJECT_MAX_CHARS = 2000;
+
+/** True only for a path that exists AND is a directory — a project path is never a file. */
+function isExistingDir(path: string): boolean {
+  try {
+    return statSync(path).isDirectory();
+  } catch {
+    return false;
+  }
+}
 
 export function handleSessionStart(raw: string): void {
   let parsed: unknown;
@@ -35,19 +44,23 @@ export function handleSessionStart(raw: string): void {
   // Record the resolved project path so `mcp-recall gc` can tell whether this
   // project still exists on disk (orphan detection is path-existence based).
   //
-  // Only recorded when it actually exists. The path is absolute by construction,
-  // but absolute is not the same as true: a relative payload `cwd` gets rooted
-  // against this process's cwd, which may not be where it was meant to be rooted.
-  // This hook runs *inside* the project, so a resolved path that does not exist
-  // means the guess was wrong — and recording it would let gc read a live project
-  // as "path gone, parent present" and delete its database. Recording nothing
-  // leaves the DB pathless, which gc keeps as legacy-fresh and only ever reclaims
+  // Only recorded when it resolves to a real directory. The path is absolute by
+  // construction, but absolute is not the same as true: a relative payload `cwd`
+  // gets rooted against this process's cwd, which may not be where it was meant to
+  // be rooted. This hook runs *inside* the project, so a resolved path that does
+  // not exist means the guess was wrong — and recording it would let gc read a live
+  // project as "path gone, parent present" and delete its database.
+  //
+  // Skipping is not the same as clearing: setMeta upserts, so a database that
+  // already holds a verified path keeps it. That is the better evidence — a path
+  // that once resolved beats a guess that just failed. Only a database that never
+  // recorded one stays pathless, which gc keeps as legacy-fresh and reclaims solely
   // on the untouched-for-N-days rule, never on a deleted-project inference.
   const projectPath = getProjectPath(input.cwd);
-  if (existsSync(projectPath)) {
+  if (isExistingDir(projectPath)) {
     setMeta(db, "project_path", projectPath);
   } else {
-    log.debug(`session-start · resolved project path does not exist, not recording: ${projectPath}`);
+    log.debug(`session-start · resolved project path is not a directory, leaving meta as-is: ${projectPath}`);
   }
 
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD

--- a/src/hooks/session-start.ts
+++ b/src/hooks/session-start.ts
@@ -1,3 +1,4 @@
+import { existsSync } from "fs";
 import { loadConfig } from "../config";
 import { getProjectKey, getProjectPath } from "../project-key";
 import { getDb, defaultDbPath, recordSession, pruneExpired, setMeta } from "../db/index";
@@ -33,7 +34,21 @@ export function handleSessionStart(raw: string): void {
 
   // Record the resolved project path so `mcp-recall gc` can tell whether this
   // project still exists on disk (orphan detection is path-existence based).
-  setMeta(db, "project_path", getProjectPath(input.cwd));
+  //
+  // Only recorded when it actually exists. The path is absolute by construction,
+  // but absolute is not the same as true: a relative payload `cwd` gets rooted
+  // against this process's cwd, which may not be where it was meant to be rooted.
+  // This hook runs *inside* the project, so a resolved path that does not exist
+  // means the guess was wrong — and recording it would let gc read a live project
+  // as "path gone, parent present" and delete its database. Recording nothing
+  // leaves the DB pathless, which gc keeps as legacy-fresh and only ever reclaims
+  // on the untouched-for-N-days rule, never on a deleted-project inference.
+  const projectPath = getProjectPath(input.cwd);
+  if (existsSync(projectPath)) {
+    setMeta(db, "project_path", projectPath);
+  } else {
+    log.debug(`session-start · resolved project path does not exist, not recording: ${projectPath}`);
+  }
 
   const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
   recordSession(db, today);

--- a/src/project-key.ts
+++ b/src/project-key.ts
@@ -48,7 +48,7 @@ function resolveProjectPath(cwd: string): string {
   // and re-key every existing git project's database.
   const resolved = result.status === 0 && result.stdout
     ? result.stdout.trim()
-    : resolve(cwd);
+    : typeof cwd === "string" && cwd ? resolve(cwd) : process.cwd();
 
   pathCache.set(cwd, resolved);
   return resolved;

--- a/src/project-key.ts
+++ b/src/project-key.ts
@@ -1,5 +1,6 @@
 import { createHash } from "crypto";
 import { spawnSync } from "child_process";
+import { resolve } from "path";
 
 const pathCache = new Map<string, string>();
 
@@ -33,9 +34,21 @@ function resolveProjectPath(cwd: string): string {
     stdio: ["pipe", "pipe", "pipe"],
   });
 
+  // The fallback is absolutised rather than used verbatim. `cwd` arrives from a
+  // hook payload that is only cast, never validated, so it can be relative or "" —
+  // and this value is recorded as `project_path`, which `mcp-recall gc` uses to
+  // decide whether a project still exists. A relative path there is un-rootable:
+  // it read as "parent survived, project deleted" and got the database removed
+  // (#212 guards the deletion site; this removes the cause). `resolve("")` yields
+  // the process cwd — plausible rather than certain, but absolute and therefore
+  // reasoned about honestly downstream.
+  //
+  // git's --show-toplevel output is already absolute and normalised, and is left
+  // untouched: passing it through resolve() could alter the string for some paths
+  // and re-key every existing git project's database.
   const resolved = result.status === 0 && result.stdout
     ? result.stdout.trim()
-    : cwd;
+    : resolve(cwd);
 
   pathCache.set(cwd, resolved);
   return resolved;

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -4,9 +4,9 @@ import { tmpdir } from "os";
 import { join } from "path";
 import { handleSessionStart } from "../src/hooks/session-start";
 import { handlePostToolUse } from "../src/hooks/post-tool-use";
-import { getDb, closeDb, listOutputs, getSessionDays, retrieveOutput, storeOutput, pinOutput } from "../src/db/index";
+import { getDb, closeDb, listOutputs, getSessionDays, retrieveOutput, storeOutput, pinOutput, getMeta } from "../src/db/index";
 import { resetConfig } from "../src/config";
-import { getProjectKey } from "../src/project-key";
+import { getProjectKey, getProjectPath } from "../src/project-key";
 
 const TEST_CWD = process.cwd();
 const SESSION_ID = "test-session-abc123";
@@ -70,6 +70,21 @@ describe("handleSessionStart", () => {
     const days = getSessionDays(db);
     const today = new Date().toISOString().slice(0, 10);
     expect(days).toContain(today);
+  });
+
+  it("records project_path when the resolved path exists", () => {
+    handleSessionStart(makeSessionStartInput());
+    expect(getMeta(getDb(":memory:"), "project_path")).toBe(getProjectPath(TEST_CWD));
+  });
+
+  // The recorded path is absolute by construction (#213), but absolute is not true:
+  // a relative payload cwd gets rooted against this process's cwd. Recording a path
+  // that doesn't exist would let gc read "path gone, parent present" as orphaned and
+  // delete a live project's database. Pathless is kept as legacy-fresh instead.
+  it("does not record project_path when the resolved path does not exist", () => {
+    handleSessionStart(makeSessionStartInput({ cwd: "definitely-not-a-real-dir-xyz" }));
+    const recorded = getMeta(getDb(":memory:"), "project_path");
+    expect(recorded).toBeNull();
   });
 
   it("is idempotent — running twice records only one session entry", () => {

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -87,6 +87,26 @@ describe("handleSessionStart", () => {
     expect(recorded).toBeNull();
   });
 
+  // A project path is a directory. An existing *file* would satisfy existsSync and
+  // then be classified "active" by gc, which is wrong about what it is.
+  it("does not record project_path when the resolved path is a file", () => {
+    const f = join(mkdtempSync(join(tmpdir(), "recall-file-")), "not-a-dir");
+    writeFileSync(f, "x");
+    handleSessionStart(makeSessionStartInput({ cwd: f }));
+    expect(getMeta(getDb(":memory:"), "project_path")).toBeNull();
+  });
+
+  // setMeta upserts, so skipping leaves a previously-verified path in place rather
+  // than clearing it — better evidence than a guess that just failed.
+  it("keeps an already-recorded path when a later session cannot verify one", () => {
+    handleSessionStart(makeSessionStartInput());
+    const first = getMeta(getDb(":memory:"), "project_path");
+    expect(first).toBe(getProjectPath(TEST_CWD));
+
+    handleSessionStart(makeSessionStartInput({ cwd: "definitely-not-a-real-dir-xyz" }));
+    expect(getMeta(getDb(":memory:"), "project_path")).toBe(first);
+  });
+
   it("is idempotent — running twice records only one session entry", () => {
     handleSessionStart(makeSessionStartInput());
     handleSessionStart(makeSessionStartInput());

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -90,10 +90,15 @@ describe("handleSessionStart", () => {
   // A project path is a directory. An existing *file* would satisfy existsSync and
   // then be classified "active" by gc, which is wrong about what it is.
   it("does not record project_path when the resolved path is a file", () => {
-    const f = join(mkdtempSync(join(tmpdir(), "recall-file-")), "not-a-dir");
-    writeFileSync(f, "x");
-    handleSessionStart(makeSessionStartInput({ cwd: f }));
-    expect(getMeta(getDb(":memory:"), "project_path")).toBeNull();
+    const dir = mkdtempSync(join(tmpdir(), "recall-file-"));
+    try {
+      const f = join(dir, "not-a-dir");
+      writeFileSync(f, "x");
+      handleSessionStart(makeSessionStartInput({ cwd: f }));
+      expect(getMeta(getDb(":memory:"), "project_path")).toBeNull();
+    } finally {
+      rmSync(dir, { recursive: true, force: true });
+    }
   });
 
   // setMeta upserts, so skipping leaves a previously-verified path in place rather

--- a/tests/project-key.test.ts
+++ b/tests/project-key.test.ts
@@ -1,7 +1,7 @@
 import { describe, it, expect } from "bun:test";
 import { getProjectKey, getProjectPath } from "../src/project-key";
 import { tmpdir } from "os";
-import { join } from "path";
+import { join, isAbsolute } from "path";
 
 describe("getProjectKey", () => {
   it("returns a 16-char hex string", () => {
@@ -44,5 +44,42 @@ describe("getProjectPath", () => {
     const nonGitDir = tmpdir();
     const path = getProjectPath(nonGitDir);
     expect(path).toBe(join(nonGitDir));
+  });
+
+  // The returned value is recorded as `project_path` and drives gc's decision about
+  // whether a project still exists. A relative or empty path is un-rootable there:
+  // it read as "parent survived, project deleted" and the database was removed
+  // (#212). Hook payloads are cast, never validated, so this must hold for any input.
+  // These two reach the non-git fallback (the directories don't exist, so
+  // `git rev-parse` fails) and are the cases that actually guard the fix —
+  // reverting to a bare `cwd` turns both red.
+  it.each([
+    ["a bare relative name", "definitely-not-a-real-dir-xyz"],
+    ["a relative path with segments", "some/relative/path"],
+  ])("returns an absolute path for %s", (_label, input) => {
+    const path = getProjectPath(input);
+    expect(isAbsolute(path)).toBe(true);
+  });
+
+  // Built by concatenation, not join(), which would normalise the input before
+  // it ever reached the function — the first version of this test did that and
+  // passed no matter what the implementation did.
+  it("normalises .. segments in a non-git path", () => {
+    const messy = `${tmpdir()}/a/../b`;
+    expect(getProjectPath(messy)).toBe(join(tmpdir(), "b"));
+  });
+
+  // Holds via the git branch rather than the fallback: spawnSync with cwd "" runs
+  // in the process cwd, so git answers. Asserted because the invariant callers
+  // depend on is "always absolute", regardless of which branch produced it.
+  it("returns an absolute path for an empty string", () => {
+    expect(isAbsolute(getProjectPath(""))).toBe(true);
+  });
+
+  it("leaves an already-absolute non-git path unchanged, so keys do not shift", () => {
+    // Guards the migration property: normalising must be a no-op for the paths
+    // real callers pass, or every existing project would be re-keyed to a new DB.
+    const abs = tmpdir();
+    expect(getProjectPath(abs)).toBe(abs);
   });
 });

--- a/tests/project-key.test.ts
+++ b/tests/project-key.test.ts
@@ -69,9 +69,10 @@ describe("getProjectPath", () => {
     expect(getProjectPath(messy)).toBe(join(tmpdir(), "b"));
   });
 
-  // Holds via the git branch rather than the fallback: spawnSync with cwd "" runs
-  // in the process cwd, so git answers. Asserted because the invariant callers
-  // depend on is "always absolute", regardless of which branch produced it.
+  // Which branch answers is runtime-specific: Bun's spawnSync with cwd "" runs in
+  // the process cwd so git answers, while Node would chdir("") -> ENOENT and take
+  // the fallback. Absolute either way, which is the invariant callers depend on —
+  // so this documents that invariant rather than guarding the fix on any runtime.
   it("returns an absolute path for an empty string", () => {
     expect(isAbsolute(getProjectPath(""))).toBe(true);
   });


### PR DESCRIPTION
Closes #213. The root-cause half of #212.

## Summary

`resolveProjectPath` returned `cwd` verbatim when `git rev-parse --show-toplevel` failed, and `cwd` comes from a hook payload that is cast but never validated. That value is recorded as `project_path`, which `gc` uses to decide whether a project still exists — and a relative path is un-rootable there, so it read as *"parent survived, project deleted"* and the database was removed.

#212 guarded the deletion site. This removes the cause, at the chokepoint the #212 review identified — `post-tool-use.ts` inherits it for free, with no per-hook payload validation needed.

```
cwd=""              → /home/sakebomb/code/open-source/mcp-recall          absolute ✓
cwd="myproject"     → /home/sakebomb/code/open-source/mcp-recall/myproject absolute ✓
cwd="some/rel/path" → …/some/rel/path                                      absolute ✓
```

## Scope: fallback only, deliberately

git's `--show-toplevel` output is already absolute and normalised and is left untouched. Passing it through `resolve()` could alter the string for some paths and **re-key every existing git project's database** — the key is a hash of this value, so a changed string means a new, empty DB.

## Migration risk, measured before changing anything

Checked the live 22-database store: **1** database has a recorded `project_path` (the field is new in 1.10.0), and it is already normalised — so nothing re-keys. Also asserted the no-op property directly, since that invariant is what keeps existing keys stable:

> `it("leaves an already-absolute non-git path unchanged, so keys do not shift")`

Worth stating the residual, and it is broader than messy absolutes: `resolveProjectPath` also feeds `getProjectKey`, so absolutising the fallback changes the hash for **any relative non-git `cwd`** — `"myproject"` hashed the literal string before and hashes `/…/repo/myproject` now. A caller passing an absolute path with a trailing slash or `..` segment re-keys too. No data loss (the old DB isn't deleted — its path exists, so `gc` calls it `active`), but that project's stored history becomes unreachable. Given the alternative is leaving an un-rootable value feeding a destructive command, that trade is right.

## The open question in #213, decided

`resolve("")` yields the process cwd. Plausible rather than certain, but absolute — so downstream code reasons about it honestly instead of inferring deletion from `""`. Documented in the code comment.

## My tests were partly theatre — mutation testing caught it

The first version used `join()` to build "messy" paths. `join()` *normalises*, so `join(tmpdir(), ".", "x")` was already `/tmp/x` before the function saw it, and `join(tmpdir(),"a","..","b")` was already `/tmp/b`. Reverting the fix reddened only **2 of 4** cases.

Rebuilt:

| Case | Reverting the fix |
|---|---|
| bare relative name | **RED** |
| relative path with segments | **RED** |
| `..` segments (string concat, not `join`) | **RED** |
| empty string | green — resolves via the *git* branch, not the fallback |
| already-absolute path unchanged | green — migration invariant, not a guard |

The last two are labelled in the test file for what they are, rather than sitting in a block whose title implies they guard the fix.

## Test plan

- [x] `bun test` — 785 tests, 0 fail
- [x] `bun run typecheck` clean
- [x] Mutation-tested: reverting to bare `cwd` reddens exactly the three real guards
- [x] Migration risk measured against the live store (1 recorded path, already normalised)
- [x] End-to-end: `""`, a bare name, and a relative path all now yield absolute paths, so none can reach `gc` as a deletion candidate
