### PR TITLE
chore: release v1.14.0

### DIFF
--- a/.claude-plugin/plugin.json
+++ b/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,8 @@ All notable changes to mcp-recall are documented here. Format based on [Keep a C
 
 ## [Unreleased]
 
+## [1.14.0] — 2026-08-20
+
 ### Added
 
 - `recall__stats` now includes a **By Bash command** breakdown that attributes the aggregate

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Context compression and persistent retrieval for Claude Code",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/.claude-plugin/plugin.json
+++ b/plugins/mcp-recall/.claude-plugin/plugin.json
@@ -1,6 +1,6 @@
 {
   "name": "mcp-recall",
-  "version": "1.13.0",
+  "version": "1.14.0",
   "description": "Context compression and persistent retrieval for Claude Code — prevents context window exhaustion in long sessions",
   "author": {
     "name": "sakebomb",

--- a/plugins/mcp-recall/dist/cli.js
+++ b/plugins/mcp-recall/dist/cli.js
@@ -48,7 +48,7 @@ var __export = (target, all) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.13.0",
+    version: "1.14.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",

--- a/plugins/mcp-recall/dist/server.js
+++ b/plugins/mcp-recall/dist/server.js
@@ -6520,7 +6520,7 @@ var require_dist = __commonJS((exports, module) => {
 var require_package = __commonJS((exports, module) => {
   module.exports = {
     name: "mcp-recall",
-    version: "1.13.0",
+    version: "1.14.0",
     description: "Context compression and persistent retrieval for Claude Code",
     author: {
       name: "sakebomb",


### PR DESCRIPTION
## Summary
- Cuts **v1.14.0** — version bump across the three manifests, CHANGELOG `[Unreleased]` → `[1.14.0]` (2026-08-20), rebuilt `dist/`.
- Ships the two features already on `main` since v1.13.0:
  - **#251** — `recall__stats` **By Bash command** breakdown (privacy-safe per-row fingerprint) so low-reduction command families are visible.
  - **#247** — eviction + pin-budget now count each item's **effective** stored size (summary-only rows cost their summary size).
- Releasing now unblocks measurement: #251's fingerprint only accumulates going forward, in a released+installed build — holding the release starved the very numbers the hold was waiting on.

## Test plan
- [x] `bun test` — 906 pass / 4 skip / 0 fail
- [x] `bun run typecheck` clean
- [x] `bun run build` — both `dist/` bundles regenerated to 1.14.0, no 1.13.0 remnants
- [x] All three manifests agree on 1.14.0 (enforced by test)

https://claude.ai/code/session_01APwm6Qv1Q6Fip79tsfGEzC