### PR TITLE
chore: gitignore tasks/scratch/

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -18,3 +18,8 @@ Thumbs.db
 *.swp
 *.swo
 *~
+
+# Agent scratch output. tasks/ itself is tracked (todo, lessons, specs); this
+# subdirectory is working notes whose durable conclusions get written elsewhere,
+# so it should never be committed.
+tasks/scratch/


### PR DESCRIPTION
## Summary

Agent scratch output has appeared as untracked in every session this whole time. `tasks/` itself is tracked (`todo.md`, `lessons.md`, `specs/`), but `tasks/scratch/` holds working notes whose durable conclusions get written elsewhere — the competitor research currently sitting there is already summarised into project memory.

Untracked-but-not-ignored is the worst of the three states: it adds noise to every `git status` and it's one careless `git add -A` from being committed.

## Test plan

- [x] `git check-ignore -v tasks/scratch/competitor-research.md` → matches `.gitignore:25`
- [x] `git status` is clean with the scratch directory present
- [x] Tracked `tasks/` files are unaffected — `git ls-files tasks/` still lists todo/lessons/specs