### PR TITLE
docs: mark phase 13 complete

### DIFF
--- a/CLAUDE.md
+++ b/CLAUDE.md
@@ -134,12 +134,13 @@ mcp-recall profiles available # list community profiles available to install
 | 11 | Store lifecycle — `gc`, free-page reclamation, pin-budget reporting | Complete (v1.10.0) |
 | 12 | Supply chain — manifest attestation restored (profiles repo), exact signer-identity pinning via `--cert-identity`, old-`gh` diagnosis | Complete (v1.10.0) |
 | 12b | Packaging integrity — symlink-safe `bin/recall`, publish-time tag/version guard, packaged-CLI CI job | Complete (v1.10.1) |
-| 13 | **Current: stabilize + document.** Docs accuracy, contributor architecture doc, `ROADMAP.md`. No new features | In progress |
+| 13 | Stabilize + document. Docs accuracy, contributor architecture doc (`docs/architecture.md`), `ROADMAP.md` with explicit non-goals. No new features | Complete |
 
 Phases 1–9 were planned up front. Everything after was reactive — ported ideas from a
-competitive review, then a dogfooding pass, then findings from those. Phase 13 exists to
-stop and consolidate before adding more. Its final step is a `ROADMAP.md` stating what is
-deliberately out of scope; until that lands, this table is the only statement of direction.
+competitive review, then a dogfooding pass, then findings from those. Phase 13 existed to
+stop and consolidate before adding more. Its final step, `ROADMAP.md`, states what is
+deliberately out of scope and is now the project's statement of direction;
+`docs/architecture.md` covers the system's shape for contributors.
 
 ## Testing Conventions
 

--- a/tasks/todo.md
+++ b/tasks/todo.md
@@ -4,15 +4,16 @@ Active work and upcoming tasks.
 
 ## In Progress
 
-**Phase 13 — stabilize + document.** No new features until it lands. Plan and phase table
-are in `CLAUDE.md`; #208 and #205 stay open deliberately.
+**Phase 13 — stabilize + document. ✓ COMPLETE** (all four steps landed). Plan and phase
+table are in `CLAUDE.md`; #208 and #205 stay open deliberately. Deferred feature/fix work
+that was blocked by the docs-only policy can now proceed: #227, #228, #205, #226, #214, #208.
 
 | Step | State |
 |------|-------|
 | A — CLAUDE.md accuracy | ✓ DONE, PR [#220](https://github.com/sakebomb/mcp-recall/pull/220) @ `709c780` |
 | B — full docs re-read | ✓ DONE — both passes, all 12 surfaces, review-hardened |
 | C — `docs/architecture.md` for contributors | ✓ DONE, PR [#229](https://github.com/sakebomb/mcp-recall/pull/229) — pipeline+module map+dispatch+4 invariants, per-assertion verified, independent claim audit found+fixed 1 wrong claim (`203d463`), linked from README & CONTRIBUTING |
-| D — `ROADMAP.md` with explicit non-goals | not started ← resume here (terminal Phase 13 deliverable) |
+| D — `ROADMAP.md` with explicit non-goals | ✓ DONE, PR [#230](https://github.com/sakebomb/mcp-recall/pull/230) — the bet, themes-not-commitments, #188/#189 deferred, 4 non-goals, linked from README |
 
 ### Step B pass 1 — what was fixed (2026-07-28)
 


### PR DESCRIPTION
## Summary

- Flips the CLAUDE.md phase table (row 13) from *In progress* to **Complete** — all four Phase 13 steps have landed: A ([#220](https://github.com/sakebomb/mcp-recall/pull/220)), B ([#225](https://github.com/sakebomb/mcp-recall/pull/225)), C ([#229](https://github.com/sakebomb/mcp-recall/pull/229)), D ([#230](https://github.com/sakebomb/mcp-recall/pull/230)).
- Updates the now-outdated paragraph under the table: `ROADMAP.md` no longer "final step, not yet landed" — it exists and is the project's statement of direction, with `docs/architecture.md` covering the system's shape for contributors.
- Marks the tracker (`tasks/todo.md`) Phase 13 complete and notes that the docs-only policy which deferred feature/fix work (#227, #228, #205, #226, #214, #208) is now lifted.

Bookkeeping only — no code, no doc-content changes beyond the status flip.

## Test plan

- [x] `bun run typecheck` passes (no `src/` change)
- [ ] `bun test` — N/A, no code or test change (status text only)
- [ ] `bun run build` — N/A, no `src/` changes
- [x] Verified the updated paragraph no longer claims ROADMAP.md is unlanded

https://claude.ai/code/session_01T2Fkofq92QNXDqhyMQ6uq6