### PR TITLE
chore: release v1.12.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+## [1.12.0] — 2026-08-02
+
 ### Added
 
 - **`recall__forget` and `recall__list_stored` accept a `project_key` override to reach rows stranded under a foreign key.** The removed `import --keep-project-key` flag (#226) could leave rows stamped with a foreign project key; every `forget`/`list_stored` branch is scoped to the current key, so those rows were only reachable via raw `sqlite3`. Both tools now take an optional explicit `project_key` that retargets the operation to that one key, and a default `recall__list_stored` appends a footer naming any foreign keys present (with row counts) so they can be discovered. The override requires a non-empty explicit key — there is no all-projects wildcard — must be paired with a selector (`all`+`confirmed`, or `id`/`tool`/`session_id`/`older_than_days`) rather than silently no-opping, and `all: true` still requires `confirmed: true` under it, so scope can never be widened by accident. A foreign-key operation that matches nothing names the keys that do exist, so a mistyped key isn't mistaken for "nothing there". Default current-project deletes and listings are unchanged; the only default-path change is the new discovery footer, shown solely when foreign-keyed rows are present (#237)

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/.claude-plugin/plugin.json
+++ b/plugins/mcp-recall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.11.0",
+  "version": "1.12.0",
   "description": "Context compression and persistent retrieval for Claude Code — prevents context window exhaustion in long sessions",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.11.0",
+    version: "1.12.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.11.0",
+    version: "1.12.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary

- Release v1.12.0 — bumps `package.json` and both plugin manifests 1.11.0 → 1.12.0, stamps CHANGELOG `[Unreleased]` → `[1.12.0]` (2026-08-02), rebuilds the bundle.
- Ships three merged-but-unreleased changes:
  - **#237** — `recall__forget`/`recall__list_stored` `project_key` override for rows stranded under a foreign key (PR #241)
  - **#205** — `store.max_pinned_mb` bounds pinned data (PR #239)
  - **#228** — reject non-finite `eviction_half_life_days` that silently disabled decay (PR #240)

Minor bump (semver): #237 and #205 are `Added`.

## Test plan

- [x] `bun test` — 833 pass / 4 skip / 0 fail
- [x] version-agreement test (all three manifests) green
- [x] `bun run typecheck` clean
- [x] `bun run build` — bundle rebuilt (embeds package.json version)

Release PR: no source logic changes beyond version bump + CHANGELOG date + rebuilt bundle.

https://claude.ai/code/session_01T2Fkofq92QNXDqhyMQ6uq6