### PR TITLE
fix: treat unavailable signature verification as fatal in error mode (#208)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Changed
+
+- **BREAKING (non-default mode): `verify_signature = "error"` now hard-fails when signature verification cannot run.** `error` previously governed only how a *failed* signature was handled — if `gh` was absent from `PATH`, or too old for the flags we verify with, it wrote a line to stderr and proceeded against an **unverified** manifest, the opposite of what a user setting `error` to guarantee verification expects. `error` now means verification must *succeed*: a missing or unusable `gh` is fatal for `profiles install/seed/update`, with a message distinct from a signature failure (an unusable tool is not evidence of tampering) that names `--skip-verify` as the escape hatch. `warn` (the default) and `skip` are unchanged. If you run `error` in an environment without a usable `gh` (a slim container image, for instance) and intend to proceed, pass `--skip-verify` or set `verify_signature = "warn"` (#208)
+
 ### Fixed
 
 - **The recorded project path is now always absolute.** `session-start` stores a `project_path` that `mcp-recall gc` uses to classify each project database, but it was taken verbatim from the hook payload's `cwd`, which is never validated — so a relative or empty value could be stored. `gc` cannot root such a path, so it classified those databases `unverifiable`: never deleted, but also never reclaimable, even by `--vacuum`. The path is now absolutised at its source, and one that does not resolve to a real directory is not recorded at all rather than recorded as a guess, so this can no longer happen for newly recorded paths. Nothing rewrites an existing one: a database that already recorded a relative path keeps it, stays `unverifiable`, and must be removed by hand. Note for anyone whose hook payload supplied a *relative* `cwd`: the project key is a hash of this value, so it changes — that project starts a new database and its earlier history becomes unreachable (nothing is deleted). Claude Code supplies an absolute `cwd`, so this is not expected in normal use (#213)

--- a/docs/profile-schema.md
+++ b/docs/profile-schema.md
@@ -188,8 +188,8 @@ When `install`, `update`, or `seed` download the community manifest, mcp-recall 
 
 ```toml
 [profiles]
-verify_signature = "warn"   # default — logs a warning if verification fails
-# verify_signature = "error"  # hard-fail if the signature does not verify — but see below: still skipped when gh is unavailable
+verify_signature = "warn"   # default — logs a warning if verification fails or can't run
+# verify_signature = "error"  # hard-fail unless the signature verifies — including when gh is unavailable
 # verify_signature = "skip"   # disable verification entirely
 ```
 
@@ -205,12 +205,21 @@ job. Repo scope alone would accept an attestation from any workflow in that repo
 and pinning only the workflow path would still accept one signed from any branch — the
 full identity pins the ref as well.
 
-If `gh` is absent, or too old to support the flags used above, verification is skipped
-with a distinct message rather than reported as a signature failure — an unusable tool is
-not evidence of tampering. Note the consequence: `error` strengthens how a *failed*
-signature is handled, not whether verification is *available*. In an environment without
-a usable `gh` (a container image, for instance), `error` still proceeds with an unverified
-manifest and only a line on stderr.
+If `gh` is absent, or too old to support the flags used above, verification cannot run.
+That is a tooling gap, not evidence of tampering, so it is always reported with a
+*distinct* message — never as a signature failure. What happens next depends on the mode:
+
+- **`warn`** (default) and **`skip`** proceed with an unverified manifest, `warn` logging
+  the gap to stderr.
+- **`error`** treats an unavailable verifier as fatal: `error` means verification must
+  *succeed*, so a missing or too-old `gh` is a hard failure, not a silent pass. The error
+  names the reason and points at `--skip-verify` so it is actionable.
+
+> **Breaking change:** previously `error` only governed how a *failed*
+> signature was handled and silently proceeded when `gh` was unavailable. It now also
+> fails when verification *cannot run*. If you run `error` in an environment without a
+> usable `gh` (a slim container image, for instance) and intend to proceed anyway, use
+> `--skip-verify` or set `verify_signature = "warn"`. The default (`warn`) is unaffected.
 
 To skip verification for a single command (e.g. in CI without `gh` installed):
 

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -8638,6 +8638,13 @@ function verifyHash(content, expected, id) {
   }
 }
 var UNSUPPORTED_FLAG_RE = /unknown (flag|command|shorthand flag)/i;
+function reportUnavailable(mode, reason) {
+  if (mode === "error") {
+    throw new Error(`[recall] manifest signature cannot be verified: ${reason}. ` + `verify_signature = "error" requires verification to succeed \u2014 ` + `install or upgrade gh, or pass --skip-verify to proceed without it.`);
+  }
+  process.stderr.write(`[recall] manifest signature verification skipped: ${reason}
+`);
+}
 function verifyManifest(manifestPath, mode) {
   if (mode === "skip")
     return;
@@ -8647,8 +8654,7 @@ function verifyManifest(manifestPath, mode) {
     ghAvailable = probe.exitCode === 0;
   } catch {}
   if (!ghAvailable) {
-    process.stderr.write(`[recall] manifest signature verification skipped: gh CLI not found in PATH
-`);
+    reportUnavailable(mode, "gh CLI not found in PATH");
     return;
   }
   const result = Bun.spawnSync([
@@ -8664,8 +8670,7 @@ function verifyManifest(manifestPath, mode) {
   if (result.exitCode !== 0) {
     const errText = result.stderr ? new TextDecoder().decode(result.stderr).trim() : "";
     if (UNSUPPORTED_FLAG_RE.test(errText)) {
-      process.stderr.write(`[recall] manifest signature verification skipped: this gh CLI does not support the flags we verify with (upgrade gh)
-`);
+      reportUnavailable(mode, "this gh CLI does not support the flags we verify with (upgrade gh)");
       return;
     }
     const msg = `[recall] manifest signature verification failed${errText ? `: ${errText}` : ""}

--- a/src/profiles/shared.ts
+++ b/src/profiles/shared.ts
@@ -121,6 +121,29 @@ export function verifyHash(content: string, expected: string | undefined, id: st
 const UNSUPPORTED_FLAG_RE = /unknown (flag|command|shorthand flag)/i;
 
 /**
+ * Handle a verification that could not run — gh absent from PATH, or too old for
+ * the flags we pin with. This is a tooling gap, not evidence of tampering, so its
+ * diagnosis must never collapse into the "signature did not verify" message.
+ *
+ * In `error` mode verification is mandatory (#208, option B): `error` means
+ * verification must *succeed*, so an unavailable verifier is fatal. `warn` logs the
+ * gap and proceeds. `--skip-verify` is the documented escape hatch and is named in
+ * the failure so it is actionable.
+ */
+function reportUnavailable(mode: "warn" | "error", reason: string): void {
+  if (mode === "error") {
+    throw new Error(
+      `[recall] manifest signature cannot be verified: ${reason}. ` +
+        `verify_signature = "error" requires verification to succeed — ` +
+        `install or upgrade gh, or pass --skip-verify to proceed without it.`
+    );
+  }
+  process.stderr.write(
+    `[recall] manifest signature verification skipped: ${reason}\n`
+  );
+}
+
+/**
  * Verify the manifest file has a valid GitHub Artifact Attestation.
  * Shells out to `gh attestation verify`. Degrades gracefully if gh is absent
  * or too old to support the flags we pin with.
@@ -137,9 +160,7 @@ export function verifyManifest(manifestPath: string, mode: "warn" | "error" | "s
   }
 
   if (!ghAvailable) {
-    process.stderr.write(
-      "[recall] manifest signature verification skipped: gh CLI not found in PATH\n"
-    );
+    reportUnavailable(mode, "gh CLI not found in PATH");
     return;
   }
 
@@ -161,8 +182,9 @@ export function verifyManifest(manifestPath: string, mode: "warn" | "error" | "s
     // Covers both an unknown --cert-identity and, on older still, no `attestation`
     // subcommand at all; the remedy is the same either way.
     if (UNSUPPORTED_FLAG_RE.test(errText)) {
-      process.stderr.write(
-        "[recall] manifest signature verification skipped: this gh CLI does not support the flags we verify with (upgrade gh)\n"
+      reportUnavailable(
+        mode,
+        "this gh CLI does not support the flags we verify with (upgrade gh)"
       );
       return;
     }

--- a/tests/profiles-commands.test.ts
+++ b/tests/profiles-commands.test.ts
@@ -943,7 +943,9 @@ describe("verifyManifest", () => {
     expect(stderrLines.join("")).toContain("gh CLI not found");
   });
 
-  test("error mode does not throw when gh is not in PATH (degrade gracefully)", () => {
+  test("error mode throws a distinct, actionable error when gh is not in PATH", () => {
+    // Option B (#208): `error` means verification must succeed, so an unavailable
+    // verifier is fatal — not the old silent-proceed-with-a-stderr-line behavior.
     const spy = spyOn(Bun, "spawnSync").mockImplementation((..._args: unknown[]) => {
       throw new Error("spawn ENOENT");
     });
@@ -951,12 +953,23 @@ describe("verifyManifest", () => {
     const origWrite = process.stderr.write.bind(process.stderr);
     process.stderr.write = () => true;
 
+    let caught: Error | undefined;
     try {
-      expect(() => verifyManifest(tmpFile, "error")).not.toThrow();
+      verifyManifest(tmpFile, "error");
+    } catch (e) {
+      caught = e as Error;
     } finally {
       process.stderr.write = origWrite;
       spy.mockRestore();
     }
+
+    expect(caught).toBeDefined();
+    expect(caught!.message).toContain("cannot be verified");
+    expect(caught!.message).toContain("gh CLI not found");
+    // Actionable: names the documented escape hatch.
+    expect(caught!.message).toContain("--skip-verify");
+    // Distinct from a signature that ran and failed — never conflate the two.
+    expect(caught!.message).not.toContain("verification failed");
   });
 
   test("pins the exact signer identity, not just the repo", () => {
@@ -989,35 +1002,72 @@ describe("verifyManifest", () => {
 
   // "unknown flag" is gh too old for --cert-identity; "unknown command" is gh < 2.49,
   // which has no `attestation` subcommand at all. Same remedy, so same branch.
-  test.each([
+  const OLD_GH_STDERR: [string][] = [
     ["unknown flag: --cert-identity"],
     ['unknown command "attestation" for "gh"'],
-  ])("reports an old gh (%s) as a tooling gap, not a failed signature", (ghStderr) => {
-    const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
-      const args = cmd as string[];
-      if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
-      return { exitCode: 1, stderr: new TextEncoder().encode(ghStderr), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
-    });
+  ];
 
-    const stderrLines: string[] = [];
-    const origWrite = process.stderr.write.bind(process.stderr);
-    process.stderr.write = (msg: string | Uint8Array, ..._rest: unknown[]) => {
-      stderrLines.push(typeof msg === "string" ? msg : new TextDecoder().decode(msg));
-      return true;
-    };
+  test.each(OLD_GH_STDERR)(
+    "warn mode reports an old gh (%s) as a tooling gap, not a failed signature",
+    (ghStderr) => {
+      const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
+        const args = cmd as string[];
+        if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
+        return { exitCode: 1, stderr: new TextEncoder().encode(ghStderr), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
+      });
 
-    try {
-      // error mode must not throw: gh being too old is not evidence of tampering.
-      expect(() => verifyManifest(tmpFile, "error")).not.toThrow();
-    } finally {
-      process.stderr.write = origWrite;
-      spy.mockRestore();
+      const stderrLines: string[] = [];
+      const origWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = (msg: string | Uint8Array, ..._rest: unknown[]) => {
+        stderrLines.push(typeof msg === "string" ? msg : new TextDecoder().decode(msg));
+        return true;
+      };
+
+      try {
+        // warn mode is unchanged: gh being too old is not evidence of tampering.
+        expect(() => verifyManifest(tmpFile, "warn")).not.toThrow();
+      } finally {
+        process.stderr.write = origWrite;
+        spy.mockRestore();
+      }
+
+      const out = stderrLines.join("");
+      expect(out).toContain("upgrade gh");
+      expect(out).not.toContain("verification failed");
     }
+  );
 
-    const out = stderrLines.join("");
-    expect(out).toContain("upgrade gh");
-    expect(out).not.toContain("verification failed");
-  });
+  test.each(OLD_GH_STDERR)(
+    "error mode throws for an old gh (%s), distinct from a failed signature",
+    (ghStderr) => {
+      // Option B (#208): unavailable verification is fatal in error mode, but the
+      // "cannot verify" diagnosis must never read as "signature did not verify".
+      const spy = spyOn(Bun, "spawnSync").mockImplementation((cmd: unknown, ..._rest: unknown[]) => {
+        const args = cmd as string[];
+        if (args[1] === "--version") return { exitCode: 0, stderr: new Uint8Array(), stdout: new Uint8Array(), success: true } as ReturnType<typeof Bun.spawnSync>;
+        return { exitCode: 1, stderr: new TextEncoder().encode(ghStderr), stdout: new Uint8Array(), success: false } as ReturnType<typeof Bun.spawnSync>;
+      });
+
+      const origWrite = process.stderr.write.bind(process.stderr);
+      process.stderr.write = () => true;
+
+      let caught: Error | undefined;
+      try {
+        verifyManifest(tmpFile, "error");
+      } catch (e) {
+        caught = e as Error;
+      } finally {
+        process.stderr.write = origWrite;
+        spy.mockRestore();
+      }
+
+      expect(caught).toBeDefined();
+      expect(caught!.message).toContain("cannot be verified");
+      expect(caught!.message).toContain("upgrade gh");
+      expect(caught!.message).toContain("--skip-verify");
+      expect(caught!.message).not.toContain("verification failed");
+    }
+  );
 
   test("warn mode succeeds silently when gh exits zero", () => {
     const spy = spyOn(Bun, "spawnSync").mockImplementation((..._args: unknown[]) => ({


### PR DESCRIPTION
## Summary

- `verify_signature = "error"` now hard-fails when signature verification **cannot run** (`gh` absent from PATH, or too old for the flags we pin with), instead of writing one stderr line and proceeding against an **unverified** manifest. Per the decision on #208 (option B): `error` means verification must *succeed*.
- The "cannot be verified" diagnosis stays **distinct** from a "signature did not verify" failure — an unusable tool is a tooling gap, not tampering — and names `--skip-verify` so the failure is actionable. `warn` (default) and `skip` are unchanged.
- Both unavailable branches route through a shared `reportUnavailable` helper.

**Breaking change**, scoped to the non-default `error` mode. Loud, not silent. Documented in `docs/profile-schema.md` and flagged BREAKING under `[Unreleased]` in the changelog. The realistic affected case is a slim CI image without `gh` running `error` — those users go from a stderr warning to a hard failure on upgrade, which is the correct direction for a security control. `--skip-verify` / `verify_signature = "warn"` are the documented escapes.

Closes #208.

## Test plan

- [x] `bun run typecheck` clean
- [x] `bun test` — 796 pass / 4 skip / 0 fail
- [x] New/rewritten tests assert `error` mode throws for **both** unavailable branches (gh absent, gh too old), with a message distinct from "verification failed" and naming `--skip-verify`
- [x] `warn`/`skip` graceful behavior retained (tests kept, still pass)
- [x] **Guard-checked**: neutering the throw turns exactly the three new error-mode tests red across both branches (independently reproduced by reviewer)
- [x] typescript-reviewer pass — no blocking findings; empirically mutation-tested

## Follow-up (not in scope)

`mcp-recall profiles info` wraps `fetchManifest()` in a bare `catch` (`cmd-catalog.ts:192`) that masks any manifest error as "(offline)", so `error` mode does not hard-fail there — a pre-existing gap that also swallowed the older failed-signature throw. #208's scope is install/seed/update (which propagate correctly); filing a separate issue.

https://claude.ai/code/session_01T2Fkofq92QNXDqhyMQ6uq6