### PR TITLE
feat: per-command savings attribution via Bash fingerprint (#251)

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,14 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+### Added
+
+- `recall__stats` now includes a **By Bash command** breakdown that attributes the aggregate
+  Bash compression figure to command families (`git diff`, `rg`, `cat`, …), so low-reduction
+  families — the compression leaks — are visible. Families come from a privacy-safe fingerprint
+  stored per row (the leading command verb/subcommand only; arguments and secrets are never
+  captured). Rows written before this feature fold into an `unknown` bucket (#251).
+
 ### Changed
 
 - `store.max_size_mb` eviction and the `store.max_pinned_mb` pin budget now count each

--- a/docs/tools.md
+++ b/docs/tools.md
@@ -123,6 +123,12 @@ memory is reported on its own `Notes/memory` line so a bulk note backend can't
 dilute the compression number. Pinned-budget accounting stays store-wide, since
 notes are pinned and do count against `store.max_pinned_mb`.
 
+A `By Bash command` section attributes the aggregate `Bash` figure to command
+families (`git diff`, `rg`, `cat`, …) so low-reduction families — the compression
+leaks — are visible. Families come from a privacy-safe fingerprint (the leading
+command verb/subcommand only; never an argument or secret); rows written before
+this feature, or with no bare command verb, fold into an `unknown` bucket.
+
 ```
 recall__stats()
 ```
@@ -142,7 +148,12 @@ Session stats for current project:
 By tool (sorted by original size):
   mcp__playwright__browser_snapshot    4 items    215KB →  1.2KB    99%
   mcp__github__list_issues             3 items    106KB →  3.3KB    97%
-  mcp__filesystem__read_file           2 items     21KB →  4.4KB    79%
+  Bash                                 6 items     88KB →   53KB    40%
+
+By Bash command (sorted by original size):
+  rg           3 items     42KB →  7.1KB    83%
+  git diff     2 items     34KB →   11KB    68%
+  cat          1 item      12KB →   11KB    12%
 
 Suggestions:
   📌 Consider pinning:

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -7279,15 +7279,23 @@ var SUBCOMMAND_TOOLS = new Set([
   "docker",
   "kubectl"
 ]);
+var WRAPPER_TOOLS = new Set(["sudo", "doas", "time", "nice"]);
+var BARE_TOKEN = /^([a-zA-Z][\w-]*)(?=[\s;&|<>()]|$)/;
 function commandFingerprint(command) {
-  const c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
-  const first = c.match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  let c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
+  for (let i = 0;i < 4; i++) {
+    const w = c.match(/^([a-zA-Z][\w-]*)\s+(?=[a-zA-Z])/);
+    if (!w || !WRAPPER_TOOLS.has(w[1]))
+      break;
+    c = c.slice(w[0].length);
+  }
+  const first = c.match(BARE_TOKEN);
   if (!first)
     return "";
   const verb = first[1];
   if (!SUBCOMMAND_TOOLS.has(verb))
     return verb;
-  const second = c.slice(first[0].length).match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  const second = c.slice(verb.length).trimStart().match(BARE_TOKEN);
   return second ? `${verb} ${second[1]}` : verb;
 }
 function getBashHandler(input) {

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -5261,7 +5261,9 @@ var MIGRATIONS = [
   "ALTER TABLE stored_outputs ADD COLUMN input_hash TEXT",
   "ALTER TABLE stored_outputs ADD COLUMN output_hash TEXT",
   "CREATE INDEX IF NOT EXISTS idx_so_output_hash ON stored_outputs(project_key, output_hash)",
-  "ALTER TABLE stored_outputs ADD COLUMN full_retained INTEGER NOT NULL DEFAULT 1"
+  "ALTER TABLE stored_outputs ADD COLUMN full_retained INTEGER NOT NULL DEFAULT 1",
+  "ALTER TABLE stored_outputs ADD COLUMN command_fp TEXT",
+  "CREATE INDEX IF NOT EXISTS idx_so_command_fp ON stored_outputs(project_key, command_fp)"
 ];
 function applyMigrations(db) {
   for (const sql of MIGRATIONS) {
@@ -5360,13 +5362,14 @@ function storeOutput(db, input) {
   const output_hash = input.output_hash ?? hashContent(input.full_content);
   const full_retained = input.full_retained ?? 1;
   const bodyToStore = full_retained ? input.full_content : "";
+  const command_fp = input.command_fp ?? null;
   const insertAndChunk = db.transaction(() => {
     db.prepare(`
       INSERT INTO stored_outputs
         (id, project_key, session_id, tool_name, summary, full_content,
-         original_size, summary_size, created_at, input_hash, output_hash, full_retained)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, bodyToStore, input.original_size, summary_size, created_at, input_hash, output_hash, full_retained);
+         original_size, summary_size, created_at, input_hash, output_hash, full_retained, command_fp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, bodyToStore, input.original_size, summary_size, created_at, input_hash, output_hash, full_retained, command_fp);
     if (full_retained)
       storeChunks(db, id, input.full_content);
   });
@@ -5382,7 +5385,8 @@ function storeOutput(db, input) {
     last_accessed: null,
     input_hash,
     output_hash,
-    full_retained
+    full_retained,
+    command_fp
   };
 }
 function hashContent(content) {
@@ -7264,6 +7268,28 @@ function normalizeCommand(command) {
   c = c.replace(/^git\s+(?:(?:--no-pager|--paginate|-P)\s+|-[cC]\s+\S+\s+)+/, "git ");
   return c;
 }
+var SUBCOMMAND_TOOLS = new Set([
+  "git",
+  "cargo",
+  "go",
+  "npm",
+  "pnpm",
+  "yarn",
+  "bun",
+  "docker",
+  "kubectl"
+]);
+function commandFingerprint(command) {
+  const c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
+  const first = c.match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  if (!first)
+    return "";
+  const verb = first[1];
+  if (!SUBCOMMAND_TOOLS.has(verb))
+    return verb;
+  const second = c.slice(first[0].length).match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  return second ? `${verb} ${second[1]}` : verb;
+}
 function getBashHandler(input) {
   const rawCommand = extractCommand(input);
   if (!rawCommand)
@@ -8674,6 +8700,7 @@ ${cached2.summary}`,
   const full_retained = shouldRetainFullBody(config.store.retention, tool_name, command) ? 1 : 0;
   if (!full_retained)
     log.debug(`summary-only \xB7 ${tool_name} \xB7 retention=${config.store.retention}`);
+  const command_fp = tool_name === "Bash" && command ? commandFingerprint(normalizeCommand(command)) || null : null;
   const stored = storeOutput(db, {
     project_key: projectKey,
     session_id,
@@ -8683,7 +8710,8 @@ ${cached2.summary}`,
     original_size: originalSize,
     input_hash: input_hash ?? undefined,
     output_hash,
-    full_retained
+    full_retained,
+    command_fp
   });
   evictIfNeeded(db, projectKey, config.store.max_size_mb, config.store.eviction_half_life_days);
   const reduction = ((1 - summarySize / originalSize) * 100).toFixed(0);
@@ -10235,7 +10263,8 @@ var StoredOutputSchema = exports_external.object({
   access_count: exports_external.number().int().nonnegative(),
   last_accessed: exports_external.number().int().nullable(),
   input_hash: exports_external.string().nullable(),
-  full_retained: exports_external.number().int().min(0).max(1).optional().default(1)
+  full_retained: exports_external.number().int().min(0).max(1).optional().default(1),
+  command_fp: exports_external.string().nullable().optional().default(null)
 });
 var ExportSchema = exports_external.array(StoredOutputSchema);
 function dryRunCount(dbPath, items, overwrite) {
@@ -10284,9 +10313,9 @@ function importItems(dbPath, items, opts) {
       INSERT INTO stored_outputs
         (id, project_key, session_id, tool_name, summary, full_content,
          original_size, summary_size, created_at, pinned, access_count,
-         last_accessed, input_hash, full_retained)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(item.id, projectKey, item.session_id, item.tool_name, item.summary, item.full_retained ? item.full_content : "", item.original_size, item.summary_size, item.created_at, item.pinned, item.access_count, item.last_accessed, item.input_hash, item.full_retained);
+         last_accessed, input_hash, full_retained, command_fp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(item.id, projectKey, item.session_id, item.tool_name, item.summary, item.full_retained ? item.full_content : "", item.original_size, item.summary_size, item.created_at, item.pinned, item.access_count, item.last_accessed, item.input_hash, item.full_retained, item.command_fp);
     if (item.full_retained) {
       const chunks = chunkText(item.full_content);
       for (let i = 0;i < chunks.length; i++) {

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -19631,7 +19631,9 @@ var MIGRATIONS = [
   "ALTER TABLE stored_outputs ADD COLUMN input_hash TEXT",
   "ALTER TABLE stored_outputs ADD COLUMN output_hash TEXT",
   "CREATE INDEX IF NOT EXISTS idx_so_output_hash ON stored_outputs(project_key, output_hash)",
-  "ALTER TABLE stored_outputs ADD COLUMN full_retained INTEGER NOT NULL DEFAULT 1"
+  "ALTER TABLE stored_outputs ADD COLUMN full_retained INTEGER NOT NULL DEFAULT 1",
+  "ALTER TABLE stored_outputs ADD COLUMN command_fp TEXT",
+  "CREATE INDEX IF NOT EXISTS idx_so_command_fp ON stored_outputs(project_key, command_fp)"
 ];
 function applyMigrations(db) {
   for (const sql of MIGRATIONS) {
@@ -19757,13 +19759,14 @@ function storeOutput(db, input) {
   const output_hash = input.output_hash ?? hashContent(input.full_content);
   const full_retained = input.full_retained ?? 1;
   const bodyToStore = full_retained ? input.full_content : "";
+  const command_fp = input.command_fp ?? null;
   const insertAndChunk = db.transaction(() => {
     db.prepare(`
       INSERT INTO stored_outputs
         (id, project_key, session_id, tool_name, summary, full_content,
-         original_size, summary_size, created_at, input_hash, output_hash, full_retained)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
-    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, bodyToStore, input.original_size, summary_size, created_at, input_hash, output_hash, full_retained);
+         original_size, summary_size, created_at, input_hash, output_hash, full_retained, command_fp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+    `).run(id, input.project_key, input.session_id, input.tool_name, input.summary, bodyToStore, input.original_size, summary_size, created_at, input_hash, output_hash, full_retained, command_fp);
     if (full_retained)
       storeChunks(db, id, input.full_content);
   });
@@ -19779,7 +19782,8 @@ function storeOutput(db, input) {
     last_accessed: null,
     input_hash,
     output_hash,
-    full_retained
+    full_retained,
+    command_fp
   };
 }
 function hashContent(content) {
@@ -19937,6 +19941,19 @@ function getStats(db, project_key) {
   `).get(project_key);
   const compression_ratio = row.total_original_bytes > 0 ? row.total_summary_bytes / row.total_original_bytes : 0;
   return { ...row, compression_ratio };
+}
+function getBashCommandBreakdown(db, project_key) {
+  return db.prepare(`
+    SELECT
+      COALESCE(command_fp, 'unknown') AS command_fp,
+      COUNT(*)                       AS items,
+      COALESCE(SUM(original_size),0) AS original_bytes,
+      COALESCE(SUM(summary_size),0)  AS summary_bytes
+    FROM stored_outputs
+    WHERE project_key = ? AND tool_name = 'Bash'
+    GROUP BY COALESCE(command_fp, 'unknown')
+    ORDER BY original_bytes DESC
+  `).all(project_key);
 }
 function getToolBreakdown(db, project_key) {
   return db.prepare(`
@@ -21520,6 +21537,15 @@ function toolStats(db, projectKey, args = {}) {
     for (const row of breakdown) {
       const reduction = row.original_bytes > 0 ? `${((1 - row.summary_bytes / row.original_bytes) * 100).toFixed(0)}%` : " \u2014";
       lines.push(`  ${row.tool_name.padEnd(colW)}  ${String(row.items).padStart(4)} item${row.items === 1 ? " " : "s"}` + `  ${formatBytes(row.original_bytes).padStart(8)} \u2192 ${formatBytes(row.summary_bytes).padEnd(8)}  ${reduction.padStart(4)}`);
+    }
+  }
+  const cmdBreakdown = getBashCommandBreakdown(db, projectKey);
+  if (cmdBreakdown.length > 0) {
+    lines.push("", "By Bash command (sorted by original size):");
+    const colW = Math.min(40, Math.max(...cmdBreakdown.map((r) => r.command_fp.length)));
+    for (const row of cmdBreakdown) {
+      const reduction = row.original_bytes > 0 ? `${((1 - row.summary_bytes / row.original_bytes) * 100).toFixed(0)}%` : " \u2014";
+      lines.push(`  ${row.command_fp.padEnd(colW)}  ${String(row.items).padStart(4)} item${row.items === 1 ? " " : "s"}` + `  ${formatBytes(row.original_bytes).padStart(8)} \u2192 ${formatBytes(row.summary_bytes).padEnd(8)}  ${reduction.padStart(4)}`);
     }
   }
   const suggestions = getSuggestions(db, projectKey, {

--- a/src/db/analytics.ts
+++ b/src/db/analytics.ts
@@ -3,6 +3,7 @@ import type {
   StoredOutput,
   Stats,
   ToolBreakdownRow,
+  CommandBreakdownRow,
   SuggestionsOptions,
   SuggestionsData,
   ContextOptions,
@@ -40,6 +41,27 @@ export function getStats(db: Database, project_key: string): Stats {
       : 0;
 
   return { ...row, compression_ratio };
+}
+
+/**
+ * Returns per-command-family storage stats for Bash rows only, sorted by
+ * original_bytes desc (#251). Rows are grouped by their privacy-safe
+ * `command_fp`; pre-migration / untagged Bash rows fold into an "unknown"
+ * bucket. This is what makes the aggregate "Bash: N%" attributable — the
+ * low-reduction families are the compression leaks.
+ */
+export function getBashCommandBreakdown(db: Database, project_key: string): CommandBreakdownRow[] {
+  return db.prepare(`
+    SELECT
+      COALESCE(command_fp, 'unknown') AS command_fp,
+      COUNT(*)                       AS items,
+      COALESCE(SUM(original_size),0) AS original_bytes,
+      COALESCE(SUM(summary_size),0)  AS summary_bytes
+    FROM stored_outputs
+    WHERE project_key = ? AND tool_name = 'Bash'
+    GROUP BY COALESCE(command_fp, 'unknown')
+    ORDER BY original_bytes DESC
+  `).all(project_key) as CommandBreakdownRow[];
 }
 
 /** Returns per-tool storage stats, sorted by original_bytes desc. */

--- a/src/db/queries.ts
+++ b/src/db/queries.ts
@@ -94,17 +94,18 @@ export function storeOutput(db: Database, input: StoreInput): StoredOutput {
   // full_content is NOT NULL, so store an empty string rather than NULL.
   const full_retained = input.full_retained ?? 1;
   const bodyToStore = full_retained ? input.full_content : "";
+  const command_fp = input.command_fp ?? null;
 
   const insertAndChunk = db.transaction(() => {
     db.prepare(`
       INSERT INTO stored_outputs
         (id, project_key, session_id, tool_name, summary, full_content,
-         original_size, summary_size, created_at, input_hash, output_hash, full_retained)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         original_size, summary_size, created_at, input_hash, output_hash, full_retained, command_fp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       id, input.project_key, input.session_id, input.tool_name,
       input.summary, bodyToStore, input.original_size,
-      summary_size, created_at, input_hash, output_hash, full_retained
+      summary_size, created_at, input_hash, output_hash, full_retained, command_fp
     );
 
     if (full_retained) storeChunks(db, id, input.full_content);
@@ -118,6 +119,7 @@ export function storeOutput(db: Database, input: StoreInput): StoredOutput {
     input_hash: input_hash,
     output_hash,
     full_retained,
+    command_fp,
   };
 }
 

--- a/src/db/schema.ts
+++ b/src/db/schema.ts
@@ -74,6 +74,11 @@ const MIGRATIONS = [
   // Whether the verbatim body is persisted (1) or the row is summary-only (0).
   // Existing rows all have bodies, so default 1. See store.retention.
   "ALTER TABLE stored_outputs ADD COLUMN full_retained INTEGER NOT NULL DEFAULT 1",
+  // Privacy-safe command family fingerprint for per-command savings attribution
+  // (#251); NULL for non-Bash rows and for rows written before this migration
+  // (reported as "unknown"). See commandFingerprint in handlers/bash.ts.
+  "ALTER TABLE stored_outputs ADD COLUMN command_fp TEXT",
+  "CREATE INDEX IF NOT EXISTS idx_so_command_fp ON stored_outputs(project_key, command_fp)",
 ];
 
 function applyMigrations(db: Database): void {

--- a/src/db/types.ts
+++ b/src/db/types.ts
@@ -16,6 +16,8 @@ export interface StoredOutput {
   output_hash: string | null;
   /** 1 = verbatim body persisted (retrievable); 0 = summary-only (body dropped per store.retention). */
   full_retained: number;
+  /** Privacy-safe command family fingerprint (Bash rows only; NULL otherwise or pre-migration). See #251. */
+  command_fp: string | null;
 }
 
 /** Input required to persist a new compressed tool output. */
@@ -36,6 +38,8 @@ export interface StoreInput {
    * keeps working.
    */
   full_retained?: number;
+  /** Privacy-safe command family fingerprint (Bash only); omitted/undefined stores NULL. See #251. */
+  command_fp?: string | null;
 }
 
 /** Options for full-text search across stored outputs. */
@@ -127,6 +131,14 @@ export interface SessionSummaryData {
 /** Per-tool row returned by {@link getToolBreakdown}. */
 export interface ToolBreakdownRow {
   tool_name: string;
+  items: number;
+  original_bytes: number;
+  summary_bytes: number;
+}
+
+/** Per-command-family row returned by {@link getBashCommandBreakdown} (#251). */
+export interface CommandBreakdownRow {
+  command_fp: string;   // "unknown" for pre-migration / untagged Bash rows
   items: number;
   original_bytes: number;
   summary_bytes: number;

--- a/src/handlers/bash.ts
+++ b/src/handlers/bash.ts
@@ -292,6 +292,36 @@ export function normalizeCommand(command: string): string {
   return c;
 }
 
+// Dispatcher commands whose first token names a tool family, not the operation —
+// the meaningful fingerprint is "verb subcommand" (e.g. "git diff", "cargo build").
+const SUBCOMMAND_TOOLS = new Set([
+  "git", "cargo", "go", "npm", "pnpm", "yarn", "bun", "docker", "kubectl",
+]);
+
+/**
+ * Derives a privacy-safe command "family" fingerprint from a NORMALIZED command
+ * (see {@link normalizeCommand}) for per-command savings attribution (#251).
+ *
+ * Returns the leading bare token, plus the second bare token when the first is a
+ * known subcommand dispatcher. A "bare token" is a leading run of letters/digits/
+ * `-`/`_` that is followed by whitespace or end-of-string. Extraction therefore
+ * stops at the first flag, path, quote, `=`, pipe, or redirection — so an
+ * argument or secret (a URL with credentials, an auth header value) can NEVER
+ * enter the fingerprint. Leading `VAR=value` env assignments are stripped first
+ * (and discarded, so a secret in a value can't leak). Returns "" when no bare
+ * leading token exists (subshell, `./script`, etc.); callers store that as unknown.
+ */
+export function commandFingerprint(command: string): string {
+  // Strip leading env-var assignments; discarded, never stored.
+  const c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
+  const first = c.match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  if (!first) return "";
+  const verb = first[1]!;
+  if (!SUBCOMMAND_TOOLS.has(verb)) return verb;
+  const second = c.slice(first[0].length).match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  return second ? `${verb} ${second[1]!}` : verb;
+}
+
 /**
  * Returns the appropriate handler for a native Bash tool call based on the
  * command string in `tool_input`. Falls back to the shell handler when no

--- a/src/handlers/bash.ts
+++ b/src/handlers/bash.ts
@@ -298,27 +298,48 @@ const SUBCOMMAND_TOOLS = new Set([
   "git", "cargo", "go", "npm", "pnpm", "yarn", "bun", "docker", "kubectl",
 ]);
 
+// Wrapper commands that prefix a real command; skipped so the fingerprint names
+// the wrapped operation ("sudo apt-get …" → "apt-get"), not the wrapper.
+const WRAPPER_TOOLS = new Set(["sudo", "doas", "time", "nice"]);
+
+// A bare command token: letters then letters/digits/`-`/`_`, terminated by
+// whitespace, a shell operator (`; & | < > ( )`), or end-of-string. The lookahead
+// (zero-width) is what lets a glued operator like `ls;pwd` still yield "ls" while
+// never absorbing an argument or secret into the token itself.
+const BARE_TOKEN = /^([a-zA-Z][\w-]*)(?=[\s;&|<>()]|$)/;
+
 /**
  * Derives a privacy-safe command "family" fingerprint from a NORMALIZED command
  * (see {@link normalizeCommand}) for per-command savings attribution (#251).
  *
  * Returns the leading bare token, plus the second bare token when the first is a
- * known subcommand dispatcher. A "bare token" is a leading run of letters/digits/
- * `-`/`_` that is followed by whitespace or end-of-string. Extraction therefore
- * stops at the first flag, path, quote, `=`, pipe, or redirection — so an
- * argument or secret (a URL with credentials, an auth header value) can NEVER
- * enter the fingerprint. Leading `VAR=value` env assignments are stripped first
- * (and discarded, so a secret in a value can't leak). Returns "" when no bare
- * leading token exists (subshell, `./script`, etc.); callers store that as unknown.
+ * known subcommand dispatcher (`git diff`). A "bare token" is a run of letters/
+ * digits/`-`/`_` terminated by whitespace, a shell operator, or end-of-string —
+ * so extraction stops at the first flag, path, quote, `=`, pipe, or redirection
+ * and an argument or secret (a URL with credentials, an auth header value) can
+ * NEVER enter the fingerprint. Leading `VAR=value` env assignments and leading
+ * wrapper commands (`sudo`/`doas`/`time`/`nice`, when directly followed by a bare
+ * verb) are skipped first, and discarded, so a secret in a value can't leak and
+ * `sudo git diff` fingerprints as `git diff`. A *flagged* wrapper (`sudo -u www …`)
+ * is left intact — its argument span isn't safely parseable — so it keeps the
+ * wrapper name. Returns "" when no bare leading token exists (subshell,
+ * `./script`, …); callers store that as unknown.
  */
 export function commandFingerprint(command: string): string {
   // Strip leading env-var assignments; discarded, never stored.
-  const c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
-  const first = c.match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  let c = command.trim().replace(/^(?:[A-Za-z_]\w*=\S*\s+)+/, "");
+  // Skip leading wrapper commands when directly followed by another bare verb.
+  // Bounded loop (chained wrappers are rare); bails on a flagged wrapper.
+  for (let i = 0; i < 4; i++) {
+    const w = c.match(/^([a-zA-Z][\w-]*)\s+(?=[a-zA-Z])/);
+    if (!w || !WRAPPER_TOOLS.has(w[1]!)) break;
+    c = c.slice(w[0].length);
+  }
+  const first = c.match(BARE_TOKEN);
   if (!first) return "";
   const verb = first[1]!;
   if (!SUBCOMMAND_TOOLS.has(verb)) return verb;
-  const second = c.slice(first[0].length).match(/^([a-zA-Z][\w-]*)(?:\s|$)/);
+  const second = c.slice(verb.length).trimStart().match(BARE_TOKEN);
   return second ? `${verb} ${second[1]!}` : verb;
 }
 

--- a/src/hooks/post-tool-use.ts
+++ b/src/hooks/post-tool-use.ts
@@ -7,6 +7,7 @@ import { getHandler, extractText } from "../handlers/index";
 import { extractHints } from "../hints";
 import { getDb, defaultDbPath, storeOutput, checkDedup, checkOutputDedup, hashContent, evictIfNeeded } from "../db/index";
 import { shouldRetainFullBody } from "../retention";
+import { commandFingerprint, normalizeCommand } from "../handlers/bash";
 import { formatBytes } from "../format";
 import { log } from "../log";
 
@@ -112,6 +113,13 @@ export function handlePostToolUse(raw: string): HookOutput {
   const full_retained = shouldRetainFullBody(config.store.retention, tool_name, command) ? 1 : 0;
   if (!full_retained) log.debug(`summary-only · ${tool_name} · retention=${config.store.retention}`);
 
+  // Privacy-safe command family fingerprint for per-command savings attribution
+  // (#251). Bash only; a "" fingerprint (no bare verb) is stored as NULL/unknown.
+  const command_fp =
+    tool_name === "Bash" && command
+      ? commandFingerprint(normalizeCommand(command)) || null
+      : null;
+
   const stored = storeOutput(db, {
     project_key: projectKey,
     session_id,
@@ -122,6 +130,7 @@ export function handlePostToolUse(raw: string): HookOutput {
     input_hash: input_hash ?? undefined,
     output_hash, // reuse the hash computed above for the dedup check
     full_retained,
+    command_fp,
   });
 
   // 8. Evict if store exceeds size limit

--- a/src/import/index.ts
+++ b/src/import/index.ts
@@ -46,6 +46,9 @@ const StoredOutputSchema = z.object({
   // Optional for backward-compat with dumps predating store.retention: an older
   // dump has no flag and its rows all carry bodies, so default to retained (1).
   full_retained: z.number().int().min(0).max(1).optional().default(1),
+  // Optional for backward-compat with dumps predating per-command attribution
+  // (#251): missing → NULL, reported as "unknown".
+  command_fp: z.string().nullable().optional().default(null),
 });
 
 type StoredOutputRow = z.infer<typeof StoredOutputSchema>;
@@ -133,8 +136,8 @@ function importItems(
       INSERT INTO stored_outputs
         (id, project_key, session_id, tool_name, summary, full_content,
          original_size, summary_size, created_at, pinned, access_count,
-         last_accessed, input_hash, full_retained)
-      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
+         last_accessed, input_hash, full_retained, command_fp)
+      VALUES (?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?, ?)
     `).run(
       item.id,
       projectKey,
@@ -153,7 +156,8 @@ function importItems(
       item.access_count,
       item.last_accessed,
       item.input_hash,
-      item.full_retained
+      item.full_retained,
+      item.command_fp
     );
 
     // Re-index chunks (FTS trigger covers stored_outputs but not content_chunks).

--- a/src/tools.ts
+++ b/src/tools.ts
@@ -20,6 +20,7 @@ import {
   foreignKeyBreakdown,
   getStats,
   getToolBreakdown,
+  getBashCommandBreakdown,
   getSuggestions,
   getSessionDays,
   getSessionSummary,
@@ -678,6 +679,24 @@ export function toolStats(
           : " —";
       lines.push(
         `  ${row.tool_name.padEnd(colW)}  ${String(row.items).padStart(4)} item${row.items === 1 ? " " : "s"}` +
+          `  ${formatBytes(row.original_bytes).padStart(8)} → ${formatBytes(row.summary_bytes).padEnd(8)}  ${reduction.padStart(4)}`
+      );
+    }
+  }
+
+  // Per-command breakdown for Bash — attributes the aggregate Bash figure to
+  // command families so low-reduction rows (the compression leaks) are visible (#251).
+  const cmdBreakdown = getBashCommandBreakdown(db, projectKey);
+  if (cmdBreakdown.length > 0) {
+    lines.push("", "By Bash command (sorted by original size):");
+    const colW = Math.min(40, Math.max(...cmdBreakdown.map((r) => r.command_fp.length)));
+    for (const row of cmdBreakdown) {
+      const reduction =
+        row.original_bytes > 0
+          ? `${((1 - row.summary_bytes / row.original_bytes) * 100).toFixed(0)}%`
+          : " —";
+      lines.push(
+        `  ${row.command_fp.padEnd(colW)}  ${String(row.items).padStart(4)} item${row.items === 1 ? " " : "s"}` +
           `  ${formatBytes(row.original_bytes).padStart(8)} → ${formatBytes(row.summary_bytes).padEnd(8)}  ${reduction.padStart(4)}`
       );
     }

--- a/tests/db.test.ts
+++ b/tests/db.test.ts
@@ -16,6 +16,7 @@ import {
   listOutputs,
   forgetOutputs,
   getStats,
+  getBashCommandBreakdown,
   setMeta,
   getMeta,
   pruneExpired,
@@ -986,6 +987,50 @@ describe("db", () => {
       storeOutput(db, makeInput({ tool_name: "Bash", original_size: 5000, summary: "short summary", full_retained: 0 }));
       const stats = getStats(db, PROJECT_KEY);
       expect(stats.total_original_bytes).toBe(5000); // savings measured against the full original
+    });
+  });
+
+  // -------------------------------------------------------------------------
+  // command_fp persistence + getBashCommandBreakdown (#251)
+  // -------------------------------------------------------------------------
+
+  describe("command fingerprint (#251)", () => {
+    it("persists command_fp and returns it on retrieve", () => {
+      const s = storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "git diff" }));
+      expect(s.command_fp).toBe("git diff");
+      expect(retrieveOutput(db, s.id)!.command_fp).toBe("git diff");
+    });
+
+    it("stores NULL command_fp when omitted (non-Bash / untagged)", () => {
+      const s = storeOutput(db, makeInput({ tool_name: "mcp__github__list_issues" }));
+      expect(s.command_fp).toBeNull();
+      expect(retrieveOutput(db, s.id)!.command_fp).toBeNull();
+    });
+
+    it("groups Bash rows by command family, sorted by original size", () => {
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "git diff", original_size: 5000, summary: "a" }));
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "git diff", original_size: 3000, summary: "b" }));
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "rg", original_size: 1000, summary: "c" }));
+
+      const rows = getBashCommandBreakdown(db, PROJECT_KEY);
+      expect(rows.map((r) => r.command_fp)).toEqual(["git diff", "rg"]); // sorted by original bytes desc
+      const gitDiff = rows.find((r) => r.command_fp === "git diff")!;
+      expect(gitDiff.items).toBe(2);
+      expect(gitDiff.original_bytes).toBe(8000);
+    });
+
+    it("folds untagged/pre-migration Bash rows into an 'unknown' bucket", () => {
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: null, original_size: 900, summary: "x" }));
+      const rows = getBashCommandBreakdown(db, PROJECT_KEY);
+      expect(rows).toHaveLength(1);
+      expect(rows[0]!.command_fp).toBe("unknown");
+    });
+
+    it("excludes non-Bash rows from the breakdown", () => {
+      storeOutput(db, makeInput({ tool_name: "mcp__github__list_issues", summary: "gh" }));
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "ls", summary: "ls" }));
+      const rows = getBashCommandBreakdown(db, PROJECT_KEY);
+      expect(rows.map((r) => r.command_fp)).toEqual(["ls"]);
     });
   });
 

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -1017,6 +1017,28 @@ describe("commandFingerprint", () => {
     expect(commandFingerprint("$(which node) app.js")).toBe("");
     expect(commandFingerprint("")).toBe("");
   });
+
+  // Shell operators glued to a token without a space still terminate it (#252 review).
+  it("terminates a token at a glued shell operator, not just whitespace", () => {
+    expect(commandFingerprint("ls;pwd")).toBe("ls");
+    expect(commandFingerprint("make&&./run")).toBe("make");
+    expect(commandFingerprint("rg foo|wc -l")).toBe("rg");
+  });
+
+  // Irregular whitespace between a dispatcher verb and its subcommand (#252 review).
+  it("finds the subcommand across irregular whitespace", () => {
+    expect(commandFingerprint("git   diff --stat")).toBe("git diff");
+    expect(commandFingerprint("git\tdiff")).toBe("git diff");
+  });
+
+  // Wrapper prefixes are skipped so the wrapped operation is attributed (#252 review).
+  it("skips leading wrapper commands (sudo/time/nice) to the real verb", () => {
+    expect(commandFingerprint("sudo systemctl restart pg")).toBe("systemctl");
+    expect(commandFingerprint("sudo git diff")).toBe("git diff");
+    expect(commandFingerprint("time cargo build")).toBe("cargo build");
+    // A flagged wrapper isn't safely parseable → keeps the wrapper name (documented).
+    expect(commandFingerprint("sudo -u www git diff")).toBe("sudo");
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/tests/handlers.test.ts
+++ b/tests/handlers.test.ts
@@ -10,7 +10,7 @@ import { slackHandler } from "../src/handlers/slack";
 import { jsonHandler } from "../src/handlers/json";
 import { genericHandler } from "../src/handlers/generic";
 import { getHandler, extractText } from "../src/handlers/index";
-import { getBashHandler, normalizeCommand, gitDiffHandler, gitLogHandler, terraformPlanHandler, gitStatusHandler, gitRefsHandler, packageInstallHandler, testRunnerHandler, dockerPsHandler, buildToolHandler, ghHandler, compilerDiagnosticsHandler, grepHandler, lsHandler, findHandler } from "../src/handlers/bash";
+import { getBashHandler, normalizeCommand, commandFingerprint, gitDiffHandler, gitLogHandler, terraformPlanHandler, gitStatusHandler, gitRefsHandler, packageInstallHandler, testRunnerHandler, dockerPsHandler, buildToolHandler, ghHandler, compilerDiagnosticsHandler, grepHandler, lsHandler, findHandler } from "../src/handlers/bash";
 import { tavilyHandler } from "../src/handlers/tavily";
 import { databaseHandler } from "../src/handlers/database";
 import { sentryHandler } from "../src/handlers/sentry";
@@ -971,6 +971,51 @@ describe("getBashHandler", () => {
   it("getHandler routes Bash tool name to bash dispatcher", () => {
     const handler = getHandler("Bash", "output", { command: "git diff HEAD" });
     expect(handler).toBe(gitDiffHandler);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// commandFingerprint (#251 — per-command savings attribution)
+// ---------------------------------------------------------------------------
+
+describe("commandFingerprint", () => {
+  it("returns the leading verb for a plain command", () => {
+    expect(commandFingerprint("rg foobar src/")).toBe("rg");
+    expect(commandFingerprint("tsc --noEmit")).toBe("tsc");
+    expect(commandFingerprint("cat file.txt")).toBe("cat");
+  });
+
+  it("includes the subcommand for dispatcher tools", () => {
+    expect(commandFingerprint("git diff HEAD~1")).toBe("git diff");
+    expect(commandFingerprint("cargo build --release")).toBe("cargo build");
+    expect(commandFingerprint("docker ps -a")).toBe("docker ps");
+    expect(commandFingerprint("go test ./...")).toBe("go test");
+  });
+
+  it("pairs with normalizeCommand so git global flags don't pollute the fingerprint", () => {
+    expect(commandFingerprint(normalizeCommand("git --no-pager diff"))).toBe("git diff");
+    expect(commandFingerprint(normalizeCommand("git -C /some/repo diff HEAD~1"))).toBe("git diff");
+  });
+
+  it("strips leading env-var assignments (value discarded, never in the fingerprint)", () => {
+    expect(commandFingerprint("RECALL_DEBUG=1 bun test")).toBe("bun test");
+    expect(commandFingerprint("TOKEN=sk-secret-xyz rg pattern")).toBe("rg");
+  });
+
+  // SECRET-SAFETY: an argument or credential must never enter the fingerprint.
+  it("never captures an argument, URL, header value, or secret", () => {
+    expect(commandFingerprint('curl -H "Authorization: Bearer sk-live-abc123" https://api')).toBe("curl");
+    expect(commandFingerprint("psql postgres://user:pw@host:5432/db")).toBe("psql");
+    expect(commandFingerprint("aws s3 cp s3://bucket/secret .")).toBe("aws"); // aws not a dispatcher in the set
+    expect(commandFingerprint("mysql -uroot -phunter2")).toBe("mysql");
+    // git IS a dispatcher, but only the bare subcommand word is taken — never the arg:
+    expect(commandFingerprint("git clone https://tok:x@github.com/o/r")).toBe("git clone");
+  });
+
+  it("returns '' (unknown) when there is no bare leading token", () => {
+    expect(commandFingerprint("./deploy.sh --prod")).toBe("");
+    expect(commandFingerprint("$(which node) app.js")).toBe("");
+    expect(commandFingerprint("")).toBe("");
   });
 });
 

--- a/tests/hooks.test.ts
+++ b/tests/hooks.test.ts
@@ -348,6 +348,28 @@ describe("handlePostToolUse", () => {
   });
 
   // -------------------------------------------------------------------------
+  // command fingerprint (#251)
+  // -------------------------------------------------------------------------
+
+  it("derives and stores a command_fp for a Bash call", () => {
+    const bigDiff = "diff --git a/f b/f\n" + "+added line\n".repeat(400);
+    handlePostToolUse(
+      makePostToolUseInput(
+        "Bash",
+        JSON.stringify({ stdout: bigDiff, stderr: "", exit_code: 0 }),
+        { tool_input: { command: "git --no-pager diff HEAD~1" } }
+      )
+    );
+    const db = getDb(":memory:");
+    const row = db
+      .prepare("SELECT tool_name, command_fp FROM stored_outputs ORDER BY created_at DESC LIMIT 1")
+      .get() as { tool_name: string; command_fp: string | null };
+    // normalizeCommand strips --no-pager; fingerprint is the git subcommand, no args.
+    expect(row.tool_name).toBe("Bash");
+    expect(row.command_fp).toBe("git diff");
+  });
+
+  // -------------------------------------------------------------------------
   // Dedup
   // -------------------------------------------------------------------------
 

--- a/tests/import.test.ts
+++ b/tests/import.test.ts
@@ -125,6 +125,27 @@ describe("import round-trip", () => {
   // two independently. Import must enforce storeOutput's invariant so the body is
   // dropped, otherwise the row occupies its full bytes on disk while the
   // effective-size cap accounting (#247) counts it as summary_size only.
+  test("round-trips command_fp across export/import (#251)", async () => {
+    storeOutput(sourceDb, makeInput({ tool_name: "Bash", command_fp: "git diff", summary: "d" }));
+
+    const dumpFile = makeTmpPath();
+    const targetDbPath = makeTmpPath(".db");
+    exportToFile(dumpFile);
+
+    process.env.RECALL_DB_PATH = targetDbPath;
+    try {
+      await handleImportCommand([dumpFile]);
+      const targetDb = new Database(targetDbPath);
+      const row = targetDb
+        .prepare(`SELECT command_fp FROM stored_outputs WHERE tool_name = 'Bash'`)
+        .get() as { command_fp: string | null };
+      targetDb.close();
+      expect(row.command_fp).toBe("git diff"); // fingerprint survives, not reset to unknown
+    } finally {
+      delete process.env.RECALL_DB_PATH;
+    }
+  });
+
   test("drops the body of a summary-only row from a malformed dump (full_retained=0 invariant)", async () => {
     const bigBody = "x".repeat(10000);
     const dump = [{

--- a/tests/tools.test.ts
+++ b/tests/tools.test.ts
@@ -512,6 +512,15 @@ describe("MCP tool handlers", () => {
       expect(result).toContain("reduction");
     });
 
+    it("renders a per-command Bash breakdown attributing the aggregate figure (#251)", () => {
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "git diff", original_size: 8000, summary: "d".repeat(80) }));
+      storeOutput(db, makeInput({ tool_name: "Bash", command_fp: "cat", original_size: 6000, summary: "c".repeat(5000) }));
+      const result = toolStats(db, PROJECT_KEY);
+      expect(result).toContain("By Bash command");
+      expect(result).toMatch(/git diff\s+1 item/);
+      expect(result).toMatch(/cat\s+1 item/);   // low-reduction family stays visible as a leak
+    });
+
     it("reports recall__note memory separately without diluting the interception reduction", () => {
       // One real interception (10000 -> 100 = 99% reduction)...
       storeOutput(db, makeInput({ tool_name: "Bash", original_size: 10000, summary: "x".repeat(100) }));


### PR DESCRIPTION
Closes #251.

## Summary

- `recall__stats` could only report an aggregate `Bash: N%`. The command was never stored, so the command **mix** and the low-compression leaks were invisible — and that mix is exactly what a data-driven release decision needs.
- Stores a **privacy-safe command fingerprint** per row and adds a **By Bash command** section to `recall__stats` that attributes the aggregate figure to command families (`git diff`, `rg`, `cat`, …), surfacing low-reduction families as the leaks.

## Design

- `commandFingerprint()` (`src/handlers/bash.ts`) takes the **normalized** command's leading verb, plus the subcommand for known dispatchers (`git`/`cargo`/`go`/`npm`/`pnpm`/`yarn`/`bun`/`docker`/`kubectl`). It reads only bare word tokens and **stops at the first flag/arg/quote/`=`**, and strips (discards) leading `VAR=val` env assignments — so an argument, URL credential, or header secret can **never** enter the fingerprint. No bare verb → `""` → stored as `unknown`.
- New **nullable `command_fp`** column (migration + index; pre-migration rows read as `unknown`), populated for Bash rows only.
- `getBashCommandBreakdown` groups Bash rows by `COALESCE(command_fp,'unknown')`; the renderer adds the new section. `command_fp` round-trips through export/import.
- Not a config key — the CLAUDE.md "three places" rule does not apply.

Sample output:

```
By tool (sorted by original size):
  Bash                        11 items   310.5KB → 95.7KB     69%
By Bash command (sorted by original size):
  rg           5 items   146.5KB → 24.4KB     83%
  git diff     3 items   117.2KB → 35.2KB     70%
  cat          2 items    39.1KB → 33.2KB     15%   ← the leak, now visible
  unknown      1 item      7.8KB → 2.9KB      63%
```

## Test plan

- [x] `commandFingerprint` unit tests incl. **secret-safety** (`curl -H "Authorization: …"`, `psql postgres://user:pw@…`, `mysql -phunter2`, `git clone https://tok:x@…` → verb/subcommand only) and env-assignment stripping.
- [x] `command_fp` persistence + `getBashCommandBreakdown` grouping/`unknown`-bucket/non-Bash-exclusion/sort (db tests); hook derivation end-to-end (`git --no-pager diff` → `git diff`); export/import round-trip.
- [x] `recall__stats` renders the section (tools test).
- [x] New guards mutation-verified (analytics Bash filter, fingerprint subcommand branch, hook derivation → each reddens exactly its test).
- [x] `bun test` 903 pass / 0 fail; typecheck clean; bundle fresh.