### PR TITLE
fix: reject non-finite eviction_half_life_days (#228)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -10,6 +10,10 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 - **`store.max_pinned_mb` bounds pinned data (default: half of `max_size_mb`).** Pinned items are exempt from eviction, so without a separate cap an unbounded number of pins silently voids `store.max_size_mb` — observed in dogfooding when a store reached 99% pinned. `recall__pin` now enforces this cap *at pin time*: a pin that would push total pinned bytes past `max_pinned_mb` is refused with a message naming what to do (unpin, raise the cap, or `recall__forget`), and the bound holds even if the caller ignores the error, since the row is never marked pinned. Unpinning and re-pinning an already-pinned item are never budget-checked. The cap defaults to half of the effective `max_size_mb` (so lowering the total cap alone never creates a contradiction) and must not exceed it (a config that sets it higher is rejected to defaults). Existing over-cap pins are never auto-deleted; `recall__stats` reports pinned usage against the new cap (#205)
 
+### Fixed
+
+- **`eviction_half_life_days = inf` no longer silently disables decay eviction.** `inf` is legal TOML and passed the bare `z.number().positive()` check (since `Infinity > 0`), so the loader accepted it; `Math.max(1, Infinity)` then made every recency factor `1`, quietly degrading eviction from recency-weighted to plain LFU with no error. The config schema now rejects non-finite values (`.finite()`), so such a config falls back to the default `7`, and `evictIfNeeded` guards its half-life with `Number.isFinite` as defense in depth against a direct caller passing `Infinity` or `NaN` (#228)
+
 ## [1.11.0] — 2026-08-01
 
 ### Changed

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5065,7 +5065,7 @@ var RecallConfigSchema = exports_external.object({
     max_pinned_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
-    eviction_half_life_days: exports_external.number().positive(),
+    eviction_half_life_days: exports_external.number().positive().finite(),
     gc_reminder_mb: exports_external.number().nonnegative()
   }),
   retrieve: exports_external.object({
@@ -5412,7 +5412,8 @@ function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EV
   `).all(project_key);
   if (candidates.length === 0)
     return 0;
-  const halfLifeSecs = Math.max(1, half_life_days * SECONDS_PER_DAY);
+  const safeHalfLifeDays = Number.isFinite(half_life_days) && half_life_days > 0 ? half_life_days : DEFAULT_EVICTION_HALF_LIFE_DAYS;
+  const halfLifeSecs = Math.max(1, safeHalfLifeDays * SECONDS_PER_DAY);
   const scoreOf = (c) => {
     const lastActive = c.last_accessed ?? c.created_at;
     const ageSecs = Math.max(0, now_secs - lastActive);

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -21015,7 +21015,7 @@ var RecallConfigSchema = exports_external.object({
     max_pinned_mb: exports_external.number().positive(),
     pin_recommendation_threshold: exports_external.number().int().positive(),
     stale_item_days: exports_external.number().int().positive(),
-    eviction_half_life_days: exports_external.number().positive(),
+    eviction_half_life_days: exports_external.number().positive().finite(),
     gc_reminder_mb: exports_external.number().nonnegative()
   }),
   retrieve: exports_external.object({

--- a/src/config.ts
+++ b/src/config.ts
@@ -13,7 +13,9 @@ export const RecallConfigSchema = z.object({
     max_pinned_mb: z.number().positive(),
     pin_recommendation_threshold: z.number().int().positive(),
     stale_item_days: z.number().int().positive(),
-    eviction_half_life_days: z.number().positive(),
+    // .finite() rejects `inf` (legal TOML that passes bare .positive() since Infinity > 0);
+    // a non-finite half-life would collapse decay eviction to plain LFU. See #228.
+    eviction_half_life_days: z.number().positive().finite(),
     gc_reminder_mb: z.number().nonnegative(),
   }),
   retrieve: z.object({

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -254,16 +254,17 @@ export function evictIfNeeded(
 
   if (candidates.length === 0) return 0; // all remaining items are pinned
 
-  // Floors zero, negative and -Infinity at 1 second. It does NOT cover the two
-  // non-finite cases — Math.max(1, NaN) is NaN, and Infinity passes straight through:
-  //   NaN      -> every score NaN -> comparator NaN -> sort treats as 0 -> eviction
-  //               proceeds in insertion order, unranked. Needs a direct caller; Zod
-  //               rejects NaN.
-  //   Infinity -> every recency factor 1, so decay is off and eviction is plain LFU.
-  //               REACHABLE FROM USER CONFIG: `eviction_half_life_days = inf` is legal
-  //               TOML and z.number().positive() accepts Infinity. See #228.
-  // A Number.isFinite check would close both.
-  const halfLifeSecs = Math.max(1, half_life_days * SECONDS_PER_DAY);
+  // Fall back to the finite default for any non-finite or non-positive half-life before
+  // deriving seconds. This closes two silent-degradation cases (#228): Infinity — reachable
+  // from `eviction_half_life_days = inf`, legal TOML that passes z.number().positive() —
+  // makes every recency factor 1, degrading decay to plain LFU; NaN (a direct caller only,
+  // Zod rejects it) makes every score NaN, so the comparator falls through to insertion
+  // order, unranked. The trailing Math.max(1, …) still floors sub-second finite values.
+  const safeHalfLifeDays =
+    Number.isFinite(half_life_days) && half_life_days > 0
+      ? half_life_days
+      : DEFAULT_EVICTION_HALF_LIFE_DAYS;
+  const halfLifeSecs = Math.max(1, safeHalfLifeDays * SECONDS_PER_DAY);
   const scoreOf = (c: (typeof candidates)[number]): number => {
     const lastActive = c.last_accessed ?? c.created_at;
     const ageSecs = Math.max(0, now_secs - lastActive);

--- a/tests/config.test.ts
+++ b/tests/config.test.ts
@@ -68,6 +68,15 @@ describe("loadConfig", () => {
     expect(config.store.expire_after_session_days).toBe(30);
   });
 
+  // #228: `inf` is legal TOML and passes z.number().positive() (Infinity > 0), so it would
+  // silently disable decay eviction. The schema must reject non-finite values so the loader
+  // falls back to the finite default rather than degrading eviction to plain LFU.
+  it("rejects non-finite eviction_half_life_days and falls back to the default", () => {
+    writeFileSync(TEST_CONFIG_PATH, "[store]\neviction_half_life_days = inf\n");
+    const config = loadConfig();
+    expect(config.store.eviction_half_life_days).toBe(7);
+  });
+
   it("strips unknown keys from TOML", () => {
     writeFileSync(
       TEST_CONFIG_PATH,

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -765,6 +765,72 @@ describe("db", () => {
       }).not.toThrow();
       expect(evicted).toBeGreaterThan(0);
     });
+
+    // #228: Infinity reaches this function from user config (`eviction_half_life_days = inf`
+    // is legal TOML and passes z.number().positive()). Math.max(1, Infinity) is Infinity, so
+    // every recency factor becomes 1 and eviction silently degrades to pure LFU. The guard
+    // must fall back to the finite default so ranking stays recency-aware.
+    it("stays recency-ranked when half_life_days is Infinity (does not degrade to LFU)", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const fresh = storeOutput(db, makeInput({ original_size: 300, summary: "fresh" }));
+      const old = storeOutput(db, makeInput({ original_size: 300, summary: "old heavy" }));
+      // Under LFU (the Infinity bug), 'old' (2 accesses) outscores 'fresh' (1) and 'fresh'
+      // is wrongly evicted. Under the finite default, 'old' is 60 days stale → evicted.
+      db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ? WHERE id = ?").run(now, fresh.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 2, last_accessed = ? WHERE id = ?").run(now - 60 * day, old.id);
+
+      const evicted = evictIfNeeded(db, PROJECT_KEY, 0.0005, Infinity, now);
+
+      expect(evicted).toBeGreaterThan(0);
+      expect(retrieveOutput(db, fresh.id)).not.toBeNull();
+      expect(retrieveOutput(db, old.id)).toBeNull();
+    });
+
+    // #228: NaN cannot come from config (Zod rejects it) but a direct caller can pass it.
+    // Math.max(1, NaN) is NaN → every score NaN → the score comparator is NaN (falsy) → sort
+    // falls through to the created_at tiebreak, evicting by insertion age, unranked. The guard
+    // must fall back to the finite default so recency, not creation order, decides.
+    it("stays recency-ranked when half_life_days is NaN", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const fresh = storeOutput(db, makeInput({ original_size: 300, summary: "fresh" }));
+      const old = storeOutput(db, makeInput({ original_size: 300, summary: "old" }));
+      // created_at is set so the NaN-path tiebreak would evict 'fresh' (older creation) —
+      // the opposite of the recency-correct outcome, making the bug observable.
+      db.prepare("UPDATE stored_outputs SET access_count = 1, last_accessed = ?, created_at = ? WHERE id = ?").run(now, now - 1000, fresh.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 2, last_accessed = ?, created_at = ? WHERE id = ?").run(now - 60 * day, now - 10, old.id);
+
+      let evicted = 0;
+      expect(() => {
+        evicted = evictIfNeeded(db, PROJECT_KEY, 0.0005, NaN, now);
+      }).not.toThrow();
+      expect(evicted).toBeGreaterThan(0);
+      expect(retrieveOutput(db, fresh.id)).not.toBeNull();
+      expect(retrieveOutput(db, old.id)).toBeNull();
+    });
+
+    // #228 lower bound: the "evicts an item aged one half-life" test above only bounds decay
+    // from ABOVE (it reduces to recency < 1, so any decreasing decay passes). This bounds it
+    // from BELOW: an item accessed 4× but one half-life stale must still outrank a fresh,
+    // never-accessed item — which holds only if recency at one half-life exceeds 0.25
+    // (it is 0.5). Reddens if a future change makes decay too aggressive (e.g. base 0.1).
+    it("does not over-decay: a much-accessed item one half-life old outranks a fresh unaccessed one", () => {
+      const now = 1_000_000_000;
+      const day = 86400;
+      const halfLife = 4;
+      const freshUnused = storeOutput(db, makeInput({ original_size: 300, summary: "fresh unused" }));
+      const agedBusy = storeOutput(db, makeInput({ original_size: 300, summary: "aged busy" }));
+      // freshUnused: score (0+1) * 1     = 1
+      // agedBusy:    score (3+1) * 0.5   = 2   → freshUnused evicted, agedBusy survives.
+      db.prepare("UPDATE stored_outputs SET access_count = 0, last_accessed = ? WHERE id = ?").run(now, freshUnused.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 3, last_accessed = ? WHERE id = ?").run(now - halfLife * day, agedBusy.id);
+
+      evictIfNeeded(db, PROJECT_KEY, 0.0005, halfLife, now);
+
+      expect(retrieveOutput(db, freshUnused.id)).toBeNull();
+      expect(retrieveOutput(db, agedBusy.id)).not.toBeNull();
+    });
   });
 
   // -------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

- `eviction_half_life_days = inf` is legal TOML and passed the bare `z.number().positive()` check (`Infinity > 0`), so the loader accepted it. `Math.max(1, Infinity)` then made every recency factor `1`, silently degrading eviction from recency-weighted decay to **plain LFU** — no error, no signal. Fixes #228.
- Two-layer fix: schema now rejects non-finite values with `.finite()` (fails loudly at load → falls back to default `7`); `evictIfNeeded` guards its half-life with `Number.isFinite` as defense in depth against a direct caller passing `Infinity` or `NaN` (Zod can't reach `NaN`, but callers can).
- No new config key, so the #227 doc-coverage guard is untriggered; no arbitrary schema lower bound (the existing `Math.max(1, …)` already floors sub-second finite values).

## Test plan

- [x] `loadConfig` with `eviction_half_life_days = inf` falls back to the default `7` (through the real loader, not the schema in isolation)
- [x] `evictIfNeeded` called with `Infinity` stays recency-ranked (does not degrade to LFU)
- [x] `evictIfNeeded` called with `NaN` stays recency-ranked (does not fall through to insertion order)
- [x] New lower-bound decay guard reddens under an over-aggressive base (mutation-verified: base `0.5`→`0.1` fails only the new test, existing above-bound test stays green)
- [x] All three bug tests confirmed RED before the fix, GREEN after
- [x] Full suite: 814 pass / 4 skip / 0 fail; `tsc --noEmit` clean