### PR TITLE
ci: pin claude-action reviews to Sonnet-5

### DIFF
--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -69,3 +69,6 @@ jobs:
             present reasoning as verification.' || '' }}
           trigger_phrase: "@claude"
           track_progress: "true"
+
+          # Cost control: pin claude-action to Sonnet-5 (~5x cheaper than Opus 4.8, strong at review + most coding).
+          claude_args: "--model claude-sonnet-5"

--- a/.github/workflows/claude.yml
+++ b/.github/workflows/claude.yml
@@ -70,5 +70,7 @@ jobs:
           trigger_phrase: "@claude"
           track_progress: "true"
 
-          # Cost control: pin claude-action to Sonnet-5 (~5x cheaper than Opus 4.8, strong at review + most coding).
+          # Pin claude-action to Sonnet-5. Since #254 auth bills against the flat-rate Max
+          # subscription (not metered API), this is not a per-token saving — it conserves the
+          # shared Max rate-limit pool the header warns about, and Sonnet-5 is strong at review.
           claude_args: "--model claude-sonnet-5"


### PR DESCRIPTION
## Summary
- Pins `claude-action` to **Sonnet-5** via `--model` in `claude_args` (was defaulting to Opus 4.8).
- Since #254 moved auth to the flat-rate **Max subscription** OAuth token, this is **not** a per-token API saving. It conserves the **shared Max rate-limit pool** the workflow header warns CI shares with interactive Claude Code and every other repo on the token. Sonnet-5 is strong at PR review.

## Test plan
- [x] YAML validates
- [ ] Next auto-review run shows the Sonnet-5 model