### PR TITLE
chore: release v1.13.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+## [1.13.0] — 2026-08-10
+
 ### Added
 
 - **Command-aware Bash compression for compilers, typecheckers, and linters.** `cargo build`/`check`/`clippy`, `go build`/`vet`, `tsc`, `eslint`, `ruff`, and `npm`/`pnpm`/`yarn`/`bun run typecheck`/`lint`/`build` now route to a diagnostics handler that collapses verbose build output to a headline error/warning count plus the individual diagnostics (errors first, capped, with `file:line` locations) — measured at ~94% byte reduction on a large `tsc` run — while the full output stays retrievable via `recall__*`. Pass/fail is driven by the command's exit code when available, so it never reports success on a non-zero exit *and* never fabricates a failure on a clean one (an incidental `host:port: message` line on a passing `*run build` won't read as an error); it falls back to the raw shell handler whenever it cannot recognise any diagnostics, so an unparsed failure is shown head/tail rather than hidden.

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/.claude-plugin/plugin.json
+++ b/plugins/mcp-recall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.12.0",
+  "version": "1.13.0",
   "description": "Context compression and persistent retrieval for Claude Code — prevents context window exhaustion in long sessions",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.12.0",
+    version: "1.13.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.12.0",
+    version: "1.13.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary

- Release v1.13.0 — version bump across `package.json` + both plugin manifests, `[1.13.0]` CHANGELOG section dated 2026-08-10, rebuilt dist bundle.
- Ships four independently-reviewed, integration-verified features merged this cycle:
  - **#243** command-aware compression for compilers/typecheckers/linters (+ the latent `extractStderr` fix)
  - **#244** command-aware compression for search + VCS-listing commands (+ `cd`/git-global-option routing normalisation)
  - **#245** `recall__stats` excludes `recall__note` memory from the interception savings figure
  - **#246** `store.retention` (default `balanced`) — summary-only for reproducible output

## Test plan

- [x] `bun test` — 882 pass / 4 skip / 0 fail
- [x] `bun run typecheck` clean
- [x] All 3 version files + dist bundle agree on 1.13.0
- [x] #245↔#246 integration verified

Release PR = version bump + CHANGELOG date + rebuilt bundle; no new source logic.

https://claude.ai/code/session_01NeK9d8X4DU7t7xuLaMyguc