### PR TITLE
feat: bound pinned data with store.max_pinned_mb (#205)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,10 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Added
+
+- **`store.max_pinned_mb` bounds pinned data (default: half of `max_size_mb`).** Pinned items are exempt from eviction, so without a separate cap an unbounded number of pins silently voids `store.max_size_mb` — observed in dogfooding when a store reached 99% pinned. `recall__pin` now enforces this cap *at pin time*: a pin that would push total pinned bytes past `max_pinned_mb` is refused with a message naming what to do (unpin, raise the cap, or `recall__forget`), and the bound holds even if the caller ignores the error, since the row is never marked pinned. Unpinning and re-pinning an already-pinned item are never budget-checked. The cap defaults to half of the effective `max_size_mb` (so lowering the total cap alone never creates a contradiction) and must not exceed it (a config that sets it higher is rejected to defaults). Existing over-cap pins are never auto-deleted; `recall__stats` reports pinned usage against the new cap (#205)
+
 ## [1.11.0] — 2026-08-01
 
 ### Changed

--- a/README.md
+++ b/README.md
@@ -354,6 +354,17 @@ key = "git_root"
 # of mostly-pinned data can exceed it. recall__stats reports when it does.
 max_size_mb = 500
 
+# Bound on pinned data in megabytes. Pinned items are exempt from eviction, so
+# without a separate cap an unbounded number of pins would silently void
+# max_size_mb. recall__pin enforces this at pin time: a pin that would push total
+# pinned bytes over the cap is refused with an actionable message, so the bound
+# holds even if the caller ignores it. Must not exceed max_size_mb (a config that
+# sets it higher is rejected). If you set max_size_mb but leave this unset, it
+# defaults to half of max_size_mb rather than the 250 shown here, so lowering the
+# total cap alone never creates a contradiction. Existing over-cap pins are never
+# auto-deleted — unpin or recall__forget to reclaim.
+max_pinned_mb = 250
+
 # Access count threshold for pin suggestions in recall__stats.
 # Items accessed at least this many times will appear as pin candidates.
 pin_recommendation_threshold = 5

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5062,6 +5062,7 @@ var RecallConfigSchema = exports_external.object({
     expire_after_session_days: exports_external.number().positive(),
     key: exports_external.enum(["git_root", "cwd"]),
     max_size_mb: exports_external.number().positive(),
+    max_pinned_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
     eviction_half_life_days: exports_external.number().positive(),
@@ -5083,11 +5084,13 @@ var RecallConfigSchema = exports_external.object({
   })
 });
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
+var DEFAULT_PINNED_FRACTION = 0.5;
 var DEFAULTS = {
   store: {
     expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
+    max_pinned_mb: 250,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
     eviction_half_life_days: 7,
@@ -5132,7 +5135,16 @@ function loadConfig() {
     const raw = readFileSync(getConfigPath(), "utf8");
     const result = PartialConfigSchema.safeParse(parse(raw));
     if (result.success) {
-      cached = deepMerge(DEFAULTS, result.data);
+      const base = deepMerge(DEFAULTS, result.data);
+      const userSetPinned = result.data.store?.max_pinned_mb !== undefined;
+      const max_pinned_mb = userSetPinned ? base.store.max_pinned_mb : base.store.max_size_mb * DEFAULT_PINNED_FRACTION;
+      const merged = { ...base, store: { ...base.store, max_pinned_mb } };
+      if (merged.store.max_pinned_mb > merged.store.max_size_mb) {
+        log.warn(`invalid config (store.max_pinned_mb ${merged.store.max_pinned_mb} exceeds ` + `store.max_size_mb ${merged.store.max_size_mb}); using defaults`);
+        cached = deepMerge(DEFAULTS, {});
+      } else {
+        cached = merged;
+      }
     } else {
       const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
       log.warn(`invalid config (${issues}); using defaults`);

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19788,11 +19788,26 @@ function recordAccess(db, id) {
     WHERE id = ?
   `).run(now, id);
 }
-function pinOutput(db, id, project_key, pinned) {
-  const result = db.prepare(`
+function pinOutput(db, id, project_key, pinned, maxPinnedMb) {
+  const item = db.prepare(`
+    SELECT original_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
+  `).get(id, project_key);
+  if (!item)
+    return { ok: false, reason: "not_found" };
+  if (pinned && item.pinned === 0 && maxPinnedMb !== undefined) {
+    const capBytes = maxPinnedMb * 1024 * 1024;
+    const { pinnedBytes } = db.prepare(`
+      SELECT COALESCE(SUM(original_size), 0) as pinnedBytes
+      FROM stored_outputs WHERE project_key = ? AND pinned = 1
+    `).get(project_key);
+    if (pinnedBytes + item.original_size > capBytes) {
+      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.original_size, capBytes };
+    }
+  }
+  db.prepare(`
     UPDATE stored_outputs SET pinned = ? WHERE id = ? AND project_key = ?
   `).run(pinned ? 1 : 0, id, project_key);
-  return result.changes > 0;
+  return { ok: true };
 }
 function retrieveSnippet(db, id, query) {
   const row = db.prepare(`SELECT rowid FROM stored_outputs WHERE id = ?`).get(id);
@@ -20997,6 +21012,7 @@ var RecallConfigSchema = exports_external.object({
     expire_after_session_days: exports_external.number().positive(),
     key: exports_external.enum(["git_root", "cwd"]),
     max_size_mb: exports_external.number().positive(),
+    max_pinned_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
     eviction_half_life_days: exports_external.number().positive(),
@@ -21018,11 +21034,13 @@ var RecallConfigSchema = exports_external.object({
   })
 });
 var PartialConfigSchema = RecallConfigSchema.deepPartial();
+var DEFAULT_PINNED_FRACTION = 0.5;
 var DEFAULTS = {
   store: {
     expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
+    max_pinned_mb: 250,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
     eviction_half_life_days: 7,
@@ -21067,7 +21085,16 @@ function loadConfig() {
     const raw = readFileSync(getConfigPath(), "utf8");
     const result = PartialConfigSchema.safeParse(parse6(raw));
     if (result.success) {
-      cached2 = deepMerge(DEFAULTS, result.data);
+      const base = deepMerge(DEFAULTS, result.data);
+      const userSetPinned = result.data.store?.max_pinned_mb !== undefined;
+      const max_pinned_mb = userSetPinned ? base.store.max_pinned_mb : base.store.max_size_mb * DEFAULT_PINNED_FRACTION;
+      const merged = { ...base, store: { ...base.store, max_pinned_mb } };
+      if (merged.store.max_pinned_mb > merged.store.max_size_mb) {
+        log.warn(`invalid config (store.max_pinned_mb ${merged.store.max_pinned_mb} exceeds ` + `store.max_size_mb ${merged.store.max_size_mb}); using defaults`);
+        cached2 = deepMerge(DEFAULTS, {});
+      } else {
+        cached2 = merged;
+      }
     } else {
       const issues = result.error.issues.map((i) => `${i.path.join(".")}: ${i.message}`).join(", ");
       log.warn(`invalid config (${issues}); using defaults`);
@@ -21195,11 +21222,14 @@ ${lines.join(`
 }
 function toolPin(db, projectKey, args) {
   const pinned = args.pinned ?? true;
-  const success = pinOutput(db, args.id, projectKey, pinned);
-  if (!success) {
+  const outcome = pinOutput(db, args.id, projectKey, pinned, loadConfig().store.max_pinned_mb);
+  if (outcome.ok) {
+    return `[recall: ${pinned ? "pinned" : "unpinned"} ${args.id}]`;
+  }
+  if (outcome.reason === "not_found") {
     return `[recall: no item found with id "${args.id}"]`;
   }
-  return `[recall: ${pinned ? "pinned" : "unpinned"} ${args.id}]`;
+  return `[recall: cannot pin ${args.id} \u2014 pinned data would reach ` + `${formatBytes(outcome.pinnedBytes + outcome.itemBytes)}, over the ` + `${formatBytes(outcome.capBytes)} store.max_pinned_mb cap. Pinned items are exempt ` + `from eviction, so this cap bounds them separately from store.max_size_mb. Unpin an ` + `item, raise store.max_pinned_mb, or recall__forget to reclaim space.]`;
 }
 function toolNote(db, projectKey, args) {
   const title = args.title ?? "(note)";
@@ -21404,12 +21434,12 @@ function toolStats(db, projectKey, args = {}) {
     `  Session days:      ${sessionDays.length}`
   ];
   if (stats.pinned_items > 0) {
-    const maxSizeMb = loadConfig().store.max_size_mb;
-    const maxBytes = maxSizeMb * 1024 * 1024;
+    const maxPinnedMb = loadConfig().store.max_pinned_mb;
+    const maxBytes = maxPinnedMb * 1024 * 1024;
     const capPct = maxBytes > 0 ? stats.pinned_bytes / maxBytes * 100 : 0;
-    lines.push(`  Pinned:            ${stats.pinned_items} item${stats.pinned_items === 1 ? "" : "s"}` + ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of cap)`);
+    lines.push(`  Pinned:            ${stats.pinned_items} item${stats.pinned_items === 1 ? "" : "s"}` + ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of max_pinned_mb)`);
     if (capPct >= PIN_BUDGET_WARN_PCT) {
-      lines.push(`  \u26A0 Pinned data is ${capPct.toFixed(0)}% of the ${maxSizeMb} MB cap and is exempt` + ` from eviction \u2014 unpin or raise store.max_size_mb to reclaim space.`);
+      lines.push(`  \u26A0 Pinned data is ${capPct.toFixed(0)}% of the ${maxPinnedMb} MB store.max_pinned_mb cap.` + ` New pins are refused once it is full \u2014 unpin or raise the cap to make room.`);
     }
   }
   const breakdown = getToolBreakdown(db, projectKey);
@@ -21520,7 +21550,7 @@ server.tool("recall__search", "Search across all stored tool outputs by content.
 }, safeTool((args) => ({
   content: [{ type: "text", text: toolSearch(db, projectKey, args) }]
 })));
-server.tool("recall__pin", "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin.", {
+server.tool("recall__pin", "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin. Pinning can fail: because pinned items are eviction-exempt they are bounded by store.max_pinned_mb, and a pin that would exceed that cap is refused (the response says so and how to make room). Unpinning always succeeds.", {
   id: exports_external.string().describe("Item ID to pin or unpin"),
   pinned: exports_external.boolean().optional().describe("true to pin (default), false to unpin")
 }, safeTool((args) => ({

--- a/src/config.ts
+++ b/src/config.ts
@@ -10,6 +10,7 @@ export const RecallConfigSchema = z.object({
     expire_after_session_days: z.number().positive(),
     key: z.enum(["git_root", "cwd"]),
     max_size_mb: z.number().positive(),
+    max_pinned_mb: z.number().positive(),
     pin_recommendation_threshold: z.number().int().positive(),
     stale_item_days: z.number().int().positive(),
     eviction_half_life_days: z.number().positive(),
@@ -33,6 +34,12 @@ export const RecallConfigSchema = z.object({
 
 const PartialConfigSchema = RecallConfigSchema.deepPartial();
 
+// When the user sets max_size_mb but not max_pinned_mb, the pinned cap defaults to
+// this fraction of the effective total cap — so lowering max_size_mb alone can never
+// manufacture a max_pinned_mb > max_size_mb contradiction. (The static DEFAULTS value
+// below covers the no-config and fallback paths, where max_size_mb is also default.)
+const DEFAULT_PINNED_FRACTION = 0.5;
+
 export type RecallConfig = z.infer<typeof RecallConfigSchema>;
 
 const DEFAULTS: RecallConfig = {
@@ -40,6 +47,7 @@ const DEFAULTS: RecallConfig = {
     expire_after_session_days: 30,
     key: "git_root",
     max_size_mb: 500,
+    max_pinned_mb: 250,
     pin_recommendation_threshold: 5,
     stale_item_days: 3,
     eviction_half_life_days: 7,
@@ -105,7 +113,29 @@ export function loadConfig(): RecallConfig {
     const raw = readFileSync(getConfigPath(), "utf8");
     const result = PartialConfigSchema.safeParse(parse(raw));
     if (result.success) {
-      cached = deepMerge(DEFAULTS, result.data);
+      const base = deepMerge(DEFAULTS, result.data);
+      // Derive the pinned cap from the effective total cap unless set explicitly,
+      // so a user who only lowers max_size_mb doesn't trip the contradiction guard.
+      const userSetPinned = result.data.store?.max_pinned_mb !== undefined;
+      const max_pinned_mb = userSetPinned
+        ? base.store.max_pinned_mb
+        : base.store.max_size_mb * DEFAULT_PINNED_FRACTION;
+      const merged = { ...base, store: { ...base.store, max_pinned_mb } };
+      // Cross-field guard: a pinned cap above the total cap is a contradiction
+      // (max_pinned_mb can never bind before max_size_mb does). Only reachable when
+      // the user set both explicitly. Reject the whole config to defaults, consistent
+      // with how a schema-invalid value is handled. This lives here rather than as a
+      // schema .refine() because RecallConfigSchema is deepPartial()'d for user
+      // parsing, where a refine would see one or both fields absent.
+      if (merged.store.max_pinned_mb > merged.store.max_size_mb) {
+        log.warn(
+          `invalid config (store.max_pinned_mb ${merged.store.max_pinned_mb} exceeds ` +
+            `store.max_size_mb ${merged.store.max_size_mb}); using defaults`
+        );
+        cached = deepMerge(DEFAULTS, {});
+      } else {
+        cached = merged;
+      }
     } else {
       const issues = result.error.issues
         .map((i) => `${i.path.join(".")}: ${i.message}`)

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -125,19 +125,51 @@ export function recordAccess(db: Database, id: string): void {
 }
 
 /**
- * Pins or unpins an item. Pinned items are exempt from expiry and eviction.
- * Returns `true` if the item was found and updated.
+ * Outcome of a {@link pinOutput} call. `over_budget` carries the byte figures so
+ * the caller can build an actionable message without re-querying.
+ */
+export type PinOutcome =
+  | { ok: true }
+  | { ok: false; reason: "not_found" }
+  | { ok: false; reason: "over_budget"; pinnedBytes: number; itemBytes: number; capBytes: number };
+
+/**
+ * Pins or unpins an item. Pinned items are exempt from expiry and eviction, so an
+ * unbounded number of pins would silently void `store.max_size_mb`. When pinning a
+ * not-yet-pinned item and `maxPinnedMb` is supplied, this enforces that cap *at the
+ * write*: if the item's `original_size` would push total pinned bytes over the cap,
+ * the row is left unpinned and `over_budget` is returned — so the bound holds even
+ * if the caller ignores the result and keeps pinning. Unpinning, and re-pinning an
+ * already-pinned item, are never budget-checked. Omitting `maxPinnedMb` disables the
+ * check (used by tests and internal callers that pin unconditionally).
  */
 export function pinOutput(
   db: Database,
   id: string,
   project_key: string,
-  pinned: boolean
-): boolean {
-  const result = db.prepare(`
+  pinned: boolean,
+  maxPinnedMb?: number
+): PinOutcome {
+  const item = db.prepare(`
+    SELECT original_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
+  `).get(id, project_key) as { original_size: number; pinned: number } | null;
+  if (!item) return { ok: false, reason: "not_found" };
+
+  if (pinned && item.pinned === 0 && maxPinnedMb !== undefined) {
+    const capBytes = maxPinnedMb * 1024 * 1024;
+    const { pinnedBytes } = db.prepare(`
+      SELECT COALESCE(SUM(original_size), 0) as pinnedBytes
+      FROM stored_outputs WHERE project_key = ? AND pinned = 1
+    `).get(project_key) as { pinnedBytes: number };
+    if (pinnedBytes + item.original_size > capBytes) {
+      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.original_size, capBytes };
+    }
+  }
+
+  db.prepare(`
     UPDATE stored_outputs SET pinned = ? WHERE id = ? AND project_key = ?
   `).run(pinned ? 1 : 0, id, project_key);
-  return result.changes > 0;
+  return { ok: true };
 }
 
 /**

--- a/src/server.ts
+++ b/src/server.ts
@@ -91,7 +91,7 @@ server.tool(
 
 server.tool(
   "recall__pin",
-  "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin.",
+  "Pin an item to protect it from expiry and eviction. Use for important results you want to keep indefinitely. Pass pinned: false to unpin. Pinning can fail: because pinned items are eviction-exempt they are bounded by store.max_pinned_mb, and a pin that would exceed that cap is refused (the response says so and how to make room). Unpinning always succeeds.",
   {
     id: z.string().describe("Item ID to pin or unpin"),
     pinned: z.boolean().optional().describe("true to pin (default), false to unpin"),

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -34,7 +34,7 @@ import { formatBytes, formatRelativeTime } from "./format";
 // Display constants
 // ---------------------------------------------------------------------------
 
-const PIN_BUDGET_WARN_PCT = 80;  // warn in recall__stats when pinned bytes reach this % of max_size_mb
+const PIN_BUDGET_WARN_PCT = 80;  // warn in recall__stats when pinned bytes reach this % of max_pinned_mb
 const SEARCH_EXCERPT_LEN  = 120; // chars shown per result in recall__search
 const NOTE_EXCERPT_LEN    = 200; // chars shown in recall__note store confirmation
 const CONTEXT_EXCERPT_LEN = 100; // chars shown per item in recall__context
@@ -185,11 +185,20 @@ export function toolPin(
   args: PinArgs
 ): string {
   const pinned = args.pinned ?? true;
-  const success = pinOutput(db, args.id, projectKey, pinned);
-  if (!success) {
+  const outcome = pinOutput(db, args.id, projectKey, pinned, loadConfig().store.max_pinned_mb);
+  if (outcome.ok) {
+    return `[recall: ${pinned ? "pinned" : "unpinned"} ${args.id}]`;
+  }
+  if (outcome.reason === "not_found") {
     return `[recall: no item found with id "${args.id}"]`;
   }
-  return `[recall: ${pinned ? "pinned" : "unpinned"} ${args.id}]`;
+  return (
+    `[recall: cannot pin ${args.id} — pinned data would reach ` +
+    `${formatBytes(outcome.pinnedBytes + outcome.itemBytes)}, over the ` +
+    `${formatBytes(outcome.capBytes)} store.max_pinned_mb cap. Pinned items are exempt ` +
+    `from eviction, so this cap bounds them separately from store.max_size_mb. Unpin an ` +
+    `item, raise store.max_pinned_mb, or recall__forget to reclaim space.]`
+  );
 }
 
 // ---------------------------------------------------------------------------
@@ -541,20 +550,21 @@ export function toolStats(
     `  Session days:      ${sessionDays.length}`,
   ];
 
-  // Pin-budget awareness: pinned items are exempt from eviction, so a store that
-  // is mostly pinned can silently defeat the max_size_mb cap. Surface it.
+  // Pin-budget awareness: pinned items are exempt from eviction and bounded
+  // separately by store.max_pinned_mb, which recall__pin enforces at pin time.
+  // Report usage against that cap (an existing store may already be over it).
   if (stats.pinned_items > 0) {
-    const maxSizeMb = loadConfig().store.max_size_mb;
-    const maxBytes = maxSizeMb * 1024 * 1024;
+    const maxPinnedMb = loadConfig().store.max_pinned_mb;
+    const maxBytes = maxPinnedMb * 1024 * 1024;
     const capPct = maxBytes > 0 ? (stats.pinned_bytes / maxBytes) * 100 : 0;
     lines.push(
       `  Pinned:            ${stats.pinned_items} item${stats.pinned_items === 1 ? "" : "s"}` +
-        ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of cap)`
+        ` (${formatBytes(stats.pinned_bytes)}, ${capPct.toFixed(0)}% of max_pinned_mb)`
     );
     if (capPct >= PIN_BUDGET_WARN_PCT) {
       lines.push(
-        `  ⚠ Pinned data is ${capPct.toFixed(0)}% of the ${maxSizeMb} MB cap and is exempt` +
-          ` from eviction — unpin or raise store.max_size_mb to reclaim space.`
+        `  ⚠ Pinned data is ${capPct.toFixed(0)}% of the ${maxPinnedMb} MB store.max_pinned_mb cap.` +
+          ` New pins are refused once it is full — unpin or raise the cap to make room.`
       );
     }
   }

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -78,6 +78,42 @@ describe("loadConfig", () => {
     expect((config.store as Record<string, unknown>).unknown_key).toBeUndefined();
   });
 
+  it("max_pinned_mb defaults to 250", () => {
+    const config = loadConfig();
+    expect(config.store.max_pinned_mb).toBe(250);
+  });
+
+  it("defaults max_pinned_mb to half of max_size_mb when only max_size_mb is set", () => {
+    // Lowering max_size_mb alone must not manufacture a contradiction with the
+    // static 250 default — the pinned cap tracks the effective total cap.
+    writeFileSync(TEST_CONFIG_PATH, "[store]\nmax_size_mb = 100\n");
+    const config = loadConfig();
+    expect(config.store.max_size_mb).toBe(100);
+    expect(config.store.max_pinned_mb).toBe(50);
+  });
+
+  it("accepts a valid max_pinned_mb below max_size_mb", () => {
+    writeFileSync(TEST_CONFIG_PATH, "[store]\nmax_pinned_mb = 128\n");
+    const config = loadConfig();
+    expect(config.store.max_pinned_mb).toBe(128);
+  });
+
+  it("accepts max_pinned_mb equal to max_size_mb", () => {
+    writeFileSync(TEST_CONFIG_PATH, "[store]\nmax_size_mb = 300\nmax_pinned_mb = 300\n");
+    const config = loadConfig();
+    expect(config.store.max_size_mb).toBe(300);
+    expect(config.store.max_pinned_mb).toBe(300);
+  });
+
+  it("rejects config where max_pinned_mb exceeds max_size_mb, using defaults", () => {
+    writeFileSync(TEST_CONFIG_PATH, "[store]\nmax_size_mb = 100\nmax_pinned_mb = 200\n");
+    const config = loadConfig();
+    // A pinned cap above the total cap is a contradiction; the whole config is
+    // rejected to defaults, consistent with any other schema-invalid value.
+    expect(config.store.max_size_mb).toBe(500);
+    expect(config.store.max_pinned_mb).toBe(250);
+  });
+
   it("debug.enabled defaults to false", () => {
     const config = loadConfig();
     expect(config.debug.enabled).toBe(false);

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -476,13 +476,66 @@ describe("db", () => {
       expect(retrieveOutput(db, stored.id)!.pinned).toBe(0);
     });
 
-    it("returns true when item exists", () => {
+    it("returns ok when item exists", () => {
       const stored = storeOutput(db, makeInput());
-      expect(pinOutput(db, stored.id, PROJECT_KEY, true)).toBe(true);
+      expect(pinOutput(db, stored.id, PROJECT_KEY, true).ok).toBe(true);
     });
 
-    it("returns false for unknown id", () => {
-      expect(pinOutput(db, "recall_00000000", PROJECT_KEY, true)).toBe(false);
+    it("returns not_found for unknown id", () => {
+      const outcome = pinOutput(db, "recall_00000000", PROJECT_KEY, true);
+      expect(outcome.ok).toBe(false);
+      expect(outcome).toMatchObject({ reason: "not_found" });
+    });
+
+    // store.max_pinned_mb (#205): pinned items are eviction-exempt, so without a
+    // separate cap an unbounded number of pins voids store.max_size_mb.
+    const CAP_MB = 1; // 1 MiB = 1_048_576 bytes
+    const HALF = 600_000; // one fits under the cap; a second would exceed it
+
+    it("refuses a pin that would exceed max_pinned_mb and leaves the item unpinned", () => {
+      const a = storeOutput(db, makeInput({ original_size: HALF }));
+      const b = storeOutput(db, makeInput({ original_size: HALF }));
+      expect(pinOutput(db, a.id, PROJECT_KEY, true, CAP_MB).ok).toBe(true);
+      const outcome = pinOutput(db, b.id, PROJECT_KEY, true, CAP_MB);
+      expect(outcome.ok).toBe(false);
+      expect(outcome).toMatchObject({ reason: "over_budget", itemBytes: HALF });
+      expect(retrieveOutput(db, b.id)!.pinned).toBe(0); // the write did not apply
+    });
+
+    it("bounds total pinned bytes even when the caller ignores the error", () => {
+      // A client that keeps pinning past the cap must not be able to grow the store.
+      for (let i = 0; i < 10; i++) {
+        const item = storeOutput(db, makeInput({ original_size: HALF }));
+        pinOutput(db, item.id, PROJECT_KEY, true, CAP_MB); // return deliberately ignored
+      }
+      const { pinnedBytes } = db.prepare(
+        "SELECT COALESCE(SUM(original_size),0) as pinnedBytes FROM stored_outputs WHERE project_key = ? AND pinned = 1"
+      ).get(PROJECT_KEY) as { pinnedBytes: number };
+      expect(pinnedBytes).toBeLessThanOrEqual(CAP_MB * 1024 * 1024);
+      expect(pinnedBytes).toBe(HALF); // exactly one pin landed
+    });
+
+    it("re-pinning an already-pinned item is a no-op success, not over_budget", () => {
+      const a = storeOutput(db, makeInput({ original_size: HALF }));
+      expect(pinOutput(db, a.id, PROJECT_KEY, true, CAP_MB).ok).toBe(true);
+      // Already counted toward the budget; pinning it again must not be rejected.
+      expect(pinOutput(db, a.id, PROJECT_KEY, true, CAP_MB).ok).toBe(true);
+      expect(retrieveOutput(db, a.id)!.pinned).toBe(1);
+    });
+
+    it("unpinning is never budget-checked", () => {
+      const a = storeOutput(db, makeInput({ original_size: HALF }));
+      pinOutput(db, a.id, PROJECT_KEY, true, CAP_MB);
+      expect(pinOutput(db, a.id, PROJECT_KEY, false, CAP_MB).ok).toBe(true);
+      expect(retrieveOutput(db, a.id)!.pinned).toBe(0);
+    });
+
+    it("omitting the cap disables enforcement (internal/test callers)", () => {
+      const a = storeOutput(db, makeInput({ original_size: HALF }));
+      const b = storeOutput(db, makeInput({ original_size: HALF }));
+      expect(pinOutput(db, a.id, PROJECT_KEY, true).ok).toBe(true);
+      expect(pinOutput(db, b.id, PROJECT_KEY, true).ok).toBe(true); // no cap → both pin
+      expect(retrieveOutput(db, b.id)!.pinned).toBe(1);
     });
 
     it("pruneExpired skips pinned items", () => {

--- a/tests/denylist.test.ts
+++ b/tests/denylist.test.ts
@@ -7,6 +7,7 @@ const baseConfig: RecallConfig = {
     expire_after_session_days: 7,
     key: "git_root",
     max_size_mb: 500,
+    max_pinned_mb: 250,
     pin_recommendation_threshold: 3,
     stale_item_days: 3,
     eviction_half_life_days: 7,


### PR DESCRIPTION
Closes #205.

## Summary

- Add **`store.max_pinned_mb`** — a second store cap that bounds pinned data independently, since pinned items are eviction-exempt and otherwise silently void `store.max_size_mb` (observed in dogfooding at 99% pinned).
- Enforced by `recall__pin` **at the write**: a pin that would push total pinned bytes past the cap is refused and the row is never marked pinned, so the bound holds even if the caller ignores the error (the heavy pinner in the observed case was an external integration that would).
- `recall__pin` becomes **fallible** — documented in the tool description and README; the error names what to do (unpin, raise the cap, or `recall__forget`). Unpinning and re-pinning an already-pinned item are never budget-checked.
- Default is **half the effective `max_size_mb`** (per the issue's implementation note), so lowering the total cap alone can't manufacture a contradiction; a config that sets `max_pinned_mb` **above** `max_size_mb` is rejected to defaults.
- `recall__stats` now reports pinned usage against the new cap (rebased from #201's `max_size_mb` warning). **No retroactive deletion** — existing over-cap pins remain; `stats` surfaces the over-cap state.

Decision (Option A) was recorded on the issue; this implements it.

## Acceptance criteria

- [x] With pinned data exceeding the bound, on-disk size stays bounded — even when the caller ignores the error (`tests/db.test.ts`: "bounds total pinned bytes even when the caller ignores the error").
- [x] The pin contract is documented in the README and the `recall__pin` tool description.
- [x] Regression test reproduces the shape (pin until the cap is exceeded, assert the bound holds), **guard-verified**.
- [x] `recall__stats` reporting stays consistent (rebased to `max_pinned_mb`).

## Test plan

- [x] `bun test` — 810 pass, 4 skip, 0 fail (+10 new)
- [x] `bun run typecheck` — clean
- [x] `bun run build` — bundle rebuilt
- [x] **Mutation 1**: neuter the budget check in `pinOutput` → the two bound tests go red; no-op/unpin/omit-cap tests stay green.
- [x] **Mutation 2**: neuter the contradiction guard in `loadConfig` → the config reject test goes red; fraction-default/valid-below/equal tests stay green.