### PR TITLE
feat: effective-size accounting for eviction and pin budget (#247)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Changed
+
+- `store.max_size_mb` eviction and the `store.max_pinned_mb` pin budget now count each
+  item's **effective** stored size — a summary-only row (written under `store.retention`)
+  costs its summary size, not its original size. Lowering `store.retention` now genuinely
+  raises the number of items the store holds before eviction fires, not just bytes-on-disk
+  (#247). Savings figures in `recall__stats` still report original size (the context saved).
+
 ## [1.13.0] — 2026-08-10
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -407,8 +407,10 @@ gc_reminder_mb = 2048
 # Notes stored via recall__note always keep their body, regardless of this.
 # Only affects future writes; existing bodies are untouched. When a body was
 # not retained, recall__retrieve returns the summary and says to re-run.
-# Note: max_size_mb / eviction count each item's ORIGINAL size, so lowering
-# retention reduces bytes-on-disk but not the item budget before eviction fires.
+# max_size_mb / eviction and the max_pinned_mb pin budget count each item's
+# EFFECTIVE size (a summary-only row costs its summary size, not the original),
+# so lowering retention both reduces bytes-on-disk and raises the number of
+# items the store holds before eviction fires.
 retention = "balanced"
 
 [retrieve]

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5316,6 +5316,7 @@ function chunkText(text) {
 }
 // src/db/queries.ts
 import { randomBytes, createHash as createHash2 } from "crypto";
+var EFFECTIVE_SIZE_EXPR = "CASE WHEN full_retained = 1 THEN original_size ELSE summary_size END";
 function generateId() {
   return `recall_${randomBytes(8).toString("hex")}`;
 }
@@ -5408,14 +5409,14 @@ var SECONDS_PER_DAY = 86400;
 function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EVICTION_HALF_LIFE_DAYS, now_secs = Math.floor(Date.now() / 1000)) {
   const max_bytes = max_size_mb * 1024 * 1024;
   const { total } = db.prepare(`
-    SELECT COALESCE(SUM(original_size), 0) as total
+    SELECT COALESCE(SUM(${EFFECTIVE_SIZE_EXPR}), 0) as total
     FROM stored_outputs WHERE project_key = ?
   `).get(project_key);
   if (total <= max_bytes)
     return 0;
   const bytesToShed = total - max_bytes;
   const candidates = db.prepare(`
-    SELECT id, original_size, access_count, last_accessed, created_at
+    SELECT id, ${EFFECTIVE_SIZE_EXPR} AS effective_size, access_count, last_accessed, created_at
     FROM stored_outputs
     WHERE project_key = ? AND pinned = 0
   `).all(project_key);
@@ -5429,14 +5430,14 @@ function evictIfNeeded(db, project_key, max_size_mb, half_life_days = DEFAULT_EV
     const recency = Math.pow(0.5, ageSecs / halfLifeSecs);
     return (c.access_count + 1) * recency;
   };
-  const ranked = candidates.map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at })).sort((a, b) => a.score - b.score || a.created_at - b.created_at || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
+  const ranked = candidates.map((c) => ({ id: c.id, effective_size: c.effective_size, score: scoreOf(c), created_at: c.created_at })).sort((a, b) => a.score - b.score || a.created_at - b.created_at || (a.id < b.id ? -1 : a.id > b.id ? 1 : 0));
   const toEvict = [];
   let shed = 0;
   for (const row of ranked) {
     if (shed >= bytesToShed)
       break;
     toEvict.push(row.id);
-    shed += row.original_size;
+    shed += row.effective_size;
   }
   const placeholders = toEvict.map(() => "?").join(",");
   db.prepare(`DELETE FROM stored_outputs WHERE id IN (${placeholders})`).run(...toEvict);

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -10286,7 +10286,7 @@ function importItems(dbPath, items, opts) {
          original_size, summary_size, created_at, pinned, access_count,
          last_accessed, input_hash, full_retained)
       VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(item.id, projectKey, item.session_id, item.tool_name, item.summary, item.full_content, item.original_size, item.summary_size, item.created_at, item.pinned, item.access_count, item.last_accessed, item.input_hash, item.full_retained);
+    `).run(item.id, projectKey, item.session_id, item.tool_name, item.summary, item.full_retained ? item.full_content : "", item.original_size, item.summary_size, item.created_at, item.pinned, item.access_count, item.last_accessed, item.input_hash, item.full_retained);
     if (item.full_retained) {
       const chunks = chunkText(item.full_content);
       for (let i = 0;i < chunks.length; i++) {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19721,6 +19721,7 @@ var log = {
 };
 
 // src/db/queries.ts
+var EFFECTIVE_SIZE_EXPR = "CASE WHEN full_retained = 1 THEN original_size ELSE summary_size END";
 function generateId() {
   return `recall_${randomBytes(8).toString("hex")}`;
 }
@@ -19797,18 +19798,18 @@ function recordAccess(db, id) {
 }
 function pinOutput(db, id, project_key, pinned, maxPinnedMb) {
   const item = db.prepare(`
-    SELECT original_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
+    SELECT ${EFFECTIVE_SIZE_EXPR} AS effective_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
   `).get(id, project_key);
   if (!item)
     return { ok: false, reason: "not_found" };
   if (pinned && item.pinned === 0 && maxPinnedMb !== undefined) {
     const capBytes = maxPinnedMb * 1024 * 1024;
     const { pinnedBytes } = db.prepare(`
-      SELECT COALESCE(SUM(original_size), 0) as pinnedBytes
+      SELECT COALESCE(SUM(${EFFECTIVE_SIZE_EXPR}), 0) as pinnedBytes
       FROM stored_outputs WHERE project_key = ? AND pinned = 1
     `).get(project_key);
-    if (pinnedBytes + item.original_size > capBytes) {
-      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.original_size, capBytes };
+    if (pinnedBytes + item.effective_size > capBytes) {
+      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.effective_size, capBytes };
     }
   }
   db.prepare(`
@@ -19928,7 +19929,7 @@ function getStats(db, project_key) {
       COALESCE(SUM(CASE WHEN tool_name != 'recall__note' THEN original_size ELSE 0 END), 0) as total_original_bytes,
       COALESCE(SUM(CASE WHEN tool_name != 'recall__note' THEN summary_size ELSE 0 END), 0) as total_summary_bytes,
       COALESCE(SUM(pinned), 0) as pinned_items,
-      COALESCE(SUM(CASE WHEN pinned = 1 THEN original_size ELSE 0 END), 0) as pinned_bytes,
+      COALESCE(SUM(CASE WHEN pinned = 1 THEN ${EFFECTIVE_SIZE_EXPR} ELSE 0 END), 0) as pinned_bytes,
       COALESCE(SUM(CASE WHEN tool_name = 'recall__note' THEN 1 ELSE 0 END), 0) as note_items,
       COALESCE(SUM(CASE WHEN tool_name = 'recall__note' THEN original_size ELSE 0 END), 0) as note_bytes
     FROM stored_outputs

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -10,7 +10,7 @@ import type {
   SessionSummaryOptions,
   SessionSummaryData,
 } from "./types";
-import { getSessionDays } from "./queries";
+import { getSessionDays, EFFECTIVE_SIZE_EXPR } from "./queries";
 
 /**
  * Returns aggregate storage stats for a project. The savings figures
@@ -27,7 +27,7 @@ export function getStats(db: Database, project_key: string): Stats {
       COALESCE(SUM(CASE WHEN tool_name != 'recall__note' THEN original_size ELSE 0 END), 0) as total_original_bytes,
       COALESCE(SUM(CASE WHEN tool_name != 'recall__note' THEN summary_size ELSE 0 END), 0) as total_summary_bytes,
       COALESCE(SUM(pinned), 0) as pinned_items,
-      COALESCE(SUM(CASE WHEN pinned = 1 THEN original_size ELSE 0 END), 0) as pinned_bytes,
+      COALESCE(SUM(CASE WHEN pinned = 1 THEN ${EFFECTIVE_SIZE_EXPR} ELSE 0 END), 0) as pinned_bytes,
       COALESCE(SUM(CASE WHEN tool_name = 'recall__note' THEN 1 ELSE 0 END), 0) as note_items,
       COALESCE(SUM(CASE WHEN tool_name = 'recall__note' THEN original_size ELSE 0 END), 0) as note_bytes
     FROM stored_outputs

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -4,6 +4,18 @@ import { log } from "../log";
 import type { StoredOutput, StoreInput, SearchOptions, ListOptions, ForgetOptions } from "./types";
 import { chunkText, sanitizeFtsQuery } from "./chunking";
 
+/**
+ * SQL expression for a row's *effective* stored size — the bytes it actually
+ * occupies. A summary-only row (`full_retained = 0`, written under
+ * `store.retention`) drops its body and chunks, so it costs ~`summary_size`,
+ * not `original_size`. Used by the byte-cap accounting (store.max_size_mb
+ * eviction, store.max_pinned_mb pin budget) so lowering retention genuinely
+ * expands the item budget (#247). NOT used for the *savings* figures in
+ * getStats — those keep reporting `original_size` (the context actually saved).
+ */
+export const EFFECTIVE_SIZE_EXPR =
+  "CASE WHEN full_retained = 1 THEN original_size ELSE summary_size END";
+
 function generateId(): string {
   return `recall_${randomBytes(8).toString("hex")}`;
 }
@@ -144,8 +156,9 @@ export type PinOutcome =
  * Pins or unpins an item. Pinned items are exempt from expiry and eviction, so an
  * unbounded number of pins would silently void `store.max_size_mb`. When pinning a
  * not-yet-pinned item and `maxPinnedMb` is supplied, this enforces that cap *at the
- * write*: if the item's `original_size` would push total pinned bytes over the cap,
- * the row is left unpinned and `over_budget` is returned — so the bound holds even
+ * write*: if the item's effective size (`summary_size` for summary-only rows,
+ * else `original_size`) would push total pinned bytes over the cap, the row is
+ * left unpinned and `over_budget` is returned — so the bound holds even
  * if the caller ignores the result and keeps pinning. Unpinning, and re-pinning an
  * already-pinned item, are never budget-checked. Omitting `maxPinnedMb` disables the
  * check (used by tests and internal callers that pin unconditionally).
@@ -158,18 +171,18 @@ export function pinOutput(
   maxPinnedMb?: number
 ): PinOutcome {
   const item = db.prepare(`
-    SELECT original_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
-  `).get(id, project_key) as { original_size: number; pinned: number } | null;
+    SELECT ${EFFECTIVE_SIZE_EXPR} AS effective_size, pinned FROM stored_outputs WHERE id = ? AND project_key = ?
+  `).get(id, project_key) as { effective_size: number; pinned: number } | null;
   if (!item) return { ok: false, reason: "not_found" };
 
   if (pinned && item.pinned === 0 && maxPinnedMb !== undefined) {
     const capBytes = maxPinnedMb * 1024 * 1024;
     const { pinnedBytes } = db.prepare(`
-      SELECT COALESCE(SUM(original_size), 0) as pinnedBytes
+      SELECT COALESCE(SUM(${EFFECTIVE_SIZE_EXPR}), 0) as pinnedBytes
       FROM stored_outputs WHERE project_key = ? AND pinned = 1
     `).get(project_key) as { pinnedBytes: number };
-    if (pinnedBytes + item.original_size > capBytes) {
-      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.original_size, capBytes };
+    if (pinnedBytes + item.effective_size > capBytes) {
+      return { ok: false, reason: "over_budget", pinnedBytes, itemBytes: item.effective_size, capBytes };
     }
   }
 
@@ -219,7 +232,10 @@ const SECONDS_PER_DAY = 86400;
 
 /**
  * Enforces the project store size cap by evicting the lowest-value non-pinned
- * items until total `original_size` is within `max_size_mb`.
+ * items until total effective size is within `max_size_mb`. Effective size is
+ * `original_size` for full-body rows and `summary_size` for summary-only rows
+ * (`full_retained = 0`, written under `store.retention`), so lowering retention
+ * genuinely raises the number of items the store holds before eviction (#247).
  *
  * Value is a recency-weighted frequency score: `(access_count + 1)` decayed by
  * an exponential half-life on the time since last access (falling back to
@@ -239,7 +255,7 @@ export function evictIfNeeded(
   const max_bytes = max_size_mb * 1024 * 1024;
 
   const { total } = db.prepare(`
-    SELECT COALESCE(SUM(original_size), 0) as total
+    SELECT COALESCE(SUM(${EFFECTIVE_SIZE_EXPR}), 0) as total
     FROM stored_outputs WHERE project_key = ?
   `).get(project_key) as { total: number };
 
@@ -248,12 +264,12 @@ export function evictIfNeeded(
   const bytesToShed = total - max_bytes;
 
   const candidates = db.prepare(`
-    SELECT id, original_size, access_count, last_accessed, created_at
+    SELECT id, ${EFFECTIVE_SIZE_EXPR} AS effective_size, access_count, last_accessed, created_at
     FROM stored_outputs
     WHERE project_key = ? AND pinned = 0
   `).all(project_key) as {
     id: string;
-    original_size: number;
+    effective_size: number;
     access_count: number;
     last_accessed: number | null;
     created_at: number;
@@ -281,7 +297,7 @@ export function evictIfNeeded(
 
   // Evict lowest value first; tiebreak oldest creation, then id for full determinism.
   const ranked = candidates
-    .map((c) => ({ id: c.id, original_size: c.original_size, score: scoreOf(c), created_at: c.created_at }))
+    .map((c) => ({ id: c.id, effective_size: c.effective_size, score: scoreOf(c), created_at: c.created_at }))
     .sort(
       (a, b) =>
         a.score - b.score ||
@@ -294,7 +310,7 @@ export function evictIfNeeded(
   for (const row of ranked) {
     if (shed >= bytesToShed) break;
     toEvict.push(row.id);
-    shed += row.original_size;
+    shed += row.effective_size;
   }
 
   // Single DELETE for all selected IDs.

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -76,7 +76,7 @@ export interface Stats {
   compression_ratio: number;
   /** Number of pinned items (exempt from eviction). Store-wide, includes notes. */
   pinned_items: number;
-  /** Sum of `original_size` across pinned items — bytes eviction cannot reclaim. Store-wide. */
+  /** Sum of effective size (summary_size for summary-only rows, else original_size) across pinned items — the bytes eviction cannot reclaim, matching the `store.max_pinned_mb` budget. Store-wide. */
   pinned_bytes: number;
   /** `recall__note` items — stored memory, not interception. Reported separately so it never dilutes the savings figure. */
   note_items: number;

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -141,7 +141,11 @@ function importItems(
       item.session_id,
       item.tool_name,
       item.summary,
-      item.full_content,
+      // Enforce storeOutput's invariant: a summary-only row (full_retained=0)
+      // carries no body. A legitimate export already has full_content="" here,
+      // but a malformed/tampered dump may not — dropping it keeps effective-size
+      // cap accounting (#247) honest and matches the write path.
+      item.full_retained ? item.full_content : "",
       item.original_size,
       item.summary_size,
       item.created_at,

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -904,6 +904,81 @@ describe("db", () => {
   });
 
   // -------------------------------------------------------------------------
+  // effective-size accounting under store.retention (#247)
+  //
+  // A summary-only row (full_retained = 0) occupies ~summary_size on disk, not
+  // original_size, so the byte-cap accounting (store.max_size_mb eviction and
+  // store.max_pinned_mb pin budget) counts it at its effective size. The
+  // *savings* figures in getStats keep reporting original_size.
+  // -------------------------------------------------------------------------
+
+  describe("effective-size accounting (#247)", () => {
+    it("eviction cap counts summary-only rows at reduced size, so more fit before eviction", () => {
+      const cap = 0.0008; // ~838 bytes
+
+      // Full-body rows: effective size == original_size → over the cap → evict.
+      const FULL_KEY = "fullkey123456789";
+      for (let i = 0; i < 3; i++) {
+        storeOutput(db, makeInput({ project_key: FULL_KEY, original_size: 400, summary: `f${i}`, full_retained: 1 }));
+      }
+      expect(evictIfNeeded(db, FULL_KEY, cap)).toBeGreaterThan(0);
+
+      // Summary-only rows: same original_size but effective size is the tiny
+      // summary → well under the cap → nothing evicted.
+      const SUMM_KEY = "summkey123456789";
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        ids.push(storeOutput(db, makeInput({ project_key: SUMM_KEY, original_size: 400, summary: `s${i}`, full_retained: 0 })).id);
+      }
+      expect(evictIfNeeded(db, SUMM_KEY, cap)).toBe(0);
+      for (const id of ids) expect(retrieveOutput(db, id)).not.toBeNull();
+    });
+
+    it("eviction sheds by effective size: a full row is still evicted when a preceding summary-only row doesn't cover the shortfall", () => {
+      const now = 1_000_000_000;
+      // s: summary-only, original 1000 but effective ~1 byte; ranks lowest (evicted first).
+      const s = storeOutput(db, makeInput({ original_size: 1000, summary: "s", full_retained: 0 }));
+      // f: full body, effective 1000; more recent + accessed, so it ranks above s.
+      const f = storeOutput(db, makeInput({ original_size: 1000, summary: "a full body row", full_retained: 1 }));
+      db.prepare("UPDATE stored_outputs SET access_count = 0, last_accessed = ? WHERE id = ?").run(now - 100000, s.id);
+      db.prepare("UPDATE stored_outputs SET access_count = 3, last_accessed = ? WHERE id = ?").run(now, f.id);
+
+      // total effective ≈ 1 + 1000 = 1001; cap 501 bytes → bytesToShed ≈ 500.
+      // Correct: shedding s (≈1) doesn't cover 500, so f must also go.
+      // Buggy (shed by original_size): s alone "sheds" 1000 ≥ 500 → f wrongly survives.
+      const capMb = 501 / (1024 * 1024);
+      evictIfNeeded(db, PROJECT_KEY, capMb, 7, now);
+
+      expect(retrieveOutput(db, f.id)).toBeNull();
+    });
+
+    it("pin budget counts summary-only rows at reduced size, so more fit than original sizes suggest", () => {
+      const cap = 0.001; // ~1049 bytes; 3 × original 800 = 2400 would blow an original-based cap
+      const ids: string[] = [];
+      for (let i = 0; i < 3; i++) {
+        ids.push(storeOutput(db, makeInput({ original_size: 800, summary: `s${i}`, full_retained: 0 })).id);
+      }
+      for (const id of ids) {
+        expect(pinOutput(db, id, PROJECT_KEY, true, cap).ok).toBe(true);
+      }
+    });
+
+    it("getStats reports pinned bytes at effective size for summary-only rows", () => {
+      const summary = "short summary";
+      const s = storeOutput(db, makeInput({ original_size: 5000, summary, full_retained: 0 }));
+      pinOutput(db, s.id, PROJECT_KEY, true);
+      const stats = getStats(db, PROJECT_KEY);
+      expect(stats.pinned_bytes).toBe(Buffer.byteLength(summary, "utf8")); // NOT 5000
+    });
+
+    it("getStats savings figures still use original_size regardless of retention", () => {
+      storeOutput(db, makeInput({ tool_name: "Bash", original_size: 5000, summary: "short summary", full_retained: 0 }));
+      const stats = getStats(db, PROJECT_KEY);
+      expect(stats.total_original_bytes).toBe(5000); // savings measured against the full original
+    });
+  });
+
+  // -------------------------------------------------------------------------
   // retrieveSnippet
   // -------------------------------------------------------------------------
 

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -963,6 +963,17 @@ describe("db", () => {
       }
     });
 
+    it("pin budget sums effective size across a MIX of full-retained and summary-only rows", () => {
+      const cap = 0.001; // ~1049 bytes
+      // Full row: effective == original 600, pinned first → running total 600.
+      const full = storeOutput(db, makeInput({ original_size: 600, summary: "f", full_retained: 1 }));
+      expect(pinOutput(db, full.id, PROJECT_KEY, true, cap).ok).toBe(true);
+      // Summary-only row: original 900 (600 + 900 = 1500 would blow an original-based
+      // cap) but its effective size is the tiny summary, so 600 + ~1 fits → ok.
+      const summ = storeOutput(db, makeInput({ original_size: 900, summary: "s", full_retained: 0 }));
+      expect(pinOutput(db, summ.id, PROJECT_KEY, true, cap).ok).toBe(true);
+    });
+
     it("getStats reports pinned bytes at effective size for summary-only rows", () => {
       const summary = "short summary";
       const s = storeOutput(db, makeInput({ original_size: 5000, summary, full_retained: 0 }));

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -119,6 +119,50 @@ describe("import round-trip", () => {
     }
   });
 
+  // A legitimate export never carries a body for a summary-only row (storeOutput
+  // zeroes it at write). But a hand-edited / tampered / foreign-version dump can
+  // pair full_retained=0 with a non-empty full_content — the schema validates the
+  // two independently. Import must enforce storeOutput's invariant so the body is
+  // dropped, otherwise the row occupies its full bytes on disk while the
+  // effective-size cap accounting (#247) counts it as summary_size only.
+  test("drops the body of a summary-only row from a malformed dump (full_retained=0 invariant)", async () => {
+    const bigBody = "x".repeat(10000);
+    const dump = [{
+      id: "recall_deadbeefcafe0001",
+      project_key: SOURCE_PROJECT,
+      session_id: "sess-abc",
+      tool_name: "Bash",
+      summary: "short summary",
+      full_content: bigBody,        // present despite full_retained = 0 (malformed)
+      original_size: 10000,
+      summary_size: 13,
+      created_at: 1_700_000_000,
+      pinned: 0,
+      access_count: 0,
+      last_accessed: null,
+      input_hash: null,
+      full_retained: 0,
+    }];
+    const dumpFile = makeTmpPath();
+    writeFileSync(dumpFile, JSON.stringify(dump));
+    const targetDbPath = makeTmpPath(".db");
+
+    process.env.RECALL_DB_PATH = targetDbPath;
+    try {
+      await handleImportCommand([dumpFile]);
+      const targetDb = new Database(targetDbPath);
+      const row = targetDb
+        .prepare(`SELECT full_retained, full_content FROM stored_outputs WHERE id = 'recall_deadbeefcafe0001'`)
+        .get() as { full_retained: number; full_content: string };
+      targetDb.close();
+
+      expect(row.full_retained).toBe(0);   // flag preserved
+      expect(row.full_content).toBe("");    // body dropped to honor the invariant
+    } finally {
+      delete process.env.RECALL_DB_PATH;
+    }
+  });
+
   test("remaps project key to current project by default", async () => {
     storeOutput(sourceDb, makeInput());
     const dumpFile = makeTmpPath();


### PR DESCRIPTION
## Summary

- `store.max_size_mb` eviction and the `store.max_pinned_mb` pin budget now count each item's **effective** stored size — a summary-only row (`full_retained=0`, written under `store.retention`) drops its body and chunks and occupies ~`summary_size`, so it's counted at `summary_size`, not `original_size`.
- Lowering `store.retention` now genuinely raises the number of items the store holds before eviction fires (and how many can be pinned), not just bytes-on-disk. Closes #247.
- The **savings** figures in `recall__stats` (`total_original_bytes`/`total_summary_bytes`) keep reporting `original_size` — they measure context saved, not disk footprint. Only the cap/eviction/pin-budget accounting switched.

Per the #247 decision, the pin budget switches consistently with eviction, so the `recall__stats` pin-budget warning (`pinned_bytes`) reflects the same accounting `pinOutput` enforces. In practice notes (the bulk of pinned data) are always `full_retained=1`, so real-world pinned figures are unchanged; this mainly affects pinned summary-only Bash/git rows.

Implementation is a shared `EFFECTIVE_SIZE_EXPR` SQL fragment wired into the size-cap total and per-candidate shed of `evictIfNeeded`, the `pinOutput` budget check, and `getStats.pinned_bytes`.

### Review follow-up (self-review via the 8-lens rubric)

- **Import invariant:** `importItems` inserted `full_content` verbatim, unlike `storeOutput` which zeroes the body for a summary-only row. A legitimate export never carries a body for such a row, but a malformed/foreign-version dump can pair `full_retained=0` with a non-empty body — which this PR's effective-size accounting would then under-count against the disk cap. Import now drops the body to mirror the write path (boundary hardening; `src/import/index.ts`).

## Test plan

- [x] 6 tests in `tests/db.test.ts` (`effective-size accounting (#247)`): eviction cap holds more summary-only rows; eviction sheds by effective size; pin budget fits more summary-only rows; **mixed full + summary-only pin budget** (heterogeneous `SUM(effective_size)`); `getStats.pinned_bytes` reports effective size; savings figures still use `original_size`.
- [x] Import regression test: a malformed dump (`full_retained=0` + non-empty body) has its body dropped on import.
- [x] All accounting sites mutation-verified (revert each to `original_size` → exactly its guard test reddens; savings test stays green).
- [x] `bun test` — 889 pass / 0 fail; `bun run typecheck` clean; stress job green; bundle fresh.
- [x] README `store.retention` note + `[Unreleased]` CHANGELOG updated.