### PR TITLE
chore: release v1.11.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+## [1.11.0] — 2026-08-01
+
 ### Changed
 
 - **BREAKING (non-default mode): `verify_signature = "error"` now hard-fails when signature verification cannot run.** `error` previously governed only how a *failed* signature was handled — if `gh` was absent from `PATH`, or too old for the flags we verify with, it wrote a line to stderr and proceeded against an **unverified** manifest, the opposite of what a user setting `error` to guarantee verification expects. `error` now means verification must *succeed*: a missing or unusable `gh` is fatal for `profiles install/seed/update`, with a message distinct from a signature failure (an unusable tool is not evidence of tampering) that names `--skip-verify` as the escape hatch. `warn` (the default) and `skip` are unchanged. If you run `error` in an environment without a usable `gh` (a slim container image, for instance) and intend to proceed, pass `--skip-verify` or set `verify_signature = "warn"` (#208)
@@ -358,7 +360,8 @@ Ten `recall__*` tools available in every Claude session:
 
 ---
 
-[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.10.1...HEAD
+[Unreleased]: https://github.com/sakebomb/mcp-recall/compare/v1.11.0...HEAD
+[1.11.0]: https://github.com/sakebomb/mcp-recall/compare/v1.10.1...v1.11.0
 [1.10.1]: https://github.com/sakebomb/mcp-recall/compare/v1.10.0...v1.10.1
 [1.10.0]: https://github.com/sakebomb/mcp-recall/compare/v1.9.0...v1.10.0
 [1.9.0]: https://github.com/sakebomb/mcp-recall/compare/v1.8.0...v1.9.0

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/.claude-plugin/plugin.json
+++ b/plugins/mcp-recall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.10.1",
+  "version": "1.11.0",
   "description": "Context compression and persistent retrieval for Claude Code — prevents context window exhaustion in long sessions",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.10.1",
+    version: "1.11.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.10.1",
+    version: "1.11.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary

- Cut **v1.11.0**: date the `[Unreleased]` CHANGELOG section, bump version across `package.json` and both plugin manifests, rebuild the bundle (embeds the version).
- Ships four already-merged changes sitting on `main` since v1.10.1:
  - **#208** — BREAKING (non-default mode): `verify_signature = "error"` now hard-fails when verification *cannot run*, not only when a signature fails.
  - **#234** — `profiles info` no longer masks a verification failure as "offline".
  - **#226** — `import --keep-project-key` is rejected instead of silently stranding data.
  - **#213** — the recorded project path is now always absolute.

## Test plan

- [x] `bun test` — 800 pass, 4 skip, 0 fail
- [x] `bun run typecheck` — clean
- [x] `bun run build` — bundle rebuilt; `./bin/recall --version` reports `1.11.0`
- [x] CHANGELOG compare links updated (`[Unreleased]` → v1.11.0, new `[1.11.0]` line)
- [ ] After merge: tag `v1.11.0` from `main`, `gh release create v1.11.0` → publish workflow ships to npm with provenance