### PR TITLE
ci: tell PR reviews to settle CI claims from CI instead of disclaiming them

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -49,6 +49,25 @@ jobs:
           # -------------------------------------------------------------------
 
           # Auto PR review supplies a review prompt; mentions use the comment body.
-          prompt: ${{ github.event_name == 'pull_request' && 'Review this PR for correctness, security, and adherence to the repo conventions in CLAUDE.md. Flag CRITICAL/HIGH issues clearly; keep notes concise.' || '' }}
+          #
+          # The CI-verification clause is deliberate. Reviews were inconsistently
+          # disclaiming "could not reproduce the test count" even though this job
+          # holds `actions: read` for exactly that — some reviews read the CI run and
+          # settled claims from it, others assumed they could not. Nothing in the old
+          # prompt asked them to look. See #221; this needs no extra permission.
+          #
+          # Folded scalar (>-) so the prompt stays readable; YAML folds the newlines
+          # to spaces before Actions evaluates the expression. Avoid apostrophes in
+          # the text — it lives inside a single-quoted GitHub expression string.
+          prompt: >-
+            ${{ github.event_name == 'pull_request' && 'Review this PR for
+            correctness, security, and adherence to the repo conventions in
+            CLAUDE.md. Flag CRITICAL/HIGH issues clearly and keep notes concise.
+            Treat every factual claim in the PR body as unverified until you have
+            checked it against the code. For claims about test counts, coverage, or
+            CI status, read the CI run for the head commit and settle them from it
+            rather than disclaiming that you could not verify them. Say plainly
+            which claims you verified and how, and which you could not — never
+            present reasoning as verification.' || '' }}
           trigger_phrase: "@claude"
           track_progress: "true"


### PR DESCRIPTION
The zero-risk half of #221. Refs #221 — the execution-grant question stays open there.

## Why

Reviews were inconsistently disclaiming that they could not reproduce a test count, even though this job **already** holds `actions: read` for the `github_ci` server. Some reviews used it:

- #217: *"CI run for this head commit is **green**, which also settles item 6"*
- #217: *"the new `Packaged CLI` job passed"* (with job link)
- #219: cited CI run `30389615164` directly

Others disclaimed the same class of claim as unverifiable. Nothing in the prompt asked them to look, so which behaviour you got was chance.

## What changed

Three instructions added:

1. Treat every factual claim in the PR body as unverified until checked against the code.
2. Settle test-count / coverage / CI claims from the actual CI run for the head commit rather than disclaiming them.
3. Say plainly which claims were verified and how, and which were not — never present reasoning as verification.

**No new permissions.** That's the significant part: #221 framed this as needing an execution grant, and reviewing that issue showed most of the gap is prompt-level. The residual — a reviewer running its *own* experiment, e.g. checking a mutation-testing claim — is a genuinely narrower ask and stays open on #221.

## Formatting

Reformatted to a folded scalar (`>-`) so the prompt is readable in a diff instead of one 588-char line. YAML folds the newlines to spaces before Actions evaluates the expression.

Verified rather than assumed, since a broken expression here silently disables auto-review:

| Check | Result |
|---|---|
| Parses as a single line | yes |
| `${{` / `}}` balanced | 1 / 1 |
| Single quotes | 6 — exactly the three delimiter pairs, no stray apostrophes |
| Ternary tokenizes as | `code` / `'pull_request'` / `&&` / `'prompt'` / `\|\|` / `''` |

The apostrophe constraint is why the text says "could not" rather than "couldn't" — the prompt lives inside a single-quoted GitHub expression string, and a stray `'` would truncate it. Noted in a comment above the block so the next edit does not reintroduce one.

## Test plan

- [x] `yaml.safe_load` parses the workflow
- [x] Expression structure validated by tokenizing on `'`
- [x] Zero apostrophes inside the literal
- [x] Prompt reaches the action intact — confirmed in the run log: `PROMPT:` contains the full text, so the expression evaluated correctly
- [ ] Reviewer actually cites CI on a subsequent PR — **cannot be tested here**, see below

### My self-verifying test was impossible, and that is worth recording

I originally claimed a review appearing on this PR would prove the expression valid. It cannot. The action refuses to run on any PR that modifies its own workflow file:

> Workflow validation failed. The workflow file must exist and have identical content to the version on the repository's default branch. … This is expected … on PRs with workflow changes. Your workflow will begin working once you merge your PR.

So the review skipped in 8s with zero comments — not because my change is broken, but because *any* change here skips it. The test could only ever fail, which makes it worse than no test: I would have read a guaranteed failure as evidence of a bug I had not introduced.

What I could verify is that the prompt reached the action intact — the run log shows the complete text under `PROMPT:`, which is stronger evidence about the expression than a posted review would have been.

Verification of the actual behaviour change moves to the **next** PR after this merges.
