### PR TITLE
test: guard that shipped surfaces stay documented (#227)

### DIFF
--- a/src/config.ts
+++ b/src/config.ts
@@ -5,7 +5,7 @@ import { join } from "path";
 import { z } from "zod";
 import { log, setDebugEnabled } from "./log";
 
-const RecallConfigSchema = z.object({
+export const RecallConfigSchema = z.object({
   store: z.object({
     expire_after_session_days: z.number().positive(),
     key: z.enum(["git_root", "cwd"]),

--- a/tests/docs-coverage.test.ts
+++ b/tests/docs-coverage.test.ts
@@ -1,0 +1,147 @@
+import { test, expect, describe } from "bun:test";
+import { readFileSync } from "fs";
+import { join } from "path";
+import { Glob } from "bun";
+import { RecallConfigSchema } from "../src/config";
+import { printHelp } from "../src/cli";
+
+// Doc-coverage guard (#227). Derives four inventories from source of truth and
+// asserts each surface is named in its canonical doc location. This catches
+// *silence* — a tool / config key / env var / command that exists in code and is
+// documented nowhere — which has recurred four times (#216, #225×3) and been
+// invisible to every other CI job.
+//
+// Design rule (learned the hard way in #225): match against PARSED STRUCTURE, not
+// a whole-file substring. A naive `grep -q "$key"` passed for `key`/`enabled`
+// because those words appear in prose. Every check below parses the specific
+// table rows, TOML `key =` lines, or fenced command block — never "does this
+// string appear somewhere in the file." Prose *accuracy* (does the flag do what
+// the sentence claims) stays a review concern and is deliberately out of scope.
+
+const readme = readFileSync("README.md", "utf8");
+
+// ── Markdown structure helpers ──────────────────────────────────────────────
+
+/** Body of a README `## <header>` section, up to the next `## ` heading. */
+function section(md: string, header: string): string {
+  const lines = md.split("\n");
+  const start = lines.findIndex((l) => l.trim() === `## ${header}`);
+  if (start === -1) throw new Error(`README section "## ${header}" not found`);
+  let end = lines.length;
+  for (let i = start + 1; i < lines.length; i++) {
+    if (/^## /.test(lines[i])) {
+      end = i;
+      break;
+    }
+  }
+  return lines.slice(start, end).join("\n");
+}
+
+/** Contents of the first ```<lang> fenced block in `body`. */
+function firstFence(body: string, lang: string): string {
+  const m = body.match(new RegExp("```" + lang + "\\n([\\s\\S]*?)```"));
+  if (!m) throw new Error(`no \`\`\`${lang} fence found in the given section`);
+  return m[1];
+}
+
+/**
+ * Asserts every source surface is documented. A miss names the exact surface, so
+ * a contributor knows precisely what to add. Also fails if the source inventory
+ * came back empty — a broken extractor would otherwise pass vacuously, which is
+ * the very false-confidence failure this guard exists to prevent.
+ */
+function assertAllDocumented(surfaces: string[], documented: string[], where: string): void {
+  expect(surfaces.length, `source inventory for ${where} is empty — the extractor is broken`).toBeGreaterThan(0);
+  for (const s of surfaces) {
+    expect(documented, `"${s}" exists in source but is undocumented in ${where}`).toContain(s);
+  }
+}
+
+// ── recall__* tools ─────────────────────────────────────────────────────────
+
+describe("docs coverage: recall__* tools", () => {
+  const serverSrc = readFileSync("src/server.ts", "utf8");
+  const registered = [...serverSrc.matchAll(/server\.tool\(\s*"(recall__\w+)"/g)].map((m) => m[1]);
+
+  test("every registered tool appears in the README tool table", () => {
+    const rows = [...section(readme, "Tools").matchAll(/^\|\s*`(recall__\w+)/gm)].map((m) => m[1]);
+    assertAllDocumented(registered, rows, "the README `## Tools` table");
+  });
+
+  test("every registered tool has a heading in docs/tools.md", () => {
+    const doc = readFileSync("docs/tools.md", "utf8");
+    const headings = [...doc.matchAll(/^##\s+`(recall__\w+)`/gm)].map((m) => m[1]);
+    assertAllDocumented(registered, headings, "docs/tools.md section headings");
+  });
+});
+
+// ── config keys ─────────────────────────────────────────────────────────────
+
+describe("docs coverage: config keys", () => {
+  // Leaf keys from the Zod schema itself, not a grep — the true source of truth.
+  const leafKeys: string[] = [];
+  for (const sectionSchema of Object.values(RecallConfigSchema.shape)) {
+    for (const key of Object.keys((sectionSchema as { shape: Record<string, unknown> }).shape)) {
+      leafKeys.push(key);
+    }
+  }
+
+  test("every schema key appears as a key = line in the README config block", () => {
+    const toml = firstFence(section(readme, "Configuration"), "toml");
+    const documented = [...toml.matchAll(/^\s*([a-z_]+)\s*=/gm)].map((m) => m[1]);
+    assertAllDocumented(leafKeys, documented, "the README `## Configuration` TOML block");
+  });
+});
+
+// ── environment variables ───────────────────────────────────────────────────
+
+describe("docs coverage: environment variables", () => {
+  // Env vars intentionally undocumented (internal/test-only). Empty today; adding
+  // a name here is the explicit escape hatch, so the omission is a decision on
+  // record rather than silence.
+  const INTERNAL_ENV_VARS = new Set<string>([]);
+
+  test("every RECALL_* env var read by source is in the README env-var table", () => {
+    let source = readFileSync("bin/recall", "utf8");
+    for (const file of new Glob("**/*.ts").scanSync("src")) {
+      source += readFileSync(join("src", file), "utf8");
+    }
+    const used = [...new Set([...source.matchAll(/RECALL_[A-Z_]+/g)].map((m) => m[0]))].filter(
+      (v) => !INTERNAL_ENV_VARS.has(v),
+    );
+    const documented = [...section(readme, "Configuration").matchAll(/^\|\s*`(RECALL_[A-Z_]+)`/gm)].map((m) => m[1]);
+    assertAllDocumented(used, documented, "the README environment-variable table");
+  });
+});
+
+// ── top-level CLI commands ──────────────────────────────────────────────────
+
+describe("docs coverage: CLI commands", () => {
+  // The `subcommand === "…"` dispatch chain in cli.ts. The internal hook
+  // dispatches (session-start, post-tool-use) use a `case` switch, not this
+  // form, so they are correctly excluded from the user-facing command set.
+  const cliSrc = readFileSync("src/cli.ts", "utf8");
+  const commands = [...new Set([...cliSrc.matchAll(/subcommand === "([a-z-]+)"/g)].map((m) => m[1]))];
+
+  test("every command is listed by printHelp()", () => {
+    const orig = console.log;
+    let out = "";
+    console.log = (...args: unknown[]) => {
+      out += args.join(" ") + "\n";
+    };
+    try {
+      printHelp();
+    } finally {
+      console.log = orig;
+    }
+    // printHelp lists commands as indented "  <name>  …" lines; match those.
+    const listed = [...out.matchAll(/^ {2}([a-z-]+)\b/gm)].map((m) => m[1]);
+    assertAllDocumented(commands, listed, "printHelp() output");
+  });
+
+  test("every command appears in the README CLI reference", () => {
+    const fence = firstFence(section(readme, "CLI reference"), "bash");
+    const documented = [...new Set([...fence.matchAll(/^mcp-recall\s+([a-z]+)/gm)].map((m) => m[1]))];
+    assertAllDocumented(commands, documented, "the README `## CLI reference` block");
+  });
+});


### PR DESCRIPTION
## Summary

- Adds `tests/docs-coverage.test.ts` — a CI guard that catches **silence**: a tool, config key, env var, or CLI command that exists in code and is documented nowhere. Closes #227.
- "Shipped but undocumented" recurred four times (#216, #225×3 — one of them a security-relevant `SECURITY.md` overstatement), each caught by a human reading carefully, none by any CI job. This converts that class into a test failure.
- Derives four inventories from their source of truth and asserts each surface is named in its canonical doc location:

| Inventory | Source of truth | Must appear in |
|---|---|---|
| `recall__*` tools | `server.tool(...)` in `src/server.ts` | README tool table + `docs/tools.md` headings |
| Config keys | `RecallConfigSchema` in `src/config.ts` | README config TOML block |
| Env vars | `RECALL_*` in `src/` + `bin/` | README env-var table |
| CLI commands | `subcommand === "…"` dispatch in `src/cli.ts` | `printHelp()` + README CLI reference |

- Runs in the existing required **Test & typecheck** job — no `ci.yml` change. Exports `RecallConfigSchema` (one-line) so the guard walks the Zod schema instead of grepping for keys.

**Design rule, learned the hard way in #225:** every check matches against **parsed structure** — table rows, TOML `key =` lines, the fenced command block — never a whole-file substring (a naive `grep -q` passed for `key`/`enabled` in prose). A miss **names the exact surface**; an empty source inventory also fails, so a broken extractor can't pass vacuously. Scope is silence only — prose *accuracy* stays a review concern, per the issue.

## Test plan

- [x] `bun test` passes — 798 tests (+6), 0 fail
- [x] `bun run typecheck` passes
- [x] `bun run build` — bundle byte-identical (the added `export` tree-shakes out), no `dist/` drift
- [x] New guard added, and **mutation-tested in both directions**: removing each of the 6 documented surfaces (a tool row, a `docs/tools.md` heading, a config key, an env-var row, a `printHelp` line, a CLI-reference line) turns the matching test red and names the missing surface; passes unmutated on `main`
- [ ] README / CHANGELOG — N/A, this is test-only tooling, no user-facing behaviour change

Self-reviewed against the verification lenses; the guard-check (Lens 1 mutation testing) is in the test plan above.

https://claude.ai/code/session_01T2Fkofq92QNXDqhyMQ6uq6